### PR TITLE
Update repository and project urls to match new repo name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,12 +6,12 @@
     <VersionPrefix>3.1.0</VersionPrefix>
 
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</RepositoryUrl>
+    <RepositoryUrl>git://github.com/npgsql/efcore.pg</RepositoryUrl>
 
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
 
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/npgsql/efcore.pg</PackageProjectUrl>
     <PackageIcon>postgresql.png</PackageIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
... now that [the repo was renamed to `efcore.pg`](https://github.com/npgsql/efcore.pg/issues/1074)