### PR TITLE
Work in progress on composite support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup Label="Package Versions">
-    <NpgsqlVersion>4.0.3</NpgsqlVersion>
+    <NpgsqlVersion>4.0.4-ci.1404</NpgsqlVersion>
     <EFCoreVersion>2.2.0</EFCoreVersion>
     <MicrosoftExtensionsVersion>$(EFCoreVersion)</MicrosoftExtensionsVersion>
   </PropertyGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,5 +6,6 @@
   <packageSources>
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="NpgsqlStable" value="https://www.myget.org/F/npgsql/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -88,7 +88,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
                         enumTypeDef.Schema, enumTypeDef.Name, enumTypeDef.Labels);
             }
 
-            if (annotation.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix))
+            if (annotation.Name.StartsWith(NpgsqlAnnotationNames.CompositePrefix))
             {
                 var compositeTypeDef = new PostgresComposite(model, annotation.Name);
 

--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -88,6 +88,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
                         enumTypeDef.Schema, enumTypeDef.Name, enumTypeDef.Labels);
             }
 
+            if (annotation.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix))
+            {
+                var compositeTypeDef = new PostgresComposite(model, annotation.Name);
+
+                return compositeTypeDef.Schema == "public"
+                    ? new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.ForNpgsqlHasComposite),
+                        compositeTypeDef.Name, compositeTypeDef.Fields)
+                    : new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.ForNpgsqlHasComposite),
+                        compositeTypeDef.Schema, compositeTypeDef.Name, compositeTypeDef.Fields);
+            }
+
             return null;
         }
 

--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -262,7 +262,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <remarks>
         /// See: https://www.postgresql.org/docs/current/rowtypes.html
         /// </remarks>
