### PR TITLE
Support JsonDocument code literal generation

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlBitTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlBitTypeMapping.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
 using NpgsqlTypes;
@@ -42,8 +43,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             var exprs = new Expression[bits.Count];
             for (var i = 0; i < bits.Count; i++)
                 exprs[i] = Expression.Constant(bits[i]);
-            return Expression.New(typeof(BitArray).GetConstructor(new[] { typeof(bool[]) }),
-                Expression.NewArrayInit(typeof(bool), exprs));
+            return Expression.New(Constructor, Expression.NewArrayInit(typeof(bool), exprs));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(BitArray).GetConstructor(new[] { typeof(bool[]) });
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlGeometricTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlGeometricTypeMapping.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
 using NpgsqlTypes;
@@ -28,10 +29,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         public override Expression GenerateCodeLiteral(object value)
         {
             var point = (NpgsqlPoint)value;
-            return Expression.New(
-                typeof(NpgsqlPoint).GetConstructor(new[] { typeof(double), typeof(double) }),
-                Expression.Constant(point.X), Expression.Constant(point.Y));
+            return Expression.New(Constructor, Expression.Constant(point.X), Expression.Constant(point.Y));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlPoint).GetConstructor(new[] { typeof(double), typeof(double) });
     }
 
     public class NpgsqlLineTypeMapping : NpgsqlTypeMapping
@@ -57,9 +59,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var line = (NpgsqlLine)value;
             return Expression.New(
-                typeof(NpgsqlLine).GetConstructor(new[] { typeof(double), typeof(double), typeof(double) }),
+                Constructor,
                 Expression.Constant(line.A), Expression.Constant(line.B), Expression.Constant(line.C));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlLine).GetConstructor(new[] { typeof(double), typeof(double), typeof(double) });
     }
 
     public class NpgsqlLineSegmentTypeMapping : NpgsqlTypeMapping
@@ -82,10 +87,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var lseg = (NpgsqlLSeg)value;
             return Expression.New(
-                typeof(NpgsqlLSeg).GetConstructor(new[] { typeof(double), typeof(double), typeof(double), typeof(double) }),
+                Constructor,
                 Expression.Constant(lseg.Start.X), Expression.Constant(lseg.Start.Y),
                 Expression.Constant(lseg.End.X), Expression.Constant(lseg.End.Y));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlLSeg).GetConstructor(new[] { typeof(double), typeof(double), typeof(double), typeof(double) });
     }
 
     public class NpgsqlBoxTypeMapping : NpgsqlTypeMapping
@@ -108,10 +116,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var box = (NpgsqlBox)value;
             return Expression.New(
-                typeof(NpgsqlBox).GetConstructor(new[] { typeof(double), typeof(double), typeof(double), typeof(double) }),
+                Constructor,
                 Expression.Constant(box.Top), Expression.Constant(box.Right),
                 Expression.Constant(box.Bottom), Expression.Constant(box.Left));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlBox).GetConstructor(new[] { typeof(double), typeof(double), typeof(double), typeof(double) });
     }
 
     public class NpgsqlPathTypeMapping : NpgsqlTypeMapping
@@ -149,13 +160,19 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var path = (NpgsqlPath)value;
             return Expression.New(
-                typeof(NpgsqlPath).GetConstructor(new[] { typeof(IEnumerable<NpgsqlPoint>), typeof(bool) }),
+                Constructor,
                 Expression.NewArrayInit(typeof(NpgsqlPoint),
                     path.Select(p => Expression.New(
-                        typeof(NpgsqlPoint).GetConstructor(new[] { typeof(double), typeof(double) }),
+                        PointConstructor,
                         Expression.Constant(p.X), Expression.Constant(p.Y)))),
                 Expression.Constant(path.Open));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlPath).GetConstructor(new[] { typeof(IEnumerable<NpgsqlPoint>), typeof(bool) });
