### PR TITLE
Depend on 3.1.0-preview2.19525.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
         shell: bash
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.0.2 # Issues with DOTNET_ROOT
+        uses: actions/setup-dotnet@bb95ce727fd49ec1a65933419cc7c91747785302
         with:
-          dotnet-version: '3.0.100'
+          dotnet-version: '3.1.100-preview1-014459'
 
       - name: Test
         run: dotnet test --configuration Debug
@@ -79,6 +79,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@bb95ce727fd49ec1a65933419cc7c91747785302
+        with:
+          dotnet-version: '3.1.100-preview1-014459'
 
       - name: Pack NuGet packages (CI versions)
         if: startsWith(github.ref, 'refs/heads/')

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/npgsql/efcore.pg</RepositoryUrl>
 
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/npgsql/efcore.pg</PackageProjectUrl>
@@ -24,6 +24,7 @@
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5105</NoWarn>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <!-- Signing configuration -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,14 +1,14 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Abstractions" Version="3.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="3.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.0-preview2.19525.5" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0-preview2.19525.5" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Abstractions" Version="3.1.0-preview2.19525.5" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="3.1.0-preview2.19525.5" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.0-preview2.19525.5" />
 
-    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="3.1.0-preview2.19525.4" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0-preview2.19525.4" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="3.1.0-preview2.19525.4" />
 
     <PackageReference Update="Npgsql" Version="4.1.1" />
     <PackageReference Update="Npgsql.NodaTime" Version="4.1.1" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
+    <add key="entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
+    <add key="entityframework6" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframework6/index.json" />
+    <add key="aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
+    <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="aspnet-blazor" value="https://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.1.100-preview1-014459"
   }
 }

--- a/src/EFCore.PG/Metadata/Internal/IdentitySequenceOptionsData.cs
+++ b/src/EFCore.PG/Metadata/Internal/IdentitySequenceOptionsData.cs
@@ -79,7 +79,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
                 end = value.IndexOf('\'', end + 2);
             }
 
-            var extracted = value[position..end].Replace("''", "'");
+            var extracted = value.Substring(position, end - position).Replace("''", "'");
             position = end + 1;
 
             return extracted.Length == 0 ? null : extracted;

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonPocoTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonPocoTranslator.cs
@@ -47,7 +47,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     returnType);
             }
 
-            if (instance.RemoveConvert() is JsonTraversalExpression prevPathTraversal)
+            if (instance is JsonTraversalExpression prevPathTraversal)
             {
                 return ConvertFromText(
                     prevPathTraversal.Append(_sqlExpressionFactory.ApplyDefaultTypeMapping(member)),
@@ -67,7 +67,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     new[] { expression }, typeof(int));
             }
 
-            if (expression.RemoveConvert() is JsonTraversalExpression traversal)
+            if (expression is JsonTraversalExpression traversal)
             {
                 // The traversal expression has ReturnsText=true (e.g. ->> not ->), so we recreate it to return
                 // the JSON object instead.

--- a/src/EFCore.PG/Query/Expressions/Internal/JsonTraversalExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/JsonTraversalExpression.cs
@@ -74,7 +74,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
             var oldPath = Path;
             var newPath = new SqlExpression[oldPath.Length + 1];
             Array.Copy(oldPath, newPath, oldPath.Length);
-            newPath[^1] = pathComponent;
+            newPath[newPath.Length - 1] = pathComponent;
             return new JsonTraversalExpression(Expression, newPath, ReturnsText, Type, TypeMapping);
         }
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,12 +3,12 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- There's lots of use of internal EF Core APIs from the tests, suppress the analyzer warnings for those -->
-    <NoWarn>$(NoWarn);xUnit1004;EF1001</NoWarn>
+    <NoWarn>$(NoWarn);xUnit1003;xUnit1004;xUnit1013;EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -38,7 +38,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
                         .Select(e => e.Int)
                         .ToList();
 
