### PR TITLE
WIP: Handle GetGuid from JSON in criteria

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDomTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDomTranslator.cs
@@ -130,7 +130,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             case TypeCode.UInt64:
                 return _sqlExpressionFactory.Convert(expression, returnType, _sqlExpressionFactory.FindMapping(returnType));
             default:
-                return expression;
+                    if (returnType == typeof(Guid))
+                    {
+                        return _sqlExpressionFactory.Convert(expression, returnType, _sqlExpressionFactory.FindMapping(returnType)); ;
+                    }
+                    else
+                    {
+                        return expression;
+                    }
             }
         }
     }

--- a/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
@@ -179,11 +179,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
                 case SqlConstantExpression _:
                 case SqlParameterExpression _:
                 case SqlFunctionExpression _:
+                case JsonTraversalExpression _:
                     var storeType = sqlUnaryExpression.TypeMapping.StoreType;
                     if (storeType == "integer")
                         storeType = "INT";  // Shorthand that looks better in SQL
-
+                    Sql.Append("(");
                     Visit(sqlUnaryExpression.Operand);
+                    Sql.Append(")");
                     Sql.Append("::");
                     Sql.Append(storeType);
                     return sqlUnaryExpression;

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
@@ -885,13 +885,13 @@ WHERE ((m.""TimeSpanAsTime"" = @__timeSpan_0) AND ((m.""TimeSpanAsTime"" IS NOT 
                 var sum3 = context.Set<MappedDataTypes>().Sum(m => m.ShortAsSmallint);
 
                 AssertSql(
-                    @"SELECT SUM(m.""LongAsBigint"")::bigint
+                    @"SELECT (SUM(m.""LongAsBigint""))::bigint
 FROM ""MappedDataTypes"" AS m",
                     //
-                    @"SELECT SUM(m.""Int"")::INT
+                    @"SELECT (SUM(m.""Int""))::INT
 FROM ""MappedDataTypes"" AS m",
                     //
-                    @"SELECT SUM(CAST(m.""ShortAsSmallint"" AS integer))::INT
+                    @"SELECT (SUM(CAST(m.""ShortAsSmallint"" AS integer)))::INT
 FROM ""MappedDataTypes"" AS m");
             }
         }

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -251,7 +251,7 @@ LIMIT 2");            }
                 Assert.Equal(count, 2);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""SomeEntities"" AS s
 WHERE cardinality(s.""SomeArray"") > 0");
             }

--- a/test/EFCore.PG.FunctionalTests/Query/DbFunctionsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/DbFunctionsNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Xunit;
@@ -26,7 +26,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             }
 
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE c.""ContactName"" LIKE '%M%'");
         }
@@ -36,7 +36,7 @@ WHERE c.""ContactName"" LIKE '%M%'");
             base.Like_identity();
 
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE c.""ContactName"" LIKE c.""ContactName"" ESCAPE ''");
         }
@@ -46,7 +46,7 @@ WHERE c.""ContactName"" LIKE c.""ContactName"" ESCAPE ''");
             base.Like_literal_with_escape();
 
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE c.""ContactName"" LIKE '!%' ESCAPE '!'");
         }
@@ -62,7 +62,7 @@ WHERE c.""ContactName"" LIKE '!%' ESCAPE '!'");
             }
 
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE c.""ContactName"" LIKE '\' ESCAPE ''");
         }
@@ -79,7 +79,7 @@ WHERE c.""ContactName"" LIKE '\' ESCAPE ''");
 
             // For the useless = TRUE below see https://github.com/aspnet/EntityFramework/issues/9143
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE c.""ContactName"" ILIKE '%M%'");
         }
@@ -95,7 +95,7 @@ WHERE c.""ContactName"" ILIKE '%M%'");
 
             // For the useless = TRUE below see https://github.com/aspnet/EntityFramework/issues/9143
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE c.""ContactName"" ILIKE '!%' ESCAPE '!'");
         }