+
+        static readonly ConstructorInfo PointConstructor =
+            typeof(NpgsqlPoint).GetConstructor(new[] { typeof(double), typeof(double) });
     }
 
     public class NpgsqlPolygonTypeMapping : NpgsqlTypeMapping
@@ -191,12 +208,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var polygon = (NpgsqlPolygon)value;
             return Expression.New(
-                typeof(NpgsqlPolygon).GetConstructor(new[] { typeof(NpgsqlPoint[]) }),
+                Constructor,
                 Expression.NewArrayInit(typeof(NpgsqlPoint),
                     polygon.Select(p => Expression.New(
-                        typeof(NpgsqlPoint).GetConstructor(new[] { typeof(double), typeof(double) }),
+                        PointConstructor,
                         Expression.Constant(p.X), Expression.Constant(p.Y)))));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlPolygon).GetConstructor(new[] { typeof(NpgsqlPoint[]) });
+
+        static readonly ConstructorInfo PointConstructor =
+            typeof(NpgsqlPoint).GetConstructor(new[] { typeof(double), typeof(double) });
     }
 
     public class NpgsqlCircleTypeMapping : NpgsqlTypeMapping
@@ -219,8 +242,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var circle = (NpgsqlCircle)value;
             return Expression.New(
-                typeof(NpgsqlCircle).GetConstructor(new[] { typeof(double), typeof(double), typeof(double) }),
+                Constructor,
                 Expression.Constant(circle.X), Expression.Constant(circle.Y), Expression.Constant(circle.Radius));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlCircle).GetConstructor(new[] { typeof(double), typeof(double), typeof(double) });
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlJsonTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlJsonTypeMapping.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using JetBrains.Annotations;
@@ -53,9 +55,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             }
             case string s:
                 return $"'{EscapeSqlLiteral(s)}'";
-            default:  // User POCO
+            default: // User POCO
                 return $"'{EscapeSqlLiteral(JsonSerializer.Serialize(value))}'";
             }
         }
+
+        public override Expression GenerateCodeLiteral(object value)
+            => value switch
+            {
+                JsonDocument document => Expression.Call(ParseMethod, Expression.Constant(document.RootElement.ToString()), DefaultJsonDocumentOptions),
+                JsonElement _         => throw new NotSupportedException("Cannot currently generate code literals for JsonDocument"),
+                string s              => Expression.Constant(s),
+                _                     => throw new NotSupportedException("Cannot generate code literals for JSON POCOs")
+            };
+
+        static readonly Expression DefaultJsonDocumentOptions = Expression.New(typeof(JsonDocumentOptions));
+
+        static readonly MethodInfo ParseMethod =
+            typeof(JsonDocument).GetMethod(nameof(JsonDocument.Parse), new[] { typeof(string), typeof(JsonDocumentOptions) });
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlNetworkTypeMappings.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlNetworkTypeMappings.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Storage;
 using NpgsqlTypes;
 
@@ -29,9 +30,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             => $"MACADDR '{(PhysicalAddress)value}'";
 
         public override Expression GenerateCodeLiteral(object value)
-            => Expression.Call(
-                typeof(PhysicalAddress).GetMethod("Parse", new[] {typeof(string)}),
-                Expression.Constant(((PhysicalAddress)value).ToString()));
+            => Expression.Call(ParseMethod, Expression.Constant(((PhysicalAddress)value).ToString()));
+
+        static readonly MethodInfo ParseMethod = typeof(PhysicalAddress).GetMethod("Parse", new[] { typeof(string) });
     }
 
     /// <summary>
@@ -57,9 +58,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             => $"MACADDR8 '{(PhysicalAddress)value}'";
 
         public override Expression GenerateCodeLiteral(object value)
