### PR TITLE
Replace MigrationsModelDiffer 

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlServiceCollectionExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     .TryAdd<IModificationCommandBatchFactory, NpgsqlModificationCommandBatchFactory>()
                     .TryAdd<IValueGeneratorSelector, NpgsqlValueGeneratorSelector>()
                     .TryAdd<IRelationalConnection>(p => p.GetService<INpgsqlRelationalConnection>())
+                    .TryAdd<IMigrationsModelDiffer, NpgsqlMigrationsModelDiffer>()
                     .TryAdd<IMigrationsSqlGenerator, NpgsqlMigrationsSqlGenerator>()
                     .TryAdd<IRelationalDatabaseCreator, NpgsqlDatabaseCreator>()
                     .TryAdd<IHistoryRepository, NpgsqlHistoryRepository>()

--- a/src/EFCore.PG/Metadata/NpgsqlAlterDatabaseOperationAnnotations.cs
+++ b/src/EFCore.PG/Metadata/NpgsqlAlterDatabaseOperationAnnotations.cs
@@ -10,6 +10,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
     /// <summary>
     /// Provides relational-specific annotations specific to Npgsql.
     /// </summary>
+    [PublicAPI]
     public class NpgsqlAlterDatabaseOperationAnnotations : RelationalAnnotations
     {
         [NotNull] readonly IAnnotatable _oldDatabase;
@@ -49,11 +50,131 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata
             : base(operation)
             => _oldDatabase = operation.OldDatabase;
 
+        #region Extensions
+
         [NotNull]
         public virtual PostgresExtension GetOrAddPostgresExtension(
             [CanBeNull] string schema,
             [NotNull] string name,
             [CanBeNull] string version)
             => PostgresExtension.GetOrAddPostgresExtension((IMutableAnnotatable)Metadata, schema, name, version);
+
+        [NotNull]
+        public virtual PostgresExtension GetOrAddOldPostgresExtension(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [CanBeNull] string version)
+            => PostgresExtension.GetOrAddPostgresExtension((IMutableAnnotatable)_oldDatabase, schema, name, version);
+
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresExtension> GetPostgresExtensionsToCreate()
+            => PostgresExtensions.Where(ne => OldPostgresExtensions.All(oe => oe.Name != ne.Name));
+
+        // TODO: Some forms of extension dropping are actually supported...
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresExtension> GetPostgresExtensionsToDrop()
+            => Enumerable.Empty<PostgresExtension>();
+
+        // TODO: Some forms of extension alterations are actually supported...
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresExtension> GetPostgresExtensionsToAlter()
+            => Enumerable.Empty<PostgresExtension>();
+
+        #endregion
+
+        #region Enums
+
+        [NotNull]
+        public virtual PostgresEnum GetOrAddPostgresEnum(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string[] labels)
+            => PostgresEnum.GetOrAddPostgresEnum((IMutableAnnotatable)Metadata, schema, name, labels);
+
+        [NotNull]
+        public virtual PostgresEnum GetOrAddOldPostgresEnum(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string[] labels)
+            => PostgresEnum.GetOrAddPostgresEnum((IMutableAnnotatable)_oldDatabase, schema, name, labels);
+
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresEnum> GetPostgresEnumsToCreate()
+            => PostgresEnums.Where(ne => OldPostgresEnums.All(oe => oe.Name != ne.Name));
+
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresEnum> GetPostgresEnumsToDrop()
+            => OldPostgresEnums.Where(oe => PostgresEnums.All(ne => ne.Name != oe.Name));
+
+        // TODO: Some forms of enum alterations are actually supported...
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresEnum> GetPostgresEnumsToAlter()
+            => Enumerable.Empty<PostgresEnum>();
+
+        #endregion
+
+        #region Ranges
+
+        [NotNull]
+        public virtual PostgresRange GetOrAddPostgresRange(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string subtype,
+            string canonicalFunction = null,
+            string subtypeOpClass = null,
+            string collation = null,
+            string subtypeDiff = null)
+            => PostgresRange.GetOrAddPostgresRange(
+                (IMutableAnnotatable)Metadata,
+                schema,
+                name,
+                subtype,
+                canonicalFunction,
+                subtypeOpClass,
+                collation,
+                subtypeDiff);
+
+        [NotNull]
+        public virtual PostgresRange GetOrAddOldPostgresRange(
+            [CanBeNull] string schema,
+            [NotNull] string name,
+            [NotNull] string subtype,
+            string canonicalFunction = null,
+            string subtypeOpClass = null,
+            string collation = null,
+            string subtypeDiff = null)
+            => PostgresRange.GetOrAddPostgresRange(
+                (IMutableAnnotatable)_oldDatabase,
+                schema,
+                name,
+                subtype,
+                canonicalFunction,
+                subtypeOpClass,
+                collation,
+                subtypeDiff);
+
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresRange> GetPostgresRangesToCreate()
+            => PostgresRanges.Where(ne => OldPostgresRanges.All(oe => oe.Name != ne.Name));
+
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresRange> GetPostgresRangesToDrop()
+            => OldPostgresRanges.Where(oe => PostgresRanges.All(ne => ne.Name != oe.Name));
+
+        // TODO: Some forms of range alterations are actually supported...
+        [NotNull]
+        [ItemNotNull]
+        public virtual IEnumerable<PostgresRange> GetPostgresRangesToAlter()
+            => Enumerable.Empty<PostgresRange>();
+
+        #endregion
     }
 }

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -46,11 +45,5 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
             if (index.Npgsql().IncludeProperties != null)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexInclude, index.Npgsql().IncludeProperties);
         }