--- a/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FullTextSearchDbFunctionsNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
@@ -32,7 +32,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             }
 
             AssertSql(
-                @"SELECT 'a b'::tsvector
+                @"SELECT ('a b')::tsvector
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -108,7 +108,7 @@ LIMIT 1");
             AssertSql(
                 @"@__config_1='english'
 
-SELECT to_tsvector(@__config_1::regconfig, c.""CompanyName"")
+SELECT to_tsvector((@__config_1)::regconfig, c.""CompanyName"")
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -123,7 +123,7 @@ LIMIT 1");
             }
 
             AssertSql(
-                @"SELECT 'a & b'::tsquery
+                @"SELECT ('a & b')::tsquery
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -171,7 +171,7 @@ LIMIT 1");
             AssertSql(
                 @"@__config_1='english'
 
-SELECT plainto_tsquery(@__config_1::regconfig, 'a')
+SELECT plainto_tsquery((@__config_1)::regconfig, 'a')
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -219,7 +219,7 @@ LIMIT 1");
             AssertSql(
                 @"@__config_1='english'
 
-SELECT phraseto_tsquery(@__config_1::regconfig, 'a b')
+SELECT phraseto_tsquery((@__config_1)::regconfig, 'a b')
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -267,7 +267,7 @@ LIMIT 1");
             AssertSql(
                 @"@__config_1='english'
 
-SELECT to_tsquery(@__config_1::regconfig, 'a & b')
+SELECT to_tsquery((@__config_1)::regconfig, 'a & b')
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -315,7 +315,7 @@ LIMIT 1");
             AssertSql(
                 @"@__config_1='english'
 
-SELECT websearch_to_tsquery(@__config_1::regconfig, 'a OR b')
+SELECT websearch_to_tsquery((@__config_1)::regconfig, 'a OR b')
 FROM ""Customers"" AS c
 LIMIT 1");
         }
@@ -513,7 +513,7 @@ LIMIT 1");
             AssertSql(
                 @"@__config_1='english'
 
-SELECT ts_headline(@__config_1::regconfig, 'a b c', to_tsquery('b'), 'MinWords=1, MaxWords=2')
+SELECT ts_headline((@__config_1)::regconfig, 'a b c', to_tsquery('b'), 'MinWords=1, MaxWords=2')
 FROM ""Customers"" AS c
 LIMIT 1");
         }

--- a/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
@@ -143,7 +143,7 @@ LIMIT 2");
                 AssertSql(
                     @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE CAST(j.""Customer""->>'Age' AS integer) < 30
+WHERE (j.""Customer""->>'Age')::INT < 30
 LIMIT 2");
             }
         }
@@ -159,7 +159,7 @@ LIMIT 2");
                 AssertSql(
                     @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE CAST(j.""Customer""->>'IsVip' AS boolean)
+WHERE (j.""Customer""->>'IsVip')::boolean
 LIMIT 2");
             }
         }
@@ -175,7 +175,7 @@ LIMIT 2");
                 AssertSql(
                     @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE CAST(j.""Customer""#>>'{Statistics,Visits}' AS bigint) = 4
+WHERE (j.""Customer""#>>'{Statistics,Visits}')::bigint = 4
 LIMIT 2");
             }
         }
@@ -191,7 +191,7 @@ LIMIT 2");
                 AssertSql(
                     @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE CAST(j.""Customer""#>>'{Statistics,Nested,SomeProperty}' AS integer) = 10
+WHERE (j.""Customer""#>>'{Statistics,Nested,SomeProperty}')::INT = 10
 LIMIT 2");
             }
         }
@@ -207,7 +207,7 @@ LIMIT 2");
                 AssertSql(
                     @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE CAST(j.""Customer""#>>'{Orders,0,Price}' AS numeric) = 99.5
+WHERE (j.""Customer""#>>'{Orders,0,Price}')::numeric = 99.5
 LIMIT 2");
             }
         }
@@ -239,7 +239,7 @@ LIMIT 2");
                 AssertSql(
                     @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE CAST(j.""Customer""#>>'{Statistics,Nested,IntArray,1}' AS integer) = 4
+WHERE (j.""Customer""#>>'{Statistics,Nested,IntArray,1}')::INT = 4
 LIMIT 2");
             }
         }
@@ -258,7 +258,7 @@ LIMIT 2");
 
 SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE (CAST(j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) = 4) AND (CAST(j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) IS NOT NULL)
+WHERE ((j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[])::INT = 4) AND ((j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[])::INT IS NOT NULL)
 LIMIT 2");
             }
         }
@@ -343,7 +343,7 @@ LIMIT 2");
                     @"@__element_1='{""Name"": ""Joe""
 ""Age"": 25}' (DbType = Object)
 
-SELECT COUNT(*)::INT
+SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE (j.""Customer"" @> @__element_1)");
             }
@@ -359,7 +359,7 @@ WHERE (j.""Customer"" @> @__element_1)");
                 Assert.Equal(1, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE (j.""Customer"" @> '{""Name"": ""Joe"", ""Age"": 25}')");
             }
@@ -379,7 +379,7 @@ WHERE (j.""Customer"" @> '{""Name"": ""Joe"", ""Age"": 25}')");
                     @"@__element_1='{""Name"": ""Joe""
 ""Age"": 25}' (DbType = Object)
 
-SELECT COUNT(*)::INT
+SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE (@__element_1 <@ j.""Customer"")");
             }
@@ -395,7 +395,7 @@ WHERE (@__element_1 <@ j.""Customer"")");
                 Assert.Equal(1, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE ('{""Name"": ""Joe"", ""Age"": 25}' <@ j.""Customer"")");
             }
@@ -411,7 +411,7 @@ WHERE ('{""Name"": ""Joe"", ""Age"": 25}' <@ j.""Customer"")");
                 Assert.Equal(2, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE (j.""Customer""->'Statistics' ? 'Visits')");
             }
@@ -427,7 +427,7 @@ WHERE (j.""Customer""->'Statistics' ? 'Visits')");
                 Assert.Equal(2, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE (j.""Customer""->'Statistics' ?| ARRAY['foo','Visits']::text[])");
             }
@@ -443,7 +443,7 @@ WHERE (j.""Customer""->'Statistics' ?| ARRAY['foo','Visits']::text[])");
                 Assert.Equal(0, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE (j.""Customer""->'Statistics' ?& ARRAY['foo','Visits']::text[])");
             }
@@ -459,7 +459,7 @@ WHERE (j.""Customer""->'Statistics' ?& ARRAY['foo','Visits']::text[])");
                 Assert.Equal(2, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonbEntities"" AS j
 WHERE jsonb_typeof(j.""Customer""#>'{Statistics,Visits}') = 'number'");
             }
@@ -475,7 +475,7 @@ WHERE jsonb_typeof(j.""Customer""#>'{Statistics,Visits}') = 'number'");
                 Assert.Equal(2, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE json_typeof(j.""Customer""#>'{Statistics,Visits}') = 'number'");
             }

--- a/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
@@ -133,7 +133,7 @@ LIMIT 2");
                 Assert.Equal(1, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE (j.""CustomerJsonb"" @> '{""Name"": ""Joe"", ""Age"": 25}')");
             }
@@ -153,7 +153,7 @@ WHERE (j.""CustomerJsonb"" @> '{""Name"": ""Joe"", ""Age"": 25}')");
                     @"@__element_1='{""Name"": ""Joe""
 ""Age"": 25}' (DbType = Object)
 
-SELECT COUNT(*)::INT
+SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE (@__element_1 <@ j.""CustomerJsonb"")");
             }
@@ -169,7 +169,7 @@ WHERE (@__element_1 <@ j.""CustomerJsonb"")");
                 Assert.Equal(1, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE ('{""Name"": ""Joe"", ""Age"": 25}' <@ j.""CustomerJsonb"")");
             }
@@ -185,7 +185,7 @@ WHERE ('{""Name"": ""Joe"", ""Age"": 25}' <@ j.""CustomerJsonb"")");
                 Assert.Equal(2, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE (j.""CustomerJsonb"" ? 'Age')");
             }
@@ -201,7 +201,7 @@ WHERE (j.""CustomerJsonb"" ? 'Age')");
                 Assert.Equal(2, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE (j.""CustomerJsonb"" ?| ARRAY['foo','Age']::text[])");
             }
@@ -217,7 +217,7 @@ WHERE (j.""CustomerJsonb"" ?| ARRAY['foo','Age']::text[])");
                 Assert.Equal(0, count);
 
                 AssertSql(
-                    @"SELECT COUNT(*)::INT
+                    @"SELECT (COUNT(*))::INT
 FROM ""JsonEntities"" AS j
 WHERE (j.""CustomerJsonb"" ?& ARRAY['foo','Age']::text[])");
             }

--- a/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
@@ -29,7 +29,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             base.Scalar_Function_Extension_Method_Static();
 
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE (""IsDate""(c.""FirstName"") = FALSE) AND (""IsDate""(c.""FirstName"") IS NOT NULL)");
         }
@@ -411,7 +411,7 @@ LIMIT 2");
             base.Scalar_Function_Extension_Method_Instance();
 
             AssertSql(
-                @"SELECT COUNT(*)::INT
+                @"SELECT (COUNT(*))::INT
 FROM ""Customers"" AS c
 WHERE (""IsDate""(c.""FirstName"") = FALSE) AND (""IsDate""(c.""FirstName"") IS NOT NULL)");
         }

--- a/test/EFCore.PG.Plugins.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.Plugins.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,7 +53,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.Year == 2018);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"DATE_PART('year', n.""LocalDateTime"")::INT = 2018", Sql);
+                Assert.Contains(@"(DATE_PART('year', n.""LocalDateTime""))::INT = 2018", Sql);
             }
         }
 