-                Assert.Equal(0, results.Count);
+                Assert.Empty(results);
 
                 AssertSql(
                     @"SELECT m.""Int""
@@ -60,14 +60,14 @@ WHERE (m.""TimeSpanAsTime"" = TIME '00:01:02') AND (m.""TimeSpanAsTime"" IS NOT 
                         .Select(e => e.Int)
                         .ToList();
 
-                Assert.Equal(0, results.Count);
+                Assert.Empty(results);
 
                 AssertSql(
                     @"@__timeSpan_0='02:01:00' (Nullable = true) (DbType = Object)
 
 SELECT m.""Int""
 FROM ""MappedNullableDataTypes"" AS m
-WHERE ((m.""TimeSpanAsTime"" = @__timeSpan_0) AND ((m.""TimeSpanAsTime"" IS NOT NULL) AND (@__timeSpan_0 IS NOT NULL))) OR ((m.""TimeSpanAsTime"" IS NULL) AND (@__timeSpan_0 IS NULL))");
+WHERE (m.""TimeSpanAsTime"" = @__timeSpan_0) AND (m.""TimeSpanAsTime"" IS NOT NULL)");
             }
         }
 

--- a/test/EFCore.PG.FunctionalTests/CommandInterceptionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/CommandInterceptionNpgsqlTest.cs
@@ -17,25 +17,32 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         }
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_one_app_and_one_injected_interceptor(bool async) => null;
+        public override Task Intercept_non_query_one_app_and_one_injected_interceptor(bool async)
+            => base.Intercept_non_query_one_app_and_one_injected_interceptor(async);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_passively(bool async, bool inject) => null;
+        public override Task Intercept_non_query_passively(bool async, bool inject)
+            => base.Intercept_non_query_passively(async, inject);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_to_mutate_command(bool async, bool inject) => null;
+        public override Task Intercept_non_query_to_mutate_command(bool async, bool inject)
+            => base.Intercept_non_query_to_mutate_command(async, inject);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_to_replace_execution(bool async, bool inject) => null;
+        public override Task Intercept_non_query_to_replace_execution(bool async, bool inject)
+            => base.Intercept_non_query_to_replace_execution(async, inject);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_with_explicitly_composed_app_interceptor(bool async) => null;
+        public override Task Intercept_non_query_with_explicitly_composed_app_interceptor(bool async)
+            => base.Intercept_non_query_with_explicitly_composed_app_interceptor(async);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_with_two_injected_interceptors(bool async) => null;
+        public override Task Intercept_non_query_with_two_injected_interceptors(bool async)
+            => base.Intercept_non_query_with_two_injected_interceptors(async);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/16701")]
-        public override Task Intercept_non_query_to_replace_result(bool async, bool inject) => null;
+        public override Task Intercept_non_query_to_replace_result(bool async, bool inject)
+            => base.Intercept_non_query_to_replace_result(async, inject);
 
         public abstract class InterceptionNpgsqlFixtureBase : InterceptionFixtureBase
         {

--- a/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 using Xunit;
@@ -13,6 +12,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             : base(fixture)
         {
         }
+
+        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/18147")]
+        public override void Value_conversion_is_appropriately_used_for_join_condition()
+            => base.Value_conversion_is_appropriately_used_for_join_condition();
+
+        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/18147")]
+        public override void Value_conversion_is_appropriately_used_for_left_join_condition()
+            => base.Value_conversion_is_appropriately_used_for_left_join_condition();
+
+        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/18147")]
+        public override void Where_bool_gets_converted_to_equality_when_value_conversion_is_used()
+            => base.Where_bool_gets_converted_to_equality_when_value_conversion_is_used();
 
         // Disabled: PostgreSQL is case-sensitive
         public override void Can_insert_and_read_back_with_case_insensitive_string_key() {}

--- a/test/EFCore.PG.FunctionalTests/LazyLoadProxySqlNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/LazyLoadProxySqlNpgsqlTest.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
@@ -13,6 +13,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
         public LazyLoadProxyNpgsqlTest(LoadNpgsqlFixture fixture)
             : base(fixture)
             => Fixture.TestSqlLoggerFactory.Clear();
+
+        [ConditionalFact]  // Requires MARS
+        public override void Top_level_projection_track_entities_before_passing_to_client_method() {}
 
         protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
@@ -42,7 +42,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var ctx = Fixture.CreateContext())
             {
                 var actual = ctx.SomeEntities.Where(e => e.SomeArray[0] == 3).ToList();
-                Assert.Equal(1, actual.Count);
+                Assert.Single(actual);
 
                 AssertSql(
                     @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
@@ -59,7 +59,7 @@ WHERE s.""SomeArray""[1] = 3");
                 // ReSharper disable once ConvertToConstant.Local
                 var x = 0;
                 var actual = ctx.SomeEntities.Where(e => e.SomeArray[x] == 3).ToList();
-                Assert.Equal(1, actual.Count);
+                Assert.Single(actual);
 
                 AssertSql(
                     @"@__x_0='0'
@@ -76,7 +76,7 @@ WHERE (s.""SomeArray""[@__x_0 + 1] = 3) AND (s.""SomeArray""[@__x_0 + 1] IS NOT 
             using (var ctx = Fixture.CreateContext())
             {
                 var actual = ctx.SomeEntities.Where(e => e.SomeBytea[0] == 3).ToList();
-                Assert.Equal(1, actual.Count);
+                Assert.Single(actual);
 
                 AssertSql(
                     @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
@@ -91,7 +91,7 @@ WHERE (get_byte(s.""SomeBytea"", 0) = 3) AND (get_byte(s.""SomeBytea"", 0) IS NO
             using (var ctx = Fixture.CreateContext())
             {
                 var actual = ctx.SomeEntities.Where(e => e.SomeText[0] == 'f').ToList();
-                Assert.Equal(1, actual.Count);
+                Assert.Single(actual);
 
                 AssertSql(
                     @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
@@ -118,7 +118,7 @@ WHERE (get_byte(s.""SomeBytea"", 0) = 3) AND get_byte(s.""SomeBytea"", 0) IS NOT
 
 SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE ((s.""SomeArray"" = @__arr_0) AND ((s.""SomeArray"" IS NOT NULL) AND (@__arr_0 IS NOT NULL))) OR ((s.""SomeArray"" IS NULL) AND (@__arr_0 IS NULL))
+WHERE (s.""SomeArray"" = @__arr_0) AND (s.""SomeArray"" IS NOT NULL)
 LIMIT 2");
             }
         }
@@ -248,7 +248,7 @@ LIMIT 2");            }
             using (var ctx = Fixture.CreateContext())
             {
                 var count = ctx.SomeEntities.Count(e => e.SomeArray.Any());
-                Assert.Equal(count, 2);
+                Assert.Equal(2, count);
 
                 AssertSql(
                     @"SELECT COUNT(*)::INT

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsQueryNpgsqlTest.cs
@@ -1,4 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore.Query;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 {
@@ -10,6 +18,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
         }
+
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Include13(bool isAsync) => base.Include13(isAsync);
+
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Include14(bool isAsync) => base.Include13(isAsync);
 
         // Should be fixed but could not verify as temporarily disabled upstream
 //        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/12970")]

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsWeakQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsWeakQueryNpgsqlTest.cs
@@ -1,4 +1,6 @@
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
@@ -12,5 +14,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
+
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Include13(bool isAsync) => base.Include13(isAsync);
+
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Include14(bool isAsync) => base.Include13(isAsync);
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/EnumQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/EnumQueryTest.cs
@@ -74,7 +74,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
 SELECT s.""Id"", s.""EnumValue"", s.""InferredEnum"", s.""MappedEnum"", s.""SchemaQualifiedEnum"", s.""UnmappedEnum""
 FROM test.""SomeEntities"" AS s
-WHERE (s.""MappedEnum"" = @__sad_0) AND (@__sad_0 IS NOT NULL)
+WHERE s.""MappedEnum"" = @__sad_0
 LIMIT 2");
             }
         }
@@ -93,7 +93,7 @@ LIMIT 2");
 
 SELECT s.""Id"", s.""EnumValue"", s.""InferredEnum"", s.""MappedEnum"", s.""SchemaQualifiedEnum"", s.""UnmappedEnum""
 FROM test.""SomeEntities"" AS s
-WHERE (s.""UnmappedEnum"" = @__sad_0) AND (@__sad_0 IS NOT NULL)
+WHERE s.""UnmappedEnum"" = @__sad_0
 LIMIT 2");
             }
         }
@@ -112,7 +112,7 @@ LIMIT 2");
 
 SELECT s.""Id"", s.""EnumValue"", s.""InferredEnum"", s.""MappedEnum"", s.""SchemaQualifiedEnum"", s.""UnmappedEnum""
 FROM test.""SomeEntities"" AS s
-WHERE (s.""UnmappedEnum"" = @__sad_0) AND (@__sad_0 IS NOT NULL)
+WHERE s.""UnmappedEnum"" = @__sad_0
 LIMIT 2");
             }
         }
@@ -131,7 +131,7 @@ LIMIT 2");
 
 SELECT s.""Id"", s.""EnumValue"", s.""InferredEnum"", s.""MappedEnum"", s.""SchemaQualifiedEnum"", s.""UnmappedEnum""
 FROM test.""SomeEntities"" AS s
-WHERE (s.""MappedEnum"" = @__sad_0) AND (@__sad_0 IS NOT NULL)
+WHERE s.""MappedEnum"" = @__sad_0
 LIMIT 2");
             }
         }

--- a/test/EFCore.PG.FunctionalTests/Query/FunkyDataQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FunkyDataQueryNpgsqlTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.FunkyDataModel;
@@ -17,17 +18,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalFact(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
-        public override void String_contains_on_argument_with_wildcard_column() {}
+        [ConditionalTheory(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
+        public override Task String_contains_on_argument_with_wildcard_column(bool isAsync)
+            => base.String_contains_on_argument_with_wildcard_column(isAsync);
 
-        [ConditionalFact(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
-        public override void String_contains_on_argument_with_wildcard_column_negated() {}
+        [ConditionalTheory(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
+        public override Task String_contains_on_argument_with_wildcard_column_negated(bool isAsync)
+            => base.String_contains_on_argument_with_wildcard_column_negated(isAsync);
 
-        [ConditionalFact(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
-        public override void String_contains_on_argument_with_wildcard_constant() {}
+        [ConditionalTheory(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
+        public override Task String_contains_on_argument_with_wildcard_constant(bool isAsync)
+            => base.String_contains_on_argument_with_wildcard_constant(isAsync);
 
-        [ConditionalFact(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
-        public override void String_contains_on_argument_with_wildcard_parameter() {}
+        [ConditionalTheory(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/996")]
+        public override Task String_contains_on_argument_with_wildcard_parameter(bool isAsync)
+            => base.String_contains_on_argument_with_wildcard_parameter(isAsync);
 
         public class FunkyDataQueryNpgsqlFixture : FunkyDataQueryFixtureBase
         {

--- a/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
@@ -15,7 +15,19 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             => Fixture.TestSqlLoggerFactory.Clear();
 
         [Theory(Skip = "https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/issues/874")]
-        public override Task String_concat_with_null_conditional_argument2(bool isAsync) => Task.CompletedTask;
+        [MemberData(nameof(IsAsyncData))]
+        public override Task String_concat_with_null_conditional_argument2(bool isAsync)
+            => base.String_concat_with_null_conditional_argument2(isAsync);
+
+        [Theory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Concat_with_collection_navigations(bool isAsync)
+            => base.Concat_with_collection_navigations(isAsync);
+
+        [Theory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Select_navigation_with_concat_and_count(bool isAsync)
+            => base.Select_navigation_with_concat_and_count(isAsync);
 
         #region Ignore DateTimeOffset tests
 
@@ -46,7 +58,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         public override Task Where_datetimeoffset_utcnow(bool isAsync) => Task.CompletedTask;
 
         [ConditionalTheory(Skip = "DateTimeOffset.Date isn't currently translated")]
-        public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool isAsync) => Task.CompletedTask;
+        [MemberData(nameof(IsAsyncData))]
+        public override Task DateTimeOffset_Contains_Less_than_Greater_than(bool isAsync)
+            => base.DateTimeOffset_Contains_Less_than_Greater_than(isAsync);
 
         #endregion Ignore DateTimeOffset tests
     }

--- a/test/EFCore.PG.FunctionalTests/Query/GroupByQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GroupByQueryNpgsqlTest.cs
@@ -1,5 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,6 +17,35 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        [ConditionalTheory]  // https://github.com/aspnet/EntityFrameworkCore/pull/18675
+        [MemberData(nameof(IsAsyncData))]
+        public override Task GroupBy_aggregate_projecting_conditional_expression(bool isAsync)
+        {
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Order>().GroupBy(o => o.OrderDate).Select(
+                    g =>
+                        new { g.Key, SomeValue = g.Count() == 0 ? 1 : g.Sum(o => o.OrderID % 2 == 0 ? 1 : 0) / g.Count() }),
+                e => (e.Key, e.SomeValue));
+        }
+
+        [ConditionalTheory]  // https://github.com/aspnet/EntityFrameworkCore/pull/18675
+        [MemberData(nameof(IsAsyncData))]
+        public override Task GroupBy_with_order_by_skip_and_another_order_by(bool isAsync)
+        {
+            return AssertQueryScalar(
+                isAsync,
+                ss => ss.Set<Order>()
+                    .OrderBy(o => o.CustomerID)
+                    .ThenBy(o => o.OrderID)
+                    .Skip(80)
+                    .OrderBy(o => o.CustomerID)
+                    .ThenBy(o => o.OrderID)
+                    .GroupBy(o => o.CustomerID)
+                    .Select(g => g.Sum(o => o.OrderID))
+            );
         }
 
         protected override void ClearLog()

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
@@ -80,14 +80,14 @@ WHERE (j.""CustomerDocument"" = '{""Name"":""Test customer"",""Age"":80}') AND (
 
 SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""Id"" = @__p_0) AND (@__p_0 IS NOT NULL)
+WHERE j.""Id"" = @__p_0
 LIMIT 1",
                     //
                     @"@__expected_0='System.Text.Json.JsonDocument' (DbType = Object)
 
 SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE ((j.""CustomerDocument"" = @__expected_0) AND ((j.""CustomerDocument"" IS NOT NULL) AND (@__expected_0 IS NOT NULL))) OR ((j.""CustomerDocument"" IS NULL) AND (@__expected_0 IS NULL))
+WHERE (j.""CustomerDocument"" = @__expected_0) AND (j.""CustomerDocument"" IS NOT NULL)
 LIMIT 2");
             }
         }
@@ -106,7 +106,7 @@ LIMIT 2");
 
 SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""Id"" = @__p_0) AND (@__p_0 IS NOT NULL)
+WHERE j.""Id"" = @__p_0
 LIMIT 1",
                     //
                     @"@__expected_0='{""ID"": ""00000000-0000-0000-0000-000000000000""
@@ -127,7 +127,7 @@ LIMIT 1",
 
 SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""CustomerElement"" = @__expected_0) AND (@__expected_0 IS NOT NULL)
+WHERE j.""CustomerElement"" = @__expected_0
 LIMIT 2");
             }
         }

--- a/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
@@ -88,14 +88,14 @@ WHERE (j.""Customer"" = '{""Name"":""Test customer"",""Age"":80,""ID"":""0000000
 
 SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""Id"" = @__p_0) AND (@__p_0 IS NOT NULL)
+WHERE j.""Id"" = @__p_0
 LIMIT 1",
                     //
                     @"@__expected_0='Npgsql.EntityFrameworkCore.PostgreSQL.Query.JsonPocoQueryTest+Customer' (DbType = Object)
 
 SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE ((j.""Customer"" = @__expected_0) AND ((j.""Customer"" IS NOT NULL) AND (@__expected_0 IS NOT NULL))) OR ((j.""Customer"" IS NULL) AND (@__expected_0 IS NULL))
+WHERE (j.""Customer"" = @__expected_0) AND (j.""Customer"" IS NOT NULL)
 LIMIT 2");
             }
         }

--- a/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
@@ -19,7 +19,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         {
             Fixture = fixture;
             Fixture.TestSqlLoggerFactory.Clear();
-            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ WHERE (j.""CustomerJsonb"" = '{""Name"":""Test customer"",""Age"":80,""IsVip"":f
 
 SELECT j.""Id"", j.""CustomerJson"", j.""CustomerJsonb""
 FROM ""JsonEntities"" AS j
-WHERE (j.""Id"" = @__p_0) AND (@__p_0 IS NOT NULL)
+WHERE j.""Id"" = @__p_0
 LIMIT 1",
                     //
                     @"@__expected_0='{""Age"": 25
@@ -96,7 +96,7 @@ LIMIT 1",
 
 SELECT j.""Id"", j.""CustomerJson"", j.""CustomerJsonb""
 FROM ""JsonEntities"" AS j
-WHERE ((j.""CustomerJsonb"" = @__expected_0) AND ((j.""CustomerJsonb"" IS NOT NULL) AND (@__expected_0 IS NOT NULL))) OR ((j.""CustomerJsonb"" IS NULL) AND (@__expected_0 IS NULL))
+WHERE (j.""CustomerJsonb"" = @__expected_0) AND (j.""CustomerJsonb"" IS NOT NULL)
 LIMIT 2");
             }
         }

--- a/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NetworkQueryNpgsqlTest.cs
@@ -135,7 +135,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.LessThan(x.Inet, IPAddress.Parse("192.168.1.7")));
-                Assert.Equal(count, 6);
+                Assert.Equal(6, count);
                 AssertContainsSql(@"WHERE n.""Inet"" < INET '192.168.1.7'");
             }
         }
@@ -162,7 +162,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.LessThan(x.Macaddr, PhysicalAddress.Parse("12-34-56-00-00-07")));
-                Assert.Equal(count, 6);
+                Assert.Equal(6, count);
                 AssertContainsSql(@"""Macaddr"" < MACADDR '123456000007'");
             }
         }
@@ -173,7 +173,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.LessThan(x.Macaddr8, PhysicalAddress.Parse("08-00-2B-01-02-03-04-07")));
-                Assert.Equal(count, 6);
+                Assert.Equal(6, count);
                 AssertContainsSql(@"""Macaddr8"" < MACADDR8 '08002B0102030407'");
             }
         }
@@ -184,7 +184,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.LessThanOrEqual(x.Inet, IPAddress.Parse("192.168.1.7")));
-                Assert.Equal(count, 7);
+                Assert.Equal(7, count);
                 AssertContainsSql(@"WHERE n.""Inet"" <= INET '192.168.1.7'");
             }
         }
