### PR TITLE
Add `IsNpgsql` extension method to EF's MigrationBuilder

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -11,6 +11,16 @@ namespace Microsoft.EntityFrameworkCore
     // TODO: This is unused. Can we remove it?
     public static class NpgsqlMigrationBuilderExtensions
     {
+        /// <summary>
+        /// Returns true if the active provider in a migration is the Npgsql provider.
+        /// </summary>
+        /// <param name="builder">The <see cref="MigrationBuilder" />.</param>
+        /// <returns>True if PostgreSQL is being used; false otherwise.</returns>
+        public static bool IsNpgsql([NotNull] this MigrationBuilder builder)
+            => builder.ActiveProvider.Equals(
+                typeof(NpgsqlMigrationBuilderExtensions).GetTypeInfo().Assembly.GetName().Name,
+                StringComparison.Ordinal);
+
         public static MigrationBuilder EnsurePostgresExtension(
             this MigrationBuilder builder,
             [NotNull] string name,

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
@@ -14,7 +14,8 @@ namespace Microsoft.EntityFrameworkCore
         /// <summary>
         /// Returns true if the active provider in a migration is the Npgsql provider.
         /// </summary>
-        /// <param name="builder">The <see cref="MigrationBuilder" />.</param>
+        /// The migrationBuilder from the parameters on <see cref="Migration.Up(MigrationBuilder)" /> or
+        /// <see cref="Migration.Down(MigrationBuilder)" />.
         /// <returns>True if PostgreSQL is being used; false otherwise.</returns>
         public static bool IsNpgsql([NotNull] this MigrationBuilder builder)
             => builder.ActiveProvider.Equals(

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
@@ -8,7 +8,6 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore
 {
-    // TODO: This is unused. Can we remove it?
     public static class NpgsqlMigrationBuilderExtensions
     {
         /// <summary>

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// The migrationBuilder from the parameters on <see cref="Migration.Up(MigrationBuilder)" /> or
         /// <see cref="Migration.Down(MigrationBuilder)" />.
-        /// <returns>True if PostgreSQL is being used; false otherwise.</returns>
+        /// <returns>True if Npgsql is being used; false otherwise.</returns>
         public static bool IsNpgsql([NotNull] this MigrationBuilder builder)
             => builder.ActiveProvider.Equals(
                 typeof(NpgsqlMigrationBuilderExtensions).GetTypeInfo().Assembly.GetName().Name,

--- a/test/EFCore.PG.Tests/NpgsqlMigrationBuilderTest.cs
+++ b/test/EFCore.PG.Tests/NpgsqlMigrationBuilderTest.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Xunit;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL
+{
+    public class NpgsqlMigrationBuilderTest
+    {
+        [Fact]
+        public void IsNpgsql_when_using_EfCorePostgreSql()
+        {
+            var migrationBuilder = new MigrationBuilder("Npgsql.EntityFrameworkCore.PostgreSQL");
+            Assert.True(migrationBuilder.IsNpgsql());
+        }
+
+        [Fact]
+        public void Not_IsNpgsql_when_using_different_provider()
+        {
+            var migrationBuilder = new MigrationBuilder("Microsoft.EntityFrameworkCore.InMemory");
+            Assert.False(migrationBuilder.IsNpgsql());
+        }
+    }
+}

--- a/test/EFCore.PG.Tests/NpgsqlMigrationBuilderTest.cs
+++ b/test/EFCore.PG.Tests/NpgsqlMigrationBuilderTest.cs
@@ -7,7 +7,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
     public class NpgsqlMigrationBuilderTest
     {
         [Fact]
-        public void IsNpgsql_when_using_EfCorePostgreSql()
+        public void IsNpgsql_when_using_Npgsql()
         {
             var migrationBuilder = new MigrationBuilder("Npgsql.EntityFrameworkCore.PostgreSQL");
             Assert.True(migrationBuilder.IsNpgsql());


### PR DESCRIPTION
Add extension method to be make it easier to detect if an Entity Framework Core migration is targeting a PostgreSQL database.

```csharp
public partial class MyDbMigration : Migration
{
    protected override void Up(MigrationBuilder migrationBuilder)
    {
        if (migrationBuilder.IsNpgsql())
        {
            // ...
        }
    }

    protected override void Down(MigrationBuilder migrationBuilder)
    {
        if (migrationBuilder.IsNpgsql())
        {
            // ...
        }
    }
}
```