@@ -64,7 +64,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.Month == 4);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"DATE_PART('month', n.""LocalDateTime"")::INT = 4", Sql);
+                Assert.Contains(@"(DATE_PART('month', n.""LocalDateTime""))::INT = 4", Sql);
             }
         }
 
@@ -75,7 +75,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.DayOfYear == 110);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"DATE_PART('doy', n.""LocalDateTime"")::INT = 110", Sql);
+                Assert.Contains(@"(DATE_PART('doy', n.""LocalDateTime""))::INT = 110", Sql);
             }
         }
 
@@ -86,7 +86,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.Day == 20);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"DATE_PART('day', n.""LocalDateTime"")::INT = 20", Sql);
+                Assert.Contains(@"(DATE_PART('day', n.""LocalDateTime""))::INT = 20", Sql);
             }
         }
 
@@ -97,7 +97,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.Hour == 10);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"DATE_PART('hour', n.""LocalDateTime"")::INT = 10", Sql);
+                Assert.Contains(@"(DATE_PART('hour', n.""LocalDateTime""))::INT = 10", Sql);
             }
         }
 
@@ -108,7 +108,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.Minute == 31);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"DATE_PART('minute', n.""LocalDateTime"")::INT = 31", Sql);
+                Assert.Contains(@"(DATE_PART('minute', n.""LocalDateTime""))::INT = 31", Sql);
             }
         }
 