-        /// <exception cref="ArgumentNullException">builder</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="modelBuilder"/></exception>
         [NotNull]
         public static ModelBuilder ForNpgsqlHasComposite(
             [NotNull] this ModelBuilder modelBuilder,
@@ -271,6 +271,7 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] params (string Name, string StoreType)[] fields)
         {
             Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NullButNotEmpty(schema, nameof(schema));
             Check.NotEmpty(name, nameof(name));
             Check.NotNull(fields, nameof(fields));
 
@@ -290,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <remarks>
         /// See: https://www.postgresql.org/docs/current/rowtypes.html
         /// </remarks>
-        /// <exception cref="ArgumentNullException">builder</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="modelBuilder"/></exception>
         [NotNull]
         public static ModelBuilder ForNpgsqlHasComposite(
             [NotNull] this ModelBuilder modelBuilder,

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -14,6 +14,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string IndexInclude = Prefix + "IndexInclude";
         public const string PostgresExtensionPrefix = Prefix + "PostgresExtension:";
         public const string EnumPrefix = Prefix + "Enum:";
+        public const string CompositePrefix = Prefix + "Composite:";
         public const string RangePrefix = Prefix + "Range:";
         public const string DatabaseTemplate = Prefix + "DatabaseTemplate";
         public const string Tablespace = Prefix + "Tablespace";

--- a/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlModelAnnotations.cs
@@ -90,6 +90,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
 
         #endregion Enum types
 
+        #region Composite types
+
+        public virtual PostgresComposite GetOrAddPostgresComposite(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] params (string Name, string StoreType)[] fields)
+            => PostgresComposite.GetOrAddPostgresComposite((IMutableModel)Model, schema, name, fields);
+
+        public virtual PostgresComposite GetOrAddPostgresComposite(
+            [NotNull] string name,
+            [NotNull] params (string Name, string StoreType)[] fields)
+            => GetOrAddPostgresComposite(null, name, fields);
+
+        public virtual IReadOnlyList<PostgresComposite> PostgresComposites
+            => PostgresComposite.GetPostgresComposites(Model).ToList();
+
+        #endregion Composite types
+
         #region Range types
 
         public virtual PostgresRange GetOrAddPostgresRange(

--- a/src/EFCore.PG/Metadata/PostgresComposite.cs
+++ b/src/EFCore.PG/Metadata/PostgresComposite.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
+{
+    public class PostgresComposite
+    {
+        readonly IAnnotatable _annotatable;
+        readonly string _annotationName;
+
+        internal PostgresComposite(IAnnotatable annotatable, string annotationName)
+        {
+            _annotatable = annotatable;
+            _annotationName = annotationName;
+        }
+
+        public static PostgresComposite GetOrAddPostgresComposite(
+            [NotNull] IMutableAnnotatable annotatable,
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] params (string Name, string StoreType)[] fields)
+        {
+            if (FindPostgresComposite(annotatable, schema, name) is PostgresComposite CompositeType)
+                return CompositeType;
+
+            // Adding a new composite definition.
+            // Each composite annotation has an ordering number in the annotation value: composite CREATE TYPE
+            // migrations need to be generated in a specific order, since they may depend on each other (composite
+            // types nested within other composite types).
+            // Find the next free ordering number
+            var ordering = GetPostgresComposites(annotatable).Any()
+                ? GetPostgresComposites(annotatable).Select(a => a.Ordering).Max() + 1
+                : 0;
+
+            CompositeType = new PostgresComposite(annotatable, BuildAnnotationName(schema, name));
+            CompositeType.SetData(ordering, fields);
+            return CompositeType;
+        }
+
+        public static PostgresComposite GetOrAddPostgresComposite(
+            [NotNull] IMutableAnnotatable annotatable,
+            [NotNull] string name,
+            [NotNull] params (string Name, string StoreType)[] fields)
+            => GetOrAddPostgresComposite(annotatable, null, name, fields);
+
+        public static PostgresComposite FindPostgresComposite(
+            [NotNull] IAnnotatable annotatable,
+            [CanBeNull] string schema,
+            [NotNull] string name)
+        {
+            Check.NotNull(annotatable, nameof(annotatable));
+            Check.NotEmpty(name, nameof(name));
+
+            var annotationName = BuildAnnotationName(schema, name);
+
+            return annotatable[annotationName] == null ? null : new PostgresComposite(annotatable, annotationName);
+        }
+
+        static string BuildAnnotationName(string schema, string name)
+            => NpgsqlAnnotationNames.CompositePrefix + (schema == null ? name : schema + '.' + name);
+
+        public static IEnumerable<PostgresComposite> GetPostgresComposites([NotNull] IAnnotatable annotatable)
+        {
+            Check.NotNull(annotatable, nameof(annotatable));
+
+            return annotatable.GetAnnotations()
+                .Where(a => a.Name.StartsWith(NpgsqlAnnotationNames.CompositePrefix, StringComparison.Ordinal))
+                .Select(a => new PostgresComposite(annotatable, a.Name));
+        }
+
+        public Annotatable Annotatable => (Annotatable)_annotatable;
+
+        public string Schema => GetData().Schema;
+
+        public string Name => GetData().Name;
+
+        public int Ordering => GetData().Ordering;
+
+        public (string Name, string StoreType)[] Fields => GetData().Fields;
+
+        (string Schema, string Name, int Ordering, (string Name, string StoreType)[] Fields) GetData()
+        {
+            return !(Annotatable[_annotationName] is string annotationValue)
+                ? (null, null, 0, null)
+                : Deserialize(_annotationName, annotationValue);
+        }
+
+        void SetData(int ordering, (string Name, string StoreType)[] fields)
+            => Annotatable[_annotationName] = ordering + ";" + string.Join(";", fields.Select(f => $"{f.Name},{f.StoreType}"));
+
+        static (string schema, string name, int ordering, (string Name, string StoreType)[]) Deserialize(
+            [NotNull] string annotationName,
+            [NotNull] string annotationValue)
+        {
+            Check.NotEmpty(annotationValue, nameof(annotationValue));
+
+            if (!int.TryParse(annotationValue.Split(';')[0], out var ordering))
+                throw new ArgumentException("Cannot parse composite ordering from annotation: " + annotationName);
+
+            var fields = annotationValue.Split(';')
+                .Skip(1)
+                .Select(s => (s.Split(',')[0], s.Split(',')[1])).ToArray();
+
+            var schemaAndName = annotationName.Substring(NpgsqlAnnotationNames.CompositePrefix.Length).Split('.');
+            switch (schemaAndName.Length)
+            {
+            case 1:
+                return (null, schemaAndName[0], ordering, fields);
+            case 2:
+                return (schemaAndName[0], schemaAndName[1], ordering, fields);
+            default:
+                throw new ArgumentException("Cannot parse composite name from annotation: " + annotationName);
+            }
+        }
+    }
+}

--- a/src/EFCore.PG/Metadata/PostgresComposite.cs
+++ b/src/EFCore.PG/Metadata/PostgresComposite.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 
@@ -26,6 +27,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             [NotNull] string name,
             [NotNull] params (string Name, string StoreType)[] fields)
         {
+            Check.NotNull(annotatable, nameof(annotatable));
+            Check.NullButNotEmpty(schema, nameof(schema));
+            Check.NotNull(name, nameof(name));
+            Check.NullButNotEmpty(fields, nameof(fields));
+
             if (FindPostgresComposite(annotatable, schema, name) is PostgresComposite CompositeType)
                 return CompositeType;
 
@@ -55,6 +61,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             [NotNull] string name)
         {
             Check.NotNull(annotatable, nameof(annotatable));
+            Check.NullButNotEmpty(schema, nameof(schema));
             Check.NotEmpty(name, nameof(name));
 
             var annotationName = BuildAnnotationName(schema, name);

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -57,6 +57,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
             => model.GetAnnotations().Where(a =>
                 a.Name.StartsWith(NpgsqlAnnotationNames.PostgresExtensionPrefix, StringComparison.Ordinal) ||
                 a.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix, StringComparison.Ordinal) ||
+                a.Name.StartsWith(NpgsqlAnnotationNames.CompositePrefix, StringComparison.Ordinal) ||
                 a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal));
     }
 }