@@ -211,7 +211,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.LessThanOrEqual(x.Macaddr, PhysicalAddress.Parse("12-34-56-00-00-07")));
-                Assert.Equal(count, 7);
+                Assert.Equal(7, count);
                 AssertContainsSql(@"""Macaddr"" <= MACADDR '123456000007'");
             }
         }
@@ -222,7 +222,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.LessThanOrEqual(x.Macaddr8, PhysicalAddress.Parse("08-00-2B-01-02-03-04-07")));
-                Assert.Equal(count, 7);
+                Assert.Equal(7, count);
                 AssertContainsSql(@"""Macaddr8"" <= MACADDR8 '08002B0102030407'");            }
         }
 
@@ -232,7 +232,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.GreaterThanOrEqual(x.Inet, IPAddress.Parse("192.168.1.7")));
-                Assert.Equal(count, 3);
+                Assert.Equal(3, count);
                 AssertContainsSql(@"WHERE n.""Inet"" >= INET '192.168.1.7'");
             }
         }
@@ -259,7 +259,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.GreaterThanOrEqual(x.Macaddr, PhysicalAddress.Parse("12-34-56-00-00-07")));
-                Assert.Equal(count, 3);
+                Assert.Equal(3, count);
                 AssertContainsSql(@"""Macaddr"" >= MACADDR '123456000007'");
             }
         }
@@ -270,7 +270,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.GreaterThanOrEqual(x.Macaddr8, PhysicalAddress.Parse("08-00-2B-01-02-03-04-07")));
-                Assert.Equal(count, 3);
+                Assert.Equal(3, count);
                 AssertContainsSql(@"""Macaddr8"" >= MACADDR8 '08002B0102030407'");
             }
         }
