### PR TITLE
Warn if auto-prepare is disabled

### DIFF
--- a/src/EFCore.PG/Diagnostics/Internal/NpgsqlLoggingDefinitions.cs
+++ b/src/EFCore.PG/Diagnostics/Internal/NpgsqlLoggingDefinitions.cs
@@ -20,5 +20,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Diagnostics.Internal
         public EventDefinitionBase LogExpressionIndexSkipped;
         public EventDefinitionBase LogUnsupportedColumnConstraintSkipped;
         public EventDefinitionBase LogUnsupportedColumnIndexSkipped;
+        public EventDefinitionBase LogAutoPrepareDisabled;
     }
 }

--- a/src/EFCore.PG/Diagnostics/NpgsqlEventId.cs
+++ b/src/EFCore.PG/Diagnostics/NpgsqlEventId.cs
@@ -51,11 +51,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             EnumColumnSkippedWarning,
             ExpressionIndexSkippedWarning,
             UnsupportedColumnIndexSkippedWarning,
-            UnsupportedConstraintIndexSkippedWarning
+            UnsupportedConstraintIndexSkippedWarning,
+
+            // Connection events
+            AutoPrepareDisabledWarning
         }
 
         static readonly string ScaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
         static EventId MakeScaffoldingId(Id id) => new EventId((int)id, ScaffoldingPrefix + id);
+
+        static readonly string ConnectionPrefix = DbLoggerCategory.Database.Connection.Name + ".";
+        static EventId MakeConnectionId(Id id) => new EventId((int)id, ConnectionPrefix + id);
+
+        #region Scaffolding events
 
         /// <summary>
         ///   <para>
@@ -206,5 +214,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///   </para>
         /// </summary>
         public static readonly EventId UnsupportedColumnConstraintSkippedWarning = MakeScaffoldingId(Id.UnsupportedConstraintIndexSkippedWarning);
+
+        #endregion
+
+        #region Connection events
+
+        /// <summary>
+        ///   <para>
+        ///     Automatic preparation is set to zero and disabled for the connection to database '{database}' on server '{server}'.
+        ///   </para>
+        ///   <para>
+        ///     This event is in the <see cref="DbLoggerCategory.Database.Connection" /> category.
+        ///   </para>
+        /// </summary>
+        public static readonly EventId AutoPrepareDisabledWarning = MakeConnectionId(Id.AutoPrepareDisabledWarning);
+
+        #endregion
     }
 }

--- a/src/EFCore.PG/EFCore.PG.csproj
+++ b/src/EFCore.PG/EFCore.PG.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</RepositoryUrl>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- PrivateAssets="none" is set to flow the EF Core analyzer to users referencing this package

--- a/src/EFCore.PG/Extensions/NpgsqlDbContextOptionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlDbContextOptionsExtensions.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Data.Common;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Diagnostics;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore
                 ? new NpgsqlOptionsExtension(existing)
                 : new NpgsqlOptionsExtension();
 
-        private static void ConfigureWarnings(DbContextOptionsBuilder optionsBuilder)
+        static void ConfigureWarnings(DbContextOptionsBuilder optionsBuilder)
         {
             var coreOptionsExtension = optionsBuilder.Options.FindExtension<CoreOptionsExtension>() ?? new CoreOptionsExtension();
 

--- a/src/EFCore.PG/Internal/NpgsqlLoggerExtensions.cs
+++ b/src/EFCore.PG/Internal/NpgsqlLoggerExtensions.cs
@@ -190,7 +190,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
             [NotNull] DbConnection connection,
             Guid connectionId)
         {
-            var definition = NpgsqlStrings.LogAutoPrepareDisabled;
+            var definition = NpgsqlResources.LogAutoPrepareDisabled(diagnostics);
 
             var warningBehavior = definition.GetLogBehavior(diagnostics);
             if (warningBehavior != WarningBehavior.Ignore)

--- a/src/EFCore.PG/Internal/NpgsqlLoggerExtensions.cs
+++ b/src/EFCore.PG/Internal/NpgsqlLoggerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;

--- a/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
@@ -554,7 +554,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
 
         /// <summary>
 
-        ///     Automatic preparation is set to zero and disabled for the connection to database '{database}' on server '{server}'.
+        ///     A connection to database '{database}' on server '{server}' is being made without automatic preparation. Consider enabling this feature to significantly improve performance. See https://www.npgsql.org/doc/prepare for more details.
 
         /// </summary>
 

--- a/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
@@ -551,6 +551,34 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
             return (EventDefinition<string, string>)definition;
         }
 