-
-        public override IEnumerable<IAnnotation> For(IModel model)
-            => model.GetAnnotations().Where(a =>
-                a.Name.StartsWith(NpgsqlAnnotationNames.PostgresExtensionPrefix, StringComparison.Ordinal) ||
-                a.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix, StringComparison.Ordinal) ||
-                a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal));
     }
 }

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsModelDiffer.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsModelDiffer.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
+{
+    /// <summary>
+    /// The default migrations model differ for Npgsql.
+    /// </summary>
+    public class NpgsqlMigrationsModelDiffer : MigrationsModelDiffer
+    {
+        public NpgsqlMigrationsModelDiffer(
+            [NotNull] IRelationalTypeMappingSource typeMappingSource,
+            [NotNull] IMigrationsAnnotationProvider migrationsAnnotations,
+            [NotNull] IChangeDetector changeDetector,
+            [NotNull] StateManagerDependencies stateManagerDependencies,
+            [NotNull] CommandBatchPreparerDependencies commandBatchPreparerDependencies)
+            : base(typeMappingSource, migrationsAnnotations, changeDetector, stateManagerDependencies, commandBatchPreparerDependencies) {}
+
+        // TODO: filter the base diff to remove annotations now handled here.
+        protected override IEnumerable<MigrationOperation> Diff(IModel source, IModel target, DiffContext diffContext)
+            => base.Diff(source, target, diffContext)
+                   .Concat(DiffAnnotations(source, target));
+
+        private IEnumerable<MigrationOperation> DiffAnnotations([CanBeNull] IModel source, [CanBeNull] IModel target)
+        {
+            // TODO: diff extensions, enums, and ranges here.
+            yield break;
+        }
+
+        [NotNull]
+        [ItemNotNull]
+        protected override IEnumerable<string> GetSchemas(IModel model)
+            => base.GetSchemas(model)
+                   .Concat(model.Npgsql().PostgresExtensions.Select(x => x.Schema))
+                   .Concat(model.Npgsql().PostgresEnums.Select(x => x.Schema))
+                   .Concat(model.Npgsql().PostgresRanges.Select(x => x.Schema))
+                   .Where(x => !string.IsNullOrEmpty(x))
+                   .Distinct();
+    }
+}

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -712,11 +712,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
         {
             var schema = enumType.Schema ?? model.Relational().DefaultSchema;
 
-            // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
-            // and other database objects. However, it isn't aware of enums, so we always ensure schema on enum creation.
-            if (schema != null)
-                Generate(new EnsureSchemaOperation { Name = schema }, model, builder);
-
             builder
                 .Append("CREATE TYPE ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(enumType.Name, schema))
@@ -783,11 +778,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             [NotNull] MigrationCommandListBuilder builder)
         {
             var schema = rangeType.Schema ?? model.Relational().DefaultSchema;
-
-            // Schemas are normally created (or rather ensured) by the model differ, which scans all tables, sequences
-            // and other database objects. However, it isn't aware of ranges, so we always ensure schema on range creation.
-            if (schema != null)
-                Generate(new EnsureSchemaOperation { Name = schema }, model, builder);
 
             builder
                 .Append("CREATE TYPE ")

--- a/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlMigrationSqlGeneratorTest.cs
@@ -751,20 +751,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [Fact]
-        public void CreatePostgresEnumWithSchema()
-        {
-            var op = new AlterDatabaseOperation();
-            PostgresEnum.GetOrAddPostgresEnum(op, "some_schema", "my_enum", new[] { "value1", "value2" });
-            Generate(op);
-
-            Assert.Equal(
-                @"CREATE SCHEMA IF NOT EXISTS some_schema;" + EOL +
-                @"GO" + EOL + EOL +
-                @"CREATE TYPE some_schema.my_enum AS ENUM ('value1', 'value2');" + EOL,
-                Sql);
-        }
-
-        [Fact]
         public void DropPostgresEnum()
         {
             var op = new AlterDatabaseOperation();


### PR DESCRIPTION
Closes: #730.

- [x] Step 1: include schemas from custom annotations in the diff.
- [x] Step 2: include extensions, enums, and ranges in the diff.

/cc @roji 

## Related
- #736
- Types:
   - [MigrationsModelDiffer.cs](https://github.com/aspnet/EntityFrameworkCore/blob/master/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs)
   - [MigrationsScaffolder.cs](https://github.com/aspnet/EntityFrameworkCore/blob/master/src/EFCore.Design/Migrations/Design/MigrationsScaffolder.cs)
- Tests:
   - [SqlServerModelDifferTest.cs](https://github.com/aspnet/EntityFrameworkCore/blob/master/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs)
   - [MigrationScaffolderTest.cs](https://github.com/aspnet/EntityFrameworkCore/blob/master/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs)