@@ -119,7 +119,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDateTime.Second == 33);
                 Assert.Equal(new LocalDateTime(2018, 4, 20, 10, 31, 33, 666), d.LocalDateTime);
-                Assert.Contains(@"FLOOR(DATE_PART('second', n.""LocalDateTime""))::INT = 33", Sql);
+                Assert.Contains(@"(FLOOR(DATE_PART('second', n.""LocalDateTime"")))::INT = 33", Sql);
             }
         }
 
@@ -144,8 +144,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
                 Assert.Equal(@"SELECT n.""Id"", n.""DateRange"", n.""Instant"", n.""LocalDate"", n.""LocalDateTime"", n.""LocalTime"", n.""OffsetTime"", n.""Period"", n.""ZonedDateTime""
 FROM ""NodaTimeTypes"" AS n
 WHERE CASE
-    WHEN FLOOR(DATE_PART('dow', n.""LocalDateTime""))::INT = 0 THEN 7
-    ELSE FLOOR(DATE_PART('dow', n.""LocalDateTime""))::INT
+    WHEN (FLOOR(DATE_PART('dow', n.""LocalDateTime"")))::INT = 0 THEN 7
+    ELSE (FLOOR(DATE_PART('dow', n.""LocalDateTime"")))::INT
 END = 5
 LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             }