+
+        /// <summary>
+
+        ///     Automatic preparation is set to zero and disabled for the connection to database '{database}' on server '{server}'.
+
+        /// </summary>
+
+        public static EventDefinition<string, string> LogAutoPrepareDisabled([NotNull] IDiagnosticsLogger logger)
+        {
+            var definition = ((Diagnostics.Internal.NpgsqlLoggingDefinitions)logger.Definitions).LogAutoPrepareDisabled;
+            if (definition == null)
+            {
+                definition = LazyInitializer.EnsureInitialized<EventDefinitionBase>(
+                    ref ((Diagnostics.Internal.NpgsqlLoggingDefinitions)logger.Definitions).LogAutoPrepareDisabled,
+                    () => new EventDefinition<string, string>(
+                        logger.Options,
+                        NpgsqlEventId.AutoPrepareDisabledWarning,
+                        LogLevel.Warning,
+                        "NpgsqlEventId.AutoPrepareDisabledWarning",
+                        level => LoggerMessage.Define<string, string>(
+                            level,
+                            NpgsqlEventId.AutoPrepareDisabledWarning,
+                            _resourceManager.GetString("LogAutoPrepareDisabled"))));
+            }
+
+            return (EventDefinition<string, string>)definition;
+        }
+
     }
 }
 

--- a/src/EFCore.PG/Properties/NpgsqlStrings.resx
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.resx
@@ -196,7 +196,7 @@
     <comment>Warning NpgsqlEventId.UnsupportedColumnIndexSkippedWarning string string</comment>
   </data>
   <data name="LogAutoPrepareDisabled" xml:space="preserve">
-    <value>Automatic preparation is set to zero and disabled for the connection to database '{database}' on server '{server}'.</value>
+    <value>A connection to database '{database}' on server '{server}' is being made without automatic preparation. Consider enabling this feature to significantly improve performance. See https://www.npgsql.org/doc/prepare for more details.</value>
     <comment>Warning NpgsqlEventId.AutoPrepareDisabledWarning string string</comment>
   </data>
 </root>

--- a/src/EFCore.PG/Properties/NpgsqlStrings.resx
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.resx
@@ -195,4 +195,8 @@
     <value>Index '{name}' on table {tableName} cannot be scaffolded because it includes a column that cannot be scaffolded (e.g. enum).</value>
     <comment>Warning NpgsqlEventId.UnsupportedColumnIndexSkippedWarning string string</comment>
   </data>
+  <data name="LogAutoPrepareDisabled" xml:space="preserve">
+    <value>Automatic preparation is set to zero and disabled for the connection to database '{database}' on server '{server}'.</value>
+    <comment>Warning NpgsqlEventId.AutoPrepareDisabledWarning string string</comment>
+  </data>
 </root>

--- a/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
@@ -11,9 +11,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
     public class NpgsqlRelationalConnection : RelationalConnection, INpgsqlRelationalConnection
     {
         /// <summary>
-        /// True if the connection settings have already been validated; otherwise, false.
+        /// True if an auto-prepare disabled warning has already been issued; otherwise, false.
         /// </summary>
-        bool _validated;
+        static bool _warnedAutoPrepareDisabled;
 
         ProvideClientCertificatesCallback ProvideClientCertificatesCallback { get; }
         RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; }
@@ -41,13 +41,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             if (RemoteCertificateValidationCallback != null)
                 conn.UserCertificateValidationCallback = RemoteCertificateValidationCallback;
 