-            => Expression.Call(
-                typeof(PhysicalAddress).GetMethod("Parse", new[] {typeof(string)}),
-                Expression.Constant(((PhysicalAddress)value).ToString()));
+            => Expression.Call(ParseMethod, Expression.Constant(((PhysicalAddress)value).ToString()));
+
+        static readonly MethodInfo ParseMethod = typeof(PhysicalAddress).GetMethod("Parse", new[] { typeof(string) });
     }
 
     /// <summary>
@@ -85,9 +86,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             => $"INET '{(IPAddress)value}'";
 
         public override Expression GenerateCodeLiteral(object value)
-            => Expression.Call(
-                typeof(IPAddress).GetMethod("Parse", new[] {typeof(string)}),
-                Expression.Constant(((IPAddress)value).ToString()));
+            => Expression.Call(ParseMethod, Expression.Constant(((IPAddress)value).ToString()));
+
+        static readonly MethodInfo ParseMethod = typeof(IPAddress).GetMethod("Parse", new[] { typeof(string) });
     }
 
     /// <summary>
@@ -119,11 +120,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var cidr = ((IPAddress Address, int Subnet))value;
             return Expression.New(
-                typeof((IPAddress, int)).GetConstructor(new[] { typeof(IPAddress), typeof(int) }),
-                Expression.Call(
-                    typeof(IPAddress).GetMethod("Parse", new[] {typeof(string)}),
-                    Expression.Constant(cidr.Address.ToString())),
+                Constructor,
+                Expression.Call(ParseMethod, Expression.Constant(cidr.Address.ToString())),
                 Expression.Constant(cidr.Subnet));
         }
+
+        static readonly MethodInfo ParseMethod = typeof(IPAddress).GetMethod("Parse", new[] { typeof(string) });
+
+        static readonly ConstructorInfo Constructor =
+            typeof((IPAddress, int)).GetConstructor(new[] { typeof(IPAddress), typeof(int) });
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlRangeTypeMapping.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlTidTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlTidTypeMapping.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
 using NpgsqlTypes;
@@ -30,8 +31,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         public override Expression GenerateCodeLiteral(object value)
         {
             var tid = (NpgsqlTid)value;
-            return Expression.New(typeof(NpgsqlTid).GetConstructor(new[] { typeof(uint), typeof(ushort) }),
-                Expression.Constant(tid.BlockNumber), Expression.Constant(tid.OffsetNumber));
+            return Expression.New(Constructor, Expression.Constant(tid.BlockNumber), Expression.Constant(tid.OffsetNumber));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(NpgsqlTid).GetConstructor(new[] { typeof(uint), typeof(ushort) });
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlVarbitTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlVarbitTypeMapping.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Storage;
 using NpgsqlTypes;
@@ -33,8 +34,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             var exprs = new Expression[bits.Count];
             for (var i = 0; i < bits.Count; i++)
                 exprs[i] = Expression.Constant(bits[i]);
-            return Expression.New(typeof(BitArray).GetConstructor(new[] { typeof(bool[]) }),
+            return Expression.New(Constructor,
                 Expression.NewArrayInit(typeof(bool), exprs));
         }
+
+        static readonly ConstructorInfo Constructor =
+            typeof(BitArray).GetConstructor(new[] { typeof(bool[]) });
     }
 }

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -496,6 +496,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
             Assert.Equal($"'{json}'", literal);
         }
 
+        [Fact]
+        public void GenerateCodeLiteral_returns_json_document_literal()
+            => Assert.Equal(
+                @"System.Text.Json.JsonDocument.Parse(""{\""Name\"":\""Joe\"",\""Age\"":25}"", new System.Text.Json.JsonDocumentOptions())",
+                CodeLiteral(JsonDocument.Parse(@"{""Name"":""Joe"",""Age"":25}")));
+
         static readonly Customer SampleCustomer = new Customer
         {
             Name = "Joe",


### PR DESCRIPTION
Also extracted out MethodInfos and other reflection objects out to static fields for one-time-only initialization, and improve variable naming.

Fixes #1100

JsonElement code literal generation is tracked by #1101.