@@ -281,7 +281,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.GreaterThan(x.Inet, IPAddress.Parse("192.168.1.7")));
-                Assert.Equal(count, 2);
+                Assert.Equal(2, count);
                 AssertContainsSql(@"WHERE n.""Inet"" > INET '192.168.1.7'");
             }
         }
@@ -308,7 +308,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.GreaterThan(x.Macaddr, PhysicalAddress.Parse("12-34-56-00-00-07")));
-                Assert.Equal(count, 2);
+                Assert.Equal(2, count);
                 AssertContainsSql(@"""Macaddr"" > MACADDR '123456000007'");
             }
         }
@@ -319,7 +319,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var count = context.NetTestEntities.Count(x => EF.Functions.GreaterThan(x.Macaddr8, PhysicalAddress.Parse("08-00-2B-01-02-03-04-07")));
-                Assert.Equal(count, 2);
+                Assert.Equal(2, count);
                 AssertContainsSql(@"""Macaddr8"" > MACADDR8 '08002B0102030407'");
             }
         }

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindQueryNpgsqlFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindQueryNpgsqlFixture.cs
@@ -1,7 +1,9 @@
 using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestModels.Northwind;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 
@@ -12,5 +14,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
     {
         protected override ITestStoreFactory TestStoreFactory => NpgsqlNorthwindTestStoreFactory.Instance;
         protected override Type ContextType => typeof(NorthwindNpgsqlContext);
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+            new NpgsqlDbContextOptionsBuilder(optionsBuilder).ReverseNullOrdering();
+            return optionsBuilder;
+        }
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/QueryNoClientEvalNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/QueryNoClientEvalNpgsqlTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Query;
+using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 {
@@ -8,5 +9,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             : base(fixture)
         {
         }
+
+        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
+        public override void Throws_when_join() {}
+
+        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
+        public override void Throws_when_group_join() {}
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/RangeQueryNpgsqlTest.cs
@@ -415,8 +415,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             using (var context = Fixture.CreateContext())
             {
                 var e = context.RangeTestEntities.Single(x => x.FloatRange.UpperBound > 5);
-                Assert.Equal(e.FloatRange.LowerBound, 0);
-                Assert.Equal(e.FloatRange.UpperBound, 10);
+                Assert.Equal(0, e.FloatRange.LowerBound);
+                Assert.Equal(10, e.FloatRange.UpperBound);
             }
         }
 