-            if (_validated)
-                return conn;
-
-            if (conn.Settings.MaxAutoPrepare == 0)
+            if (!_warnedAutoPrepareDisabled && conn.Settings.MaxAutoPrepare == 0)
+            {
                 Dependencies.ConnectionLogger.AutoPrepareDisabledWarning(conn, ConnectionId);
+                _warnedAutoPrepareDisabled = true;
+            }
 
-            _validated = true;
             return conn;
         }
 

--- a/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
@@ -10,6 +10,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 {
     public class NpgsqlRelationalConnection : RelationalConnection, INpgsqlRelationalConnection
     {
+        /// <summary>
+        /// True if the connection settings have already been validated; otherwise, false.
+        /// </summary>
+        bool _validated;
+
         ProvideClientCertificatesCallback ProvideClientCertificatesCallback { get; }
         RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; }
 
@@ -35,8 +40,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 conn.ProvideClientCertificatesCallback = ProvideClientCertificatesCallback;
             if (RemoteCertificateValidationCallback != null)
                 conn.UserCertificateValidationCallback = RemoteCertificateValidationCallback;
+
+            if (_validated)
+                return conn;
+
             if (conn.Settings.MaxAutoPrepare == 0)
                 Dependencies.ConnectionLogger.AutoPrepareDisabledWarning(conn, ConnectionId);
+
+            _validated = true;
             return conn;
         }
 

--- a/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
@@ -1,10 +1,10 @@
 using System.Data.Common;
