### PR TITLE
Added basic support for HStore operations query translation

### DIFF
--- a/src/EFCore.PG/NpgsqlDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/NpgsqlDbFunctionsExtensions.cs
@@ -136,5 +136,15 @@ namespace Microsoft.EntityFrameworkCore
                 RegexOptions.Singleline,
                 _regexTimeout);
         }
+
+        public static string[] HStoreKeys([CanBeNull] this DbFunctions _, [NotNull] IDictionary<string, string> hstore)
+        {
+            return hstore.Keys.ToArray();
+        }
+
+        public static string[] HStoreValues([CanBeNull] this DbFunctions _, [NotNull] IDictionary<string, string> hstore)
+        {
+            return hstore.Values.ToArray();
+        }
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlCompositeMethodCallTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlCompositeMethodCallTranslator.cs
@@ -47,7 +47,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
             new NpgsqlStringTrimTranslator(),
             new NpgsqlStringTrimEndTranslator(),
             new NpgsqlStringTrimStartTranslator(),
-            new NpgsqlRegexIsMatchTranslator()
+            new NpgsqlRegexIsMatchTranslator(),
+            new NpgsqlDictionaryIndexTranslator(),
+            new NpgsqlHStoreKeysTranslator()
         };
 
         public NpgsqlCompositeMethodCallTranslator(

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDictionaryIndexTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDictionaryIndexTranslator.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class NpgsqlDictionaryIndexTranslator : IMethodCallTranslator
+    {
+        static readonly PropertyInfo DictionaryPropertyIndexAccessor =
+            typeof(IDictionary<string, string>).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Single(p => p.Name == "Item");
+
+        public Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.NodeType == ExpressionType.Call
+                && methodCallExpression.Method.Name == "get_Item"
+                && typeof(IDictionary<string, string>).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
+            {
+                return Expression.MakeIndex(methodCallExpression.Object, DictionaryPropertyIndexAccessor, methodCallExpression.Arguments);
+            }
+            return null;
+        }
+    }
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlHStoreKeysTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlHStoreKeysTranslator.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    public class NpgsqlHStoreKeysTranslator : IMethodCallTranslator
+    {
+        public Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if(methodCallExpression.Method == 
+                typeof(NpgsqlDbFunctionsExtensions)
+                .GetRuntimeMethod(
+                    nameof(NpgsqlDbFunctionsExtensions.HStoreKeys), new Type[] { typeof(DbFunctions), typeof(IDictionary<string, string>) }))
+            {
+                return new SqlFunctionExpression("akeys", typeof(string[]), new Expression[] { methodCallExpression.Arguments[1] });
+            }
+
+            if (methodCallExpression.Method ==
+                typeof(NpgsqlDbFunctionsExtensions)
+                .GetRuntimeMethod(
+                    nameof(NpgsqlDbFunctionsExtensions.HStoreValues), new Type[] { typeof(DbFunctions), typeof(IDictionary<string, string>) }))
+            {
+                return new SqlFunctionExpression("avals", typeof(string[]), new Expression[] { methodCallExpression.Arguments[1] });
+            }
+
+            if(typeof(IDictionary<string, string>).IsAssignableFrom(methodCallExpression.Method.DeclaringType)
+                && methodCallExpression.Method.Name == nameof(IDictionary<string, string>.ContainsKey))
+            {
+                return new DictionaryContainsKeyExpression(methodCallExpression.Arguments.Single(), methodCallExpression.Object);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.PG/Query/Expressions/Internal/DictionaryContainsKeyExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/DictionaryContainsKeyExpression.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    public class DictionaryContainsKeyExpression : Expression
+    {
+        /// <summary>
+        ///     Creates a new instance of expression that is used by EF translator to fetch 
+        ///     HStore keys from database.
+        /// </summary>
+        /// <param name="key"> The key. </param>
+        /// <param name="dictionary"> The dictionary. </param>
+        public DictionaryContainsKeyExpression(
+            [NotNull] Expression key,
+            [NotNull] Expression dictionary)
+        {
+            Check.NotNull(dictionary, nameof(dictionary));
+            Check.NotNull(key, nameof(key));
+            Debug.Assert(typeof(IDictionary<string, string>).IsAssignableFrom(dictionary.Type));
+
+            Dictionary = dictionary;
+            Key = key;
+        }
+
+        /// <summary>
+        ///     Gets the dictionary.
+        /// </summary>
+        /// <value>
+        ///     The dictionary.
+        /// </value>
+        public virtual Expression Dictionary { get; }
+
+        /// <summary>
+        ///     Gets the key.
+        /// </summary>
+        /// <value>
+        ///     The key.
+        /// </value>
+        public virtual Expression Key { get; }
+
+        /// <summary>
+        ///     Returns the node type of this <see cref="Expression" />. (Inherited from <see cref="Expression" />.)
+        /// </summary>
+        /// <returns>The <see cref="ExpressionType" /> that represents this expression.</returns>
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <summary>
+        ///     Gets the static type of the expression that this <see cref="Expression" /> represents. (Inherited from <see cref="Expression" />.)
+        /// </summary>
+        /// <returns>The <see cref="Type" /> that represents the static type of the expression.</returns>
+        public override Type Type => typeof(bool);
+
+        /// <summary>
+        ///     Dispatches to the specific visit method for this node type.
+        /// </summary>
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is NpgsqlQuerySqlGenerator npsgqlGenerator
+                ? npsgqlGenerator.VisitDictionaryContainsKey(this)
+                : base.Accept(visitor);
+        }
+
+        /// <summary>
+        ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(System.Linq.Expressions.Expression)" /> method passing the
+        ///     reduced expression.
+        ///     Throws an exception if the node isn't reducible.
+        /// </summary>
+        /// <param name="visitor"> An instance of <see cref="ExpressionVisitor" />. </param>
+        /// <returns> The expression being visited, or an expression which should replace it in the tree. </returns>
+        /// <remarks>
+        ///     Override this method to provide logic to walk the node's children.
+        ///     A typical implementation will call visitor.Visit on each of its
+        ///     children, and if any of them change, should return a new copy of
+        ///     itself with the modified children.
+        /// </remarks>
+        ///
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newDictionary = visitor.Visit(Dictionary);
+            var newKey = visitor.Visit(Key);
+
+            return newKey != Key || newDictionary != Dictionary
+                ? new DictionaryContainsKeyExpression(newKey, newDictionary)
+                : this;
+        }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((DictionaryContainsKeyExpression)obj);
+        }
+
+        bool Equals(DictionaryContainsKeyExpression other)
+            => Dictionary.Equals(other.Dictionary) && Key.Equals(other.Key);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Key.GetHashCode() * 397) ^ Dictionary.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="string" /> representation of the Expression.
+        /// </summary>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
+        public override string ToString() => $"{Dictionary} ? {Key}";
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/Query/HStoreQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/HStoreQueryTest.cs
@@ -1,0 +1,237 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests.Query
+{
+    public class HStoreQueryTest : IClassFixture<HStoreFixture>
+    {
+        [Fact]
+        public void HStore_key_value_selector()
+        {
+            using (var ctx = CreateContext())
+            {
+                var actual = ctx.SomeEntities.Where(e => e.Tags["kind"] == "big").ToList();
+
+                Assert.Equal(2, actual.Count);
+                AssertContainsInSql(@"WHERE ""e"".""Tags"" -> 'kind' = 'big'");
+            }
+        }
+
+        [Fact]
+        public void HStore_projection()
+        {
+            using (var ctx = CreateContext())
+            {
+                var actual = ctx.SomeEntities
+                    .Select(e => new
+                    {
+                        Kind = e.Tags["kind"]
+                    }).ToList();
+
+                AssertContainsInSql(@"SELECT ""e"".""Tags"" -> 'kind' AS ""Kind""");
+            }
+        }
+
+        [Fact]
+        public void HStore_add_value()
+        {
+            //EF does not detect changes on single entries in dictionary
+            using (var ctx = CreateContext())
+            {
+                var entity = ctx.SomeEntities.First(e => e.Id == 1);
+                entity.Tags.Add("m", "d");
+                var numberOfSavedEntities = ctx.SaveChanges();
+
+                ctx.Entry(entity).State = EntityState.Detached;
+
+                entity = ctx.SomeEntities.First(e => e.Id == 1);
+
+                Assert.Equal(1, numberOfSavedEntities);
+                Assert.True(entity.Tags.ContainsKey("m"));
+                Assert.Equal("d", entity.Tags["m"]);
+            }
+        }
+
+        [Fact]
+        public void HStore_update_value()
+        {
+            //EF does not detect changes on single entries in dictionary
+            using (var ctx = CreateContext())
+            {
+                var entity = ctx.SomeEntities.First(e => e.Id == 1);
+                entity.Tags["kind"] = "thick";
+                var numberOfSavedEntities = ctx.SaveChanges();
+
+                ctx.Entry(entity).State = EntityState.Detached;
+
+                entity = ctx.SomeEntities.First(e => e.Id == 1);
+
+                Assert.Equal(1, numberOfSavedEntities);
+                Assert.Equal("thick", entity.Tags["kind"]);
+            }
+        }
+
+        [Fact]
+        public void HStore_fetch_keys()
+        {
+            using (var ctx = CreateContext())
+            {
+                ctx.SomeEntities.Select(e => new
+                {
+                    TagNames = EF.Functions.HStoreKeys(e.Tags)
+                }).ToList();
+
+                AssertContainsInSql(@" akeys(""e"".""Tags"") ");
+            }
+        }
+
+        [Fact]
+        public void HStore_fetch_values()
+        {
+            using (var ctx = CreateContext())
+            {
+                ctx.SomeEntities.Select(e => new
+                {
+                    TagValues = EF.Functions.HStoreValues(e.Tags)
+                }).ToList();
+
+                AssertContainsInSql(@" avals(""e"".""Tags"") ");
+            }
+        }
+
+        [Fact]
+        public void HStore_contains_key()
+        {
+            using (var ctx = CreateContext())
+            {
+                var selected = ctx.SomeEntities.Where(e => e.Tags.ContainsKey("type")).ToList();
+
+                Assert.Equal(1, selected.Count);
+                AssertContainsInSql(@" ""e"".""Tags"" ? 'type' ");
+            }
+        }
+
+        [Fact]
+        public void HStore_key_contains_all_values_from_collection()
+        {
+            using (var ctx = CreateContext())
+            {
+                string[] values = new string[] { "big", "small" };
+                ctx.SomeEntities.Where(e => values.All(v => e.Tags.Keys.Contains(v))).ToList();
+
+                AssertContainsInSql(@"WHERE ""e"".""Tags"" ?& ARRAY [ 'big', 'small' ");
+            }
+        }
+
+        [Fact]
+        public void HStore_key_contains_any_value_from_collection()
+        {
+            using (var ctx = CreateContext())
+            {
+                string[] values = new string[] { "big", "small" };
+                ctx.SomeEntities.Where(e => values.Any(v => e.Tags.Keys.Contains(v))).ToList();
+
+                AssertContainsInSql(@"WHERE ""e"".""Tags"" ?| ARRAY [ 'big', 'small' ");
+            }
+        }
+
+        #region Support
+
+        HStoreFixture Fixture { get; }
+
+        public HStoreQueryTest(HStoreFixture fixture)
+        {
+            Fixture = fixture;
+            Fixture.TestSqlLoggerFactory.Clear();
+        }
+
+        HStoreContext CreateContext() => Fixture.CreateContext();
+
+        void AssertContainsInSql(string expected)
+            => Assert.Contains(expected, Fixture.TestSqlLoggerFactory.Sql);
+
+        void AssertDoesNotContainInSql(string expected)
+            => Assert.DoesNotContain(expected, Fixture.TestSqlLoggerFactory.Sql);
+
+        #endregion Support
+    }
+
+    public class HStoreContext : DbContext
+    {
+        public DbSet<SomeEntity> SomeEntities { get; set; }
+        public HStoreContext(DbContextOptions options) : base(options) { }
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            builder.HasPostgresExtension("hstore");
+        }
+    }
+
+    public class SomeEntity
+    {
+        public int Id { get; set; }
+        public Dictionary<string, string> Tags { get; set; }
+    }
+
+    public class HStoreFixture : IDisposable
+    {
+        readonly DbContextOptions _options;
+        public TestSqlLoggerFactory TestSqlLoggerFactory { get; } = new TestSqlLoggerFactory();
+
+        public HStoreFixture()
+        {
+            _testStore = NpgsqlTestStore.CreateScratch();
+            _options = new DbContextOptionsBuilder()
+                .UseNpgsql(_testStore.Connection, b => b.ApplyConfiguration())
+                .UseInternalServiceProvider(
+                    new ServiceCollection()
+                        .AddEntityFrameworkNpgsql()
+                        .AddSingleton<ILoggerFactory>(TestSqlLoggerFactory)
+                        .BuildServiceProvider())
+                .Options;
+
+            using (var ctx = CreateContext())
+            {
+                ctx.Database.EnsureCreated();
+                ctx.SomeEntities.Add(new SomeEntity
+                {
+                    Id = 1,
+                    Tags = new Dictionary<string, string>(ImmutableDictionary<string, string>.Empty.AddRange(new KeyValuePair<string, string>[] 
+                    {
+                        new KeyValuePair<string, string>("kind", "big"), 
+                        new KeyValuePair<string, string>("type", "car")
+                    }))
+                });
+                ctx.SomeEntities.Add(new SomeEntity
+                {
+                    Id = 2,
+                    Tags = new Dictionary<string, string>(ImmutableDictionary<string, string>.Empty.AddRange(new KeyValuePair<string, string>[]
+                    {
+                        new KeyValuePair<string, string>("kind", "big")
+                    }))
+                });
+                ctx.SomeEntities.Add(new SomeEntity
+                {
+                    Id = 3,
+                    Tags = new Dictionary<string, string>(ImmutableDictionary<string, string>.Empty.AddRange(new KeyValuePair<string, string>[]
+                    {
+                        new KeyValuePair<string, string>("kind", "small")
+                    }))
+                });
+                ctx.SaveChanges();
+            }
+        }
+
+        readonly NpgsqlTestStore _testStore;
+        public HStoreContext CreateContext() => new HStoreContext(_options);
+        public void Dispose() => _testStore.Dispose();
+    }
+}


### PR DESCRIPTION
I looked into how hstore support could be implemented. Some basic operations work but it is still not good enough, in my opinion, to be used properly. 

When dictionary object that represents hsore column is updated it is not tracked by EF's change tracker so users would have to reassign previous value with new dictionary before every call to `SaveChanges()` which is not really a safe solution in my opinion. 

I tried using ImmutableDictionary which would solve this problem but the serializer does not support ImmutableDictionary so we can not deserialize into it after we get data from DB.

So
* is there a way to make EF's change tracker track changes to dictionary ?
* can we add support for deserialization into ImmutableDictionary ?