@@ -427,8 +427,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             {
                 var e = context.RangeTestEntities.Single(x => x.SchemaRange == NpgsqlRange<double>.Parse("(0,10)"));
                 AssertContainsSql(@"WHERE r.""SchemaRange"" = '(0,10)'::test.""Schema_Range""");
-                Assert.Equal(e.SchemaRange.LowerBound, 0);
-                Assert.Equal(e.SchemaRange.UpperBound, 10);
+                Assert.Equal(0, e.SchemaRange.LowerBound);
+                Assert.Equal(10, e.SchemaRange.UpperBound);
             }
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Functions.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Functions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
@@ -27,7 +26,8 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         }
 
         [ConditionalTheory(Skip = "Fixed for PostgreSQL 12.1, https://www.postgresql.org/message-id/CADT4RqAz7oN4vkPir86Kg1_mQBmBxCp-L_%3D9vRpgSNPJf0KRkw%40mail.gmail.com")]
-        public override Task Indexof_with_emptystring(bool isAsync) => Task.CompletedTask;
+        public override Task Indexof_with_emptystring(bool isAsync)
+            => base.Indexof_with_emptystring(isAsync);
 
         #region Regex
 
@@ -35,10 +35,11 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public async Task Regex_IsMatch(bool isAsync)
         {
-            await AssertQuery<Customer>(
+            await AssertQuery(
                 isAsync,
-                cs => cs.Where(c => Regex.IsMatch(c.CompanyName, "^A")),
+                cs => cs.Set<Customer>().Where(c => Regex.IsMatch(c.CompanyName, "^A")),
                 entryCount: 4);
+
             AssertContainsSqlFragment(@"WHERE c.""CompanyName"" ~ ('(?p)' || '^A')");
         }
 
@@ -46,10 +47,11 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public async Task Regex_IsMatchOptionsNone(bool isAsync)
         {
-            await AssertQuery<Customer>(
+            await AssertQuery(
                 isAsync,
-                cs => cs.Where(c => Regex.IsMatch(c.CompanyName, "^A", RegexOptions.None)),
+                cs => cs.Set<Customer>().Where(c => Regex.IsMatch(c.CompanyName, "^A", RegexOptions.None)),
                 entryCount: 4);
+
             AssertContainsSqlFragment(@"WHERE c.""CompanyName"" ~ ('(?p)' || '^A')");
         }
 
@@ -57,10 +59,11 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public async Task Regex_IsMatchOptionsIgnoreCase(bool isAsync)
         {
-            await AssertQuery<Customer>(
+            await AssertQuery(
                 isAsync,
-                cs => cs.Where(c => Regex.IsMatch(c.CompanyName, "^a", RegexOptions.IgnoreCase)),
+                cs => cs.Set<Customer>().Where(c => Regex.IsMatch(c.CompanyName, "^a", RegexOptions.IgnoreCase)),
                 entryCount: 4);
+
             AssertContainsSqlFragment(@"WHERE c.""CompanyName"" ~ ('(?ip)' || '^a')");
         }
 
@@ -68,10 +71,11 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public async Task Regex_IsMatchOptionsMultiline(bool isAsync)
         {
-            await AssertQuery<Customer>(
+            await AssertQuery(
                 isAsync,
-                cs => cs.Where(c => Regex.IsMatch(c.CompanyName, "^A", RegexOptions.Multiline)),
+                cs => cs.Set<Customer>().Where(c => Regex.IsMatch(c.CompanyName, "^A", RegexOptions.Multiline)),
                 entryCount: 4);
+
             AssertContainsSqlFragment(@"WHERE c.""CompanyName"" ~ ('(?n)' || '^A')");
         }
 
@@ -80,10 +84,11 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public async Task Regex_IsMatchOptionsSingleline(bool isAsync)
         {
-            await AssertQuery<Customer>(
+            await AssertQuery(
                 isAsync,
-                cs => cs.Where(c => Regex.IsMatch(c.CompanyName, "^A", RegexOptions.Singleline)),
+                cs => cs.Set<Customer>().Where(c => Regex.IsMatch(c.CompanyName, "^A", RegexOptions.Singleline)),
                 entryCount: 4);
+
             AssertContainsSqlFragment(@"WHERE c.""CompanyName"" ~ '^A'");
         }
 
@@ -91,10 +96,11 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public async Task Regex_IsMatchOptionsIgnorePatternWhitespace(bool isAsync)
         {
-            await AssertQuery<Customer>(
+            await AssertQuery(
                 isAsync,
-                cs => cs.Where(c => Regex.IsMatch(c.CompanyName, "^ A", RegexOptions.IgnorePatternWhitespace)),
+                cs => cs.Set<Customer>().Where(c => Regex.IsMatch(c.CompanyName, "^ A", RegexOptions.IgnorePatternWhitespace)),
                 entryCount: 4);
+
             AssertContainsSqlFragment(@"WHERE c.""CompanyName"" ~ ('(?px)' || '^ A')");
         }
 
@@ -110,6 +116,7 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         public override async Task Where_guid_newguid(bool isAsync)
         {
             await base.Where_guid_newguid(isAsync);
+
             AssertContainsSqlFragment(@"WHERE uuid_generate_v4() <> '00000000-0000-0000-0000-000000000000'");
         }
 
@@ -117,13 +124,17 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         [MemberData(nameof(IsAsyncData))]
         public virtual async Task OrderBy_Guid_NewGuid(bool isAsync)
         {
-            await AssertQuery<OrderDetail>(isAsync, ods => ods.OrderBy(od => Guid.NewGuid()).Select(x => x), entryCount: 2155);
+            await AssertQuery(
+                isAsync,
+                ods => ods.Set<OrderDetail>().OrderBy(od => Guid.NewGuid()).Select(x => x),
+                entryCount: 2155);
+
             AssertContainsSqlFragment(@"ORDER BY uuid_generate_v4()");
         }
 
         #endregion
 
         void AssertContainsSqlFragment(string expectedFragment)
-            => Assert.True(Fixture.TestSqlLoggerFactory.SqlStatements.Any(s => s.Contains(expectedFragment)));
+            => Assert.Contains(Fixture.TestSqlLoggerFactory.SqlStatements, s => s.Contains(expectedFragment));
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.ResultOperators.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.ResultOperators.cs
@@ -1,0 +1,8 @@
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    public partial class SimpleQueryNpgsqlTest
+    {
+        // Already removed in 3.1, waiting for nightly build
+        public override void Paging_operation_on_string_doesnt_issue_warning() {}
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Select.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Select.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    public partial class SimpleQueryNpgsqlTest
+    {
+        [ConditionalTheory(Skip = "To be fixed in PG 12.0, https://www.postgresql.org/message-id/CADT4RqAz7oN4vkPir86Kg1_mQBmBxCp-L_%3D9vRpgSNPJf0KRkw%40mail.gmail.com")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Select_with_complex_expression_that_can_be_funcletized(bool isAsync)
+            => base.Select_with_complex_expression_that_can_be_funcletized(isAsync);
+
+        public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool isAsync)
+            => AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(isAsync));
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Where.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Where.cs
@@ -9,18 +9,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
     public partial class SimpleQueryNpgsqlTest
     {
         [Theory(Skip = "SQL translation not implemented, too annoying")]
-        public override Task Where_datetime_millisecond_component(bool isAsync) => null;
+        public override Task Where_datetime_millisecond_component(bool isAsync)
+            => base.Where_datetime_millisecond_component(isAsync);
 
         [Theory(Skip = "Translation not implemented yet, #873")]
-        public override Task Where_datetimeoffset_now_component(bool isAsync) => null;
+        public override Task Where_datetimeoffset_now_component(bool isAsync)
+            => base.Where_datetimeoffset_now_component(isAsync);
 
         [Theory(Skip = "Translation not implemented yet, #873")]
-        public override Task Where_datetimeoffset_utcnow_component(bool isAsync) => null;
+        public override Task Where_datetimeoffset_utcnow_component(bool isAsync)
+            => base.Where_datetimeoffset_utcnow_component(isAsync);
 
         [Theory(Skip = "PostgreSQL only has log(x, base) over numeric, may be possible to cast back and forth though")]
-        public override Task Where_math_log_new_base(bool isAsync) => null;
+        public override Task Where_math_log_new_base(bool isAsync)
+            => base.Where_math_log_new_base(isAsync);
 
         [Theory(Skip = "Convert on DateTime not yet supported")]
-        public override Task Convert_ToString(bool isAsync) => null;
+        public override Task Convert_ToString(bool isAsync)
+            => base.Convert_ToString(isAsync);
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
@@ -18,11 +18,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/17379")]
-        public override Task SelectMany_correlated_with_outer_2(bool isAsync) => null;
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Default_if_empty_top_level_arg(bool isAsync)
+            => base.Default_if_empty_top_level_arg(isAsync);
+
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
+        [MemberData(nameof(IsAsyncData))]
+        public override Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool isAsync)
+            => base.Default_if_empty_top_level_arg_followed_by_projecting_constant(isAsync);
 
         [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/17379")]
-        public override Task SelectMany_correlated_with_outer_4(bool isAsync) => null;
+        public override Task SelectMany_correlated_with_outer_2(bool isAsync)
+            => base.SelectMany_correlated_with_outer_2(isAsync);
+
+        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/17379")]
+        public override Task SelectMany_correlated_with_outer_4(bool isAsync)
+            => base.SelectMany_correlated_with_outer_4(isAsync);
 
         #region Overrides
 
@@ -42,9 +54,9 @@ WHERE (o.""OrderDate"" IS NOT NULL)");
         {
             var years = 2;
 
-            await AssertQuery<Order>(
+            await AssertQuery(
                 isAsync,
-                os => os.Where(o => o.OrderDate != null)
+                ss => ss.Set<Order>().Where(o => o.OrderDate != null)
                     .Select(
                         o => new Order
                         {
@@ -101,15 +113,17 @@ WHERE e.""EmployeeID"" IN (0)");
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task PadLeft_with_constant(bool isAsync)
-            => AssertQuery<Customer>(isAsync, cs => cs
-                .Where(x => x.Address.PadLeft(20).EndsWith("Walserweg 21")),
+            => AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadLeft(20).EndsWith("Walserweg 21")),
                 entryCount: 1);
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task PadLeft_char_with_constant(bool isAsync)
-            => AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadLeft(20, 'a').EndsWith("Walserweg 21")),
+            => AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadLeft(20, 'a').EndsWith("Walserweg 21")),
                 entryCount: 1);
 
         [ConditionalTheory]
@@ -118,8 +132,9 @@ WHERE e.""EmployeeID"" IN (0)");
         {
             var length = 20;
 
-            return AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadLeft(length).EndsWith("Walserweg 21")),
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadLeft(length).EndsWith("Walserweg 21")),
                 entryCount: 1);
         }
 
@@ -129,23 +144,26 @@ WHERE e.""EmployeeID"" IN (0)");
         {
             var length = 20;
 
-            return AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadLeft(length, 'a').EndsWith("Walserweg 21")),
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadLeft(length, 'a').EndsWith("Walserweg 21")),
                 entryCount: 1);
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task PadRight_with_constant(bool isAsync)
-            => AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadRight(20).StartsWith("Walserweg 21")),
+            => AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadRight(20).StartsWith("Walserweg 21")),
                 entryCount: 1);
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task PadRight_char_with_constant(bool isAsync)
-            => AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadRight(20).StartsWith("Walserweg 21")),
+            => AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadRight(20).StartsWith("Walserweg 21")),
                 entryCount: 1);
 
         [ConditionalTheory]