@@ -162,7 +162,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDate.Year == 2018);
                 Assert.Equal(new LocalDate(2018, 4, 20), d.LocalDate);
-                Assert.Contains(@"DATE_PART('year', n.""LocalDate"")::INT = 2018", Sql);
+                Assert.Contains(@"(DATE_PART('year', n.""LocalDate""))::INT = 2018", Sql);
             }
         }
 
@@ -173,7 +173,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDate.Month == 4);
                 Assert.Equal(new LocalDate(2018, 4, 20), d.LocalDate);
-                Assert.Contains(@"DATE_PART('month', n.""LocalDate"")::INT = 4", Sql);
+                Assert.Contains(@"(DATE_PART('month', n.""LocalDate""))::INT = 4", Sql);
             }
         }
 
@@ -184,7 +184,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDate.DayOfYear == 110);
                 Assert.Equal(new LocalDate(2018, 4, 20), d.LocalDate);
-                Assert.Contains(@"DATE_PART('doy', n.""LocalDate"")::INT = 110", Sql);
+                Assert.Contains(@"(DATE_PART('doy', n.""LocalDate""))::INT = 110", Sql);
             }
         }
 
@@ -195,7 +195,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalDate.Day == 20);
                 Assert.Equal(new LocalDate(2018, 4, 20), d.LocalDate);
-                Assert.Contains(@"DATE_PART('day', n.""LocalDate"")::INT = 20", Sql);
+                Assert.Contains(@"(DATE_PART('day', n.""LocalDate""))::INT = 20", Sql);
             }
         }
 
@@ -210,7 +210,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalTime.Hour == 10);
                 Assert.Equal(new LocalTime(10, 31, 33, 666), d.LocalTime);
-                Assert.Contains(@"DATE_PART('hour', n.""LocalTime"")::INT = 10", Sql);
+                Assert.Contains(@"(DATE_PART('hour', n.""LocalTime""))::INT = 10", Sql);
             }
         }
 
@@ -221,7 +221,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalTime.Minute == 31);
                 Assert.Equal(new LocalTime(10, 31, 33, 666), d.LocalTime);
-                Assert.Contains(@"DATE_PART('minute', n.""LocalTime"")::INT = 31", Sql);
+                Assert.Contains(@"(DATE_PART('minute', n.""LocalTime""))::INT = 31", Sql);
             }
         }
 
@@ -232,7 +232,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.LocalTime.Second == 33);
                 Assert.Equal(new LocalTime(10, 31, 33, 666), d.LocalTime);
-                Assert.Contains(@"FLOOR(DATE_PART('second', n.""LocalTime""))::INT = 33", Sql);
+                Assert.Contains(@"(FLOOR(DATE_PART('second', n.""LocalTime"")))::INT = 33", Sql);
             }
         }
 
@@ -247,7 +247,7 @@ LIMIT 2", Sql, ignoreLineEndingDifferences: true);
             {
                 var d = ctx.NodaTimeTypes.Single(t => t.Period.Years == 2018);
                 Assert.Equal(_defaultPeriod, d.Period);
-                Assert.Contains(@"DATE_PART('year', n.""Period"")::INT = 2018", Sql);
+                Assert.Contains(@"(DATE_PART('year', n.""Period""))::INT = 2018", Sql);
             }
         }
 


### PR DESCRIPTION
There are still tests failing, but I just want to get early feedback. This change will handle GetGuid method from JsonElement when used in SQL Criteria or Join condition. The downside is that it will always wrap the convert operand with extra bracket, which should be harmless in all cases I can think of but can prevent errors when brackets are needed. Thoughts?