--- a/src/EFCore.PG/Query/Expressions/Internal/CompositeMemberExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/CompositeMemberExpression.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Sql.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+
+// ReSharper disable ArgumentsStyleLiteral
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
+{
+    /// <summary>
+    /// Represents a member access on a mapped PostgreSQL composite type.
+    /// </summary>
+    [DebuggerDisplay("{" + nameof(ToString) + "()}")]
+    public class CompositeMemberExpression : Expression, IEquatable<CompositeMemberExpression>
+    {
+        /// <summary>
+        /// Gets the containing object of the composite member.
+        /// </summary>
+        [NotNull]
+        public virtual Expression Expression { get; }
+
+        /// <value>
+        /// Gets the composite member to be accessed.
+        /// </value>
+        [NotNull]
+        public virtual string Member { get; }
+
+        /// <inheritdoc />
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <inheritdoc />
+        public override Type Type { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompositeMemberExpression" /> class.
+        /// </summary>
+        public CompositeMemberExpression(
+            [NotNull] Expression expression,
+            [NotNull] string member,
+            [NotNull] Type returnType)
+        {
+            Expression = expression;
+            Member = member;
+            Type = returnType;
+        }
+
+        /// <inheritdoc />
+        protected override Expression Accept(ExpressionVisitor visitor)
+            => visitor is NpgsqlQuerySqlGenerator npgsqlGenerator
+                ? npgsqlGenerator.VisitCompositeMember(this)
+                : base.Accept(visitor);
+
+        /// <inheritdoc />
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var e = visitor.Visit(Expression) ?? Expression;
+            return e != Expression ? new CompositeMemberExpression(e, Member, Type) : this;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is CompositeMemberExpression e && Equals(e);
+
+        /// <inheritdoc />
+        public bool Equals(CompositeMemberExpression other)
+            => other != null && Member == other.Member && Expression.Equals(other.Expression);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Expression.GetHashCode() * 397) ^ Member.GetHashCode();
+            }
+        }
+
+        /// <inheritdoc />
+        public override string ToString() => Expression + "." + Member;
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCompositeTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlCompositeTypeMapping.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
+{
+    public class NpgsqlCompositeTypeMapping : RelationalTypeMapping
+    {
+        [NotNull] static readonly NpgsqlSqlGenerationHelper SqlGenerationHelper =
+            new NpgsqlSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies());
+
+        [CanBeNull] readonly string _storeTypeSchema;
+
+        [NotNull] public INpgsqlNameTranslator NameTranslator { get; }
+
+        [NotNull]
+        public override string StoreType => SqlGenerationHelper.DelimitIdentifier(base.StoreType, _storeTypeSchema);
+
+        public NpgsqlCompositeTypeMapping(
+            [NotNull] string storeType,
+            [CanBeNull] string storeTypeSchema,
+            [NotNull] Type clrType,
+            [CanBeNull] INpgsqlNameTranslator nameTranslator = null)
+            : base(storeType, clrType)
+        {
+            if (nameTranslator == null)
+                nameTranslator = NpgsqlConnection.GlobalTypeMapper.DefaultNameTranslator;
+
+            NameTranslator = nameTranslator;
+            _storeTypeSchema = storeTypeSchema;
+            //_members = CreateValueMapping(enumType, nameTranslator);
+        }
+
+        protected NpgsqlCompositeTypeMapping(
+            RelationalTypeMappingParameters parameters,
+            [CanBeNull] string storeTypeSchema,
+            [NotNull] INpgsqlNameTranslator nameTranslator)
+            : base(parameters)
+        {
+            NameTranslator = nameTranslator;
+            _storeTypeSchema = storeTypeSchema;
+            //_members = CreateValueMapping(parameters.CoreParameters.ClrType, nameTranslator);
+        }
+
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new NpgsqlCompositeTypeMapping(parameters, _storeTypeSchema, NameTranslator);
+
+        // TODO: Requires PostgreSQL composite fields definition from the ADO layer, which we don't have.
+        // This is currently problematic since the EF Core mapping is constructed based on the ADO global mapping,
+        // but composite fields are only loaded once a specific connection is made to a database.
+        // protected override string GenerateNonNullSqlLiteral(object value) => $"'{_members[value]}'::{StoreType}";
+
+        // TODO: Look for a constructor on ClrType that has parameters matching in name and type all the
+        // type's members? Or should we make use of the PostgreSQL composite fields definition from
+        // the ADO layer, once we get it here somehow (necessary anyway for SQL generation)?
+        // public override Expression GenerateCodeLiteral(object value) {}
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -292,11 +292,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             var operations = Dependencies.ModelDiffer.GetDifferences(null, Dependencies.Model);
             var commands = Dependencies.MigrationsSqlGenerator.Generate(operations, Dependencies.Model);
 
-            // If a PostgreSQL extension, enum or range was added, we want Npgsql to reload all types at the ADO.NET level.
+            // If a PostgreSQL extension, enum, composite or range was added,
+            // we want Npgsql to reload all types at the ADO.NET level.
             var reloadTypes = operations.Any(o =>
                 o is AlterDatabaseOperation && (
                     PostgresExtension.GetPostgresExtensions(o).Any() ||
                     PostgresEnum.GetPostgresEnums(o).Any() ||
+                    PostgresComposite.GetPostgresComposites(o).Any() ||
                     PostgresRange.GetPostgresRanges(o).Any()
                 )
             );

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -753,6 +753,44 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
         #endregion Enums
 
+        #region Composites
+
+        [Fact]
+        public void CreatePostgresComposite()
+        {
+            var op = new AlterDatabaseOperation();
+            PostgresComposite.GetOrAddPostgresComposite(op, "public", "my_composite", new[] { ("f1", "int"), ("f2", "text") });
+            Generate(op);
+
+            Assert.Equal(@"CREATE TYPE public.my_composite AS (f1 int, f2 text);" + EOL, Sql);
+        }
+
+        [Fact]
+        public void CreatePostgresCompositeWithSchema()
+        {
+            var op = new AlterDatabaseOperation();
+            PostgresComposite.GetOrAddPostgresComposite(op, "some_schema", "my_composite", new[] { ("f1", "int"), ("f2", "text") });
+            Generate(op);
+
+            Assert.Equal(
+                @"CREATE SCHEMA IF NOT EXISTS some_schema;" + EOL +
+                @"GO" + EOL + EOL +
+                @"CREATE TYPE some_schema.my_composite AS (f1 int, f2 text);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public void DropPostgresComposite()
+        {
+            var op = new AlterDatabaseOperation();
+            PostgresComposite.GetOrAddPostgresComposite(op.OldDatabase, "public", "my_composite", new[] { ("f1", "int"), ("f2", "text") });
+            Generate(op);
+
+            Assert.Equal(@"DROP TYPE public.my_composite;" + EOL, Sql);
+        }
+
+        #endregion Composites
+
         #region PostgreSQL Storage Parameters
 
         [Fact]


### PR DESCRIPTION
This is work in progress on composite support for EFCore.PG 2.2, allowing you to map a CLR type to a PostgreSQL column defined as a composite type. This leverages composite support at the Npgsql level which is already there.

It's definitely not complete, but I wanted to get some feedback before going any deeper. It's probably a bit ambitious to push this for 2.2, but we may have enough value to deliver something.

What works:

* `ForNpgsqlHasComposite()` can be used to generate composite types in the database (much like `ForNpgsqlHasEnum()`. Currently there's no overload the infers the definition from the CLR type (like for enums).
* NpgsqlMigrationsSqlGenerator picks up the annotations and generates the types in the database (`CREATE TYPE ... AS (...)`).
* NpgsqlTypeMappingSource pulls global composite mappings from the ADO layer (like enums) and sets up new NpgsqlCompositeTypeMapping, including the configured NameTranslator. This requires exposing a new interface at the ADO level, so this depends on the unreleased 4.0.4.
* NpgsqlSqlTranslatingExpressionVisitor identifies MemberExpressions which traverse a composite type by finding a composite mapping for the CLR type. It then creates a new NpgsqlCompositeMemberExpression, including the composite's translated member name.
* NpgsqlCompositeMemberExpression is picked up by NpgsqlQuerySqlGenerator, which generates the appropriate member access SQL.
* All this allows you to query on composite fields (e.g. `WHERE my_entity.my_composite.some_field > 100`).
* Nested composites are (somewhat) supported. You can create them - the composite annotation contains an ordering vaue, allowing the nested composite to be created before the outer composite. Querying doesn't yet work though (see below).

What doesn't work:

* NpgsqlCompositeTypeMapping does *not* contain information about the composite's types. Unlike for enums, this cannot be inferred only from the CLR type, since the order of the composite's field is important and it only exists in the database. Unfortunately at the ADO level the actual database definition is only loaded when we actually connect to the database, but the EF Core layer looks at global composite mappings, which are set up without any specific databases. We'll have to think about what to do with this.
* This means that SQL and possibly code literals are unsupported at this time, because composite field knowledge is required at the mapping level. I *think* there's enough value without these for us to release this, but let me know what you think.
* Queries on fields of nested composites aren't translated yet, because `MemberAccessBindingExpressionVisitor.GetPropertyPath` does not traverse the outer composite. I think it's OK to move forward while documenting this limitation.
* Composite types currently cannot be altered in any way after creation (although this is supported by PostgreSQL). Again, not a blocker IMO.
* Scaffolding isn't yet implemented, although it shouldn't be difficult. This would mean scaffolding `ForNpgsqlHasComposite()`, but it will be up to the user to actually create the relevant CLR type and entity properties. This partial support is currently what we do for enums, maybe in the future we can actually generate the CLR types as well.
* No tests yet (tested ad-hoc)

@ajcvickers @divega @smitpatel you may be interested in this work which seems to push the limits a little.