@@ -154,8 +172,9 @@ WHERE e.""EmployeeID"" IN (0)");
         {
             var length = 20;
 
-            return AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadRight(length).StartsWith("Walserweg 21")),
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadRight(length).StartsWith("Walserweg 21")),
                 entryCount: 1);
         }
 
@@ -165,8 +184,9 @@ WHERE e.""EmployeeID"" IN (0)");
         {
             var length = 20;
 
-            return AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(x => x.Address.PadRight(length, 'a').StartsWith("Walserweg 21")),
+            return AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(x => x.Address.PadRight(length, 'a').StartsWith("Walserweg 21")),
                 entryCount: 1);
         }
 
@@ -177,26 +197,32 @@ WHERE e.""EmployeeID"" IN (0)");
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task Substring_without_length_with_Index_of(bool isAsync)
-            => AssertQuery<Customer>(isAsync, cs => cs
-                .Where(x => x.Address == "Walserweg 21")
-                .Where(x => x.Address.Substring(x.Address.IndexOf("e")) == "erweg 21"), entryCount: 1);
-
+            => AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>()
+                    .Where(x => x.Address == "Walserweg 21")
+                    .Where(x => x.Address.Substring(x.Address.IndexOf("e")) == "erweg 21"),
+                entryCount: 1);
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task Substring_without_length_with_constant(bool isAsync)
-            => AssertQuery<Customer>(isAsync, cs => cs
+            => AssertQuery(
+                isAsync,
                 //Walserweg 21
-                .Where(x => x.Address.Substring(5) == "rweg 21"), entryCount: 1);
+                cs => cs.Set<Customer>().Where(x => x.Address.Substring(5) == "rweg 21"),
+                entryCount: 1);
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public Task Substring_without_length_with_closure(bool isAsync)
         {
             var startIndex = 5;
-            return AssertQuery<Customer>(isAsync, cs => cs
+            return AssertQuery(
+                isAsync,
                 //Walserweg 21
-                .Where(x => x.Address.Substring(startIndex) == "rweg 21"), entryCount: 1);
+                ss => ss.Set<Customer>().Where(x => x.Address.Substring(startIndex) == "rweg 21"),
+                entryCount: 1);
         }
 
         #endregion