-using System.Linq;
 using System.Net.Security;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 {
@@ -22,7 +22,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             : base(dependencies)
         {
             var npgsqlOptions =
-                dependencies.ContextOptions.Extensions.OfType<NpgsqlOptionsExtension>().FirstOrDefault();
+                dependencies.ContextOptions.FindExtension<NpgsqlOptionsExtension>() ?? new NpgsqlOptionsExtension();
 
             ProvideClientCertificatesCallback = npgsqlOptions.ProvideClientCertificatesCallback;
             RemoteCertificateValidationCallback = npgsqlOptions.RemoteCertificateValidationCallback;
@@ -35,6 +35,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 conn.ProvideClientCertificatesCallback = ProvideClientCertificatesCallback;
             if (RemoteCertificateValidationCallback != null)
                 conn.UserCertificateValidationCallback = RemoteCertificateValidationCallback;
+            if (conn.Settings.MaxAutoPrepare == 0)
+                Dependencies.ConnectionLogger.AutoPrepareDisabledWarning(conn, ConnectionId);
             return conn;
         }
 

--- a/test/EFCore.PG.Tests/EFCore.PG.Tests.csproj
+++ b/test/EFCore.PG.Tests/EFCore.PG.Tests.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' OR '$(CoreOnly)' == 'True'">netcoreapp3.0</TargetFrameworks>
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.Tests</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL</RootNamespace>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.PG.Tests/NpgsqlRelationalConnectionTest.cs
+++ b/test/EFCore.PG.Tests/NpgsqlRelationalConnectionTest.cs
@@ -1,8 +1,11 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Logging;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Diagnostics.Internal;
 using Xunit;
@@ -12,25 +15,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
     public class NpgsqlRelationalConnectionTest
     {
+        #region Tests
+
         [Fact]
         public void Creates_Npgsql_Server_connection_string()
         {
-            using (var connection = new NpgsqlRelationalConnection(CreateDependencies()))
-            {
-                Assert.IsType<NpgsqlConnection>(connection.DbConnection);
-            }
+            using var connection = new NpgsqlRelationalConnection(CreateDependencies());
+            Assert.IsType<NpgsqlConnection>(connection.DbConnection);
         }
 
         [Fact]
         public void Can_create_master_connection_string()
         {
-            using (var connection = new NpgsqlRelationalConnection(CreateDependencies()))
-            {
-                using (var master = connection.CreateMasterConnection())
-                {
-                    Assert.Equal(@"Host=localhost;Database=postgres;Username=some_user;Password=some_password;Pooling=False", master.ConnectionString);
-                }
-            }
+            using var connection = new NpgsqlRelationalConnection(CreateDependencies());
+            using var master = connection.CreateMasterConnection();
+            Assert.Equal(@"Host=localhost;Database=postgres;Username=some_user;Password=some_password;Pooling=False", master.ConnectionString);
         }
 
         [Fact]
@@ -38,40 +37,66 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         {
             var options = new DbContextOptionsBuilder()
                 .UseNpgsql(
-                    @"Host=localhost;Database=NpgsqlConnectionTest;Username=some_user;Password=some_password",
+                    "Host=localhost;Database=NpgsqlConnectionTest;Username=some_user;Password=some_password",
                     b => b.UseAdminDatabase("template0"))
                 .Options;
 
-            using (var connection = new NpgsqlRelationalConnection(CreateDependencies(options)))
-            {
-                using (var master = connection.CreateMasterConnection())
-                {
-                    Assert.Equal(@"Host=localhost;Database=template0;Username=some_user;Password=some_password;Pooling=False", master.ConnectionString);
-                }
-            }
+            using var connection = new NpgsqlRelationalConnection(CreateDependencies(options));
+            using var master = connection.CreateMasterConnection();
+            Assert.Equal(@"Host=localhost;Database=template0;Username=some_user;Password=some_password;Pooling=False", master.ConnectionString);
         }
 
-        public static RelationalConnectionDependencies CreateDependencies(DbContextOptions options = null)
+        [Fact]
+        public void Warning_is_logged_if_auto_prepare_is_disabled()
         {
-            options = options
-                      ?? new DbContextOptionsBuilder()
-                          .UseNpgsql(@"Host=localhost;Database=NpgsqlConnectionTest;Username=some_user;Password=some_password")
-                          .Options;
+            var options = new DbContextOptionsBuilder()
+                .UseNpgsql("Host=localhost;Database=NpgsqlConnectionTest;Username=some_user;Password=some_password;MaxAutoPrepare=0")
+                .Options;
+
+            using var conn1 = new NpgsqlRelationalConnection(CreateDependencies(options));
+            using var conn2 = new NpgsqlRelationalConnection(CreateDependencies(options));
+
+            Assert.NotNull(conn1.DbConnection);
+            Assert.NotNull(conn2.DbConnection);
+
+            var (level, _, message, _, _) = Assert.Single(TestLoggerFactory.Log.Where(x => x.Id == NpgsqlEventId.AutoPrepareDisabledWarning));
+
+            Assert.Equal(level, LogLevel.Warning);
+            Assert.Equal(
+                "A connection to database 'NpgsqlConnectionTest' on server 'tcp://localhost:5432' is being made without automatic preparation. Consider enabling this feature to significantly improve performance. See https://www.npgsql.org/doc/prepare for more details.",
+                message);
+        }
+
+        #endregion
+
+        #region Support
+
+        static readonly ListLoggerFactory TestLoggerFactory = new ListLoggerFactory();
+
+        public NpgsqlRelationalConnectionTest() => TestLoggerFactory.Clear();
+
+        static RelationalConnectionDependencies CreateDependencies(DbContextOptions? options = null)
+        {
+            options ??= new DbContextOptionsBuilder()
+                .UseNpgsql(@"Host=localhost;Database=NpgsqlConnectionTest;Username=some_user;Password=some_password")
+                .Options;
 
             return new RelationalConnectionDependencies(
                 options,
                 new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
-                    new LoggerFactory(),
+                    TestLoggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener"),
                     new NpgsqlLoggingDefinitions()),
                 new DiagnosticsLogger<DbLoggerCategory.Database.Connection>(
-                    new LoggerFactory(),
+                    TestLoggerFactory,
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener"),
                     new NpgsqlLoggingDefinitions()),
                 new NamedConnectionStringResolver(options),
                 new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies()));
         }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Noticed that this is one of the last items marked for `2.1.4`, so figured I'd give it a first pass. Since we don't do anything like this currently, I tried to model this after similar stuff in [`EFCore.Relational`](https://github.com/aspnet/EntityFrameworkCore/tree/master/src/EFCore.Relational).

Closes #296 
