### PR TITLE
Set versioning upper bound to exclude Npgsql.NetTopologySuite >= 4.1.0

### DIFF
--- a/src/EFCore.PG.NTS/EFCore.PG.NTS.csproj
+++ b/src/EFCore.PG.NTS/EFCore.PG.NTS.csproj
@@ -32,6 +32,8 @@
     <ProjectReference Include="..\EFCore.PG\EFCore.PG.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql.NetTopologySuite" Version="$(NpgsqlVersion)" />
+    <!-- Npgsql.NetTopologySuite 4.1.0 switched to NetTopologySuite 2.0.0. As we're still on NetTopologySuite 1, we
+         set a versioning upper bound to exclude it. -->
+    <PackageReference Include="Npgsql.NetTopologySuite" Version="[$(NpgsqlVersion),4.1.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
EFCore 3.0.0 switched to using NetTopologySuite 2.0.0, and so did Npgsql.NetTopologySuite 4.1.0. As this is an incompatible version, make sure that EFCore.PG.NetToplogySuite 2.x has an upper version bound to exclude 4.1.0.

Will also backport to earlier branches.