@@ -208,8 +234,9 @@ WHERE e.""EmployeeID"" IN (0)");
         [MemberData(nameof(IsAsyncData))]
         public async Task Array_Contains_constant(bool isAsync)
         {
-            await AssertQuery<Customer>(isAsync, cs => cs
-                .Where(c => new[] { "ALFKI", "ANATR" }.Contains(c.CustomerID)),
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(c => new[] { "ALFKI", "ANATR" }.Contains(c.CustomerID)),
                 entryCount: 2);
 
             // Note: for constant lists there's no advantage in using the PostgreSQL-specific x = ANY (a b, c), unlike
@@ -227,8 +254,9 @@ WHERE c.""CustomerID"" IN ('ALFKI', 'ANATR')");
         {
             var ids = new[] { "ALFKI", "ANATR" };
 
-            await AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(c => ids.Contains(c.CustomerID)),
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(c => ids.Contains(c.CustomerID)),
                 entryCount: 2);
 
             // Instead of c.""CustomerID"" x in ('ALFKI', 'ANATR') we should generate the PostgreSQL-specific x = ANY (a, b, c), which can
@@ -257,8 +285,9 @@ WHERE c.""CustomerID"" IN ('ALFKI', 'ANATR')");
         {
             var collection = new[] { "A%", "B%", "C%" };
 
-            await AssertQuery<Customer>(isAsync, cs => cs
-                .Where(c => collection.Any(y => EF.Functions.Like(c.Address, y))),
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(c => collection.Any(y => EF.Functions.Like(c.Address, y))),
                 entryCount: 22);
 
             AssertSql(
@@ -275,8 +304,9 @@ WHERE c.""Address"" LIKE ANY (@__collection_0)");
         {
             var collection = new[] { "A%", "B%", "C%" };
 
-            await AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(c => collection.All(y => EF.Functions.Like(c.Address, y))));
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(c => collection.All(y => EF.Functions.Like(c.Address, y))));
 
             AssertSql(
                 @"@__collection_0='System.String[]' (DbType = Object)
@@ -292,8 +322,9 @@ WHERE c.""Address"" LIKE ALL (@__collection_0)");
         {
             var collection = new[] { "a%", "b%", "c%" };
 
-            await AssertQuery<Customer>(isAsync, cs => cs
-                .Where(c => collection.Any(y => EF.Functions.ILike(c.Address, y))),
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(c => collection.Any(y => EF.Functions.ILike(c.Address, y))),
                 entryCount: 22);
 
             AssertSql(
@@ -310,8 +341,9 @@ WHERE c.""Address"" ILIKE ANY (@__collection_0)");
         {
             var collection = new[] { "a%", "b%", "c%" };
 
-            await AssertQuery<Customer>(isAsync, cs => cs
-                    .Where(c => collection.All(y => EF.Functions.ILike(c.Address, y))));
+            await AssertQuery(
+                isAsync,
+                ss => ss.Set<Customer>().Where(c => collection.All(y => EF.Functions.ILike(c.Address, y))));
 
             AssertSql(
                 @"@__collection_0='System.String[]' (DbType = Object)

--- a/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeographyTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeographyTest.cs
@@ -85,11 +85,11 @@ FROM ""PolygonEntity"" AS p");
         public override async Task GeometryType(bool isAsync)
         {
             // PostGIS returns "POINT", NTS returns "Point"
-            await AssertQuery<PointEntity>(
+            await AssertQuery(
                 isAsync,
-                es => es.Select(
+                es => es.Set<PointEntity>().Select(
                     e => new { e.Id, GeometryType = e.Point == null ? null : e.Point.GeometryType.ToLower() }),
-                elementSorter: x => x.Id);
+                x => x.Id);
 
 //            AssertSql(
 //                @"SELECT p.""Id"", LOWER(GeometryType(p.""Point"")) AS ""GeometryType""

--- a/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeometryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SpatialQueryNpgsqlGeometryTest.cs
@@ -13,7 +13,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override async Task Area(bool isAsync)
@@ -218,11 +218,11 @@ FROM ""PolygonEntity"" AS p");
         public override async Task GeometryType(bool isAsync)
         {
             // PostGIS returns "POINT", NTS returns "Point"
-            await AssertQuery<PointEntity>(
+            await AssertQuery(
                 isAsync,
-                es => es.Select(
+                es => es.Set<PointEntity>().Select(
                     e => new { e.Id, GeometryType = e.Point == null ? null : e.Point.GeometryType.ToLower() }),
-                elementSorter: x => x.Id);
+                x => x.Id);
 
 //            AssertSql(
 //                @"SELECT p.""Id"", LOWER(GeometryType(p.""Point"")) AS ""GeometryType""

--- a/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
@@ -44,7 +44,7 @@ WHERE (""IsDate""(c.""FirstName"") = FALSE) AND (""IsDate""(c.""FirstName"") IS 
 
 SELECT length(c.""LastName"")
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -98,7 +98,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""CustomerOrderCount""(@__customerId_0) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -113,7 +113,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""StarValue""(@__starCount_1, ""CustomerOrderCount""(@__customerId_0)) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -202,7 +202,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""CustomerOrderCount""(@__customerId_0) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -217,7 +217,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""StarValue""(@__starCount_0, ""CustomerOrderCount""(@__customerId_1)) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_1) AND (@__customerId_1 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_1
 LIMIT 2");
         }
 
@@ -426,7 +426,7 @@ WHERE (""IsDate""(c.""FirstName"") = FALSE) AND (""IsDate""(c.""FirstName"") IS 
 
 SELECT length(c.""LastName"")
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -476,7 +476,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""CustomerOrderCount""(@__customerId_0) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -491,7 +491,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""StarValue""(@__starCount_2, ""CustomerOrderCount""(@__customerId_0)) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_0) AND (@__customerId_0 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_0
 LIMIT 2");
         }
 
@@ -576,11 +576,11 @@ LIMIT 2");
             base.Scalar_Function_Let_Not_Parameter_Instance();
 
             AssertSql(
-                @"@__8__locals1_customerId_1='2'
+                @"@__customerId_1='2'
 
-SELECT c.""LastName"", ""CustomerOrderCount""(@__8__locals1_customerId_1) AS ""OrderCount""
+SELECT c.""LastName"", ""CustomerOrderCount""(@__customerId_1) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__8__locals1_customerId_1) AND (@__8__locals1_customerId_1 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_1
 LIMIT 2");
         }
 
@@ -595,7 +595,7 @@ LIMIT 2");
 
 SELECT c.""LastName"", ""StarValue""(@__starCount_1, ""CustomerOrderCount""(@__customerId_2)) AS ""OrderCount""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = @__customerId_2) AND (@__customerId_2 IS NOT NULL)
+WHERE c.""Id"" = @__customerId_2
 LIMIT 2");
         }
 

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -460,7 +460,7 @@ SELECT
                     var table = dbModel.Tables.Single();
 
                     Assert.Equal(2, table.Columns.Count);
-                    Assert.Equal(null, table.PrimaryKey);
+                    Assert.Null(table.PrimaryKey);
                     Assert.All(
                         table.Columns, c =>
                         {
@@ -491,7 +491,7 @@ SELECT
                     var table = dbModel.Tables.Single();
 
                     Assert.Equal(2, table.Columns.Count);
-                    Assert.Equal(null, table.PrimaryKey);
+                    Assert.Null(table.PrimaryKey);
                     Assert.All(
                         table.Columns, c =>
                         {
@@ -839,7 +839,7 @@ CREATE TABLE ""ComputedValues"" (
                     var columns = dbModel.Tables.Single().Columns;
 
                     // Note that on-the-fly computed columns aren't (yet) supported by PostgreSQL, only stored/persistedcolumns.
-                    Assert.Equal(null, columns.Single(c => c.Name == "SumOfAAndB").DefaultValueSql);
+                    Assert.Null(columns.Single(c => c.Name == "SumOfAAndB").DefaultValueSql);
                     Assert.Equal(@"(""A"" + ""B"")", columns.Single(c => c.Name == "SumOfAAndB").ComputedColumnSql);
                 },
                 @"DROP TABLE ""ComputedValues""");

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -35,7 +35,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         [InlineData(typeof(NpgsqlRange<DummyType>), "dummyrange")]
         [InlineData(typeof(Geometry), "geometry")]
         [InlineData(typeof(Point), "geometry")]
-        [InlineData(typeof(Point), "geometry")]
         public void By_ClrType(Type clrType, string expectedStoreType)
             => Assert.Equal(expectedStoreType, ((RelationalTypeMapping)Source.FindMapping(clrType)).StoreType);
 


### PR DESCRIPTION
* Remove unneeded RemoveConvert in JSON POCO translator as it has been   obsoleted upstream. It wasn't actually necessary anyway.
* Target .NET Standard 2.0
* Various test fixes for 3.1
* Correct all test issues flagged by xunit analyzer

Closes #1081