### PR TITLE
Sync with latest EF Core 3.1.0 preview3

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,14 +1,14 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.0-preview2.19525.5" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0-preview2.19525.5" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Abstractions" Version="3.1.0-preview2.19525.5" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="3.1.0-preview2.19525.5" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.0-preview2.19525.5" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.0-preview3.19554.8" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0-preview3.19554.8" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Abstractions" Version="3.1.0-preview3.19554.8" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="3.1.0-preview3.19554.8" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.0-preview3.19554.8" />
 
-    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="3.1.0-preview2.19525.4" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0-preview2.19525.4" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Version="3.1.0-preview2.19525.4" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="3.1.0-preview3.19553.2" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0-preview3.19553.2" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="3.1.0-preview3.19553.2" />
 
     <PackageReference Update="Npgsql" Version="4.1.1" />
     <PackageReference Update="Npgsql.NodaTime" Version="4.1.1" />

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
+    <add key="entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
+    <add key="entityframework6" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframework6/index.json" />
+    <add key="aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
+    <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="aspnet-blazor" value="https://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlFullTextSearchMethodTranslator.cs
@@ -115,11 +115,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     nameof(NpgsqlFullTextSearchLinqExtensions.And) => QueryReturningOnTwoQueries("&&"),
                     nameof(NpgsqlFullTextSearchLinqExtensions.Or)  => QueryReturningOnTwoQueries("||"),
 
-                    nameof(NpgsqlFullTextSearchLinqExtensions.ToNegative) => new SqlUnaryExpression(ExpressionType.Not, arguments[0], arguments[0].Type, arguments[0].TypeMapping),
+                    // TODO: Hack, see #1118
+                    nameof(NpgsqlFullTextSearchLinqExtensions.ToNegative)
+                        => new SqlUnaryExpression(ExpressionType.Negate, arguments[0], arguments[0].Type, arguments[0].TypeMapping),
+
                     nameof(NpgsqlFullTextSearchLinqExtensions.Contains) => BoolReturningOnTwoQueries("@>"),
                     nameof(NpgsqlFullTextSearchLinqExtensions.IsContainedIn) => BoolReturningOnTwoQueries("<@"),
 
-                    nameof(NpgsqlFullTextSearchLinqExtensions.Concat) => _sqlExpressionFactory.Add(arguments[0], arguments[1], _tsVectorMapping),
+                    nameof(NpgsqlFullTextSearchLinqExtensions.Concat)
+                        => _sqlExpressionFactory.Add(arguments[0], arguments[1], _tsVectorMapping),
 
                     nameof(NpgsqlFullTextSearchLinqExtensions.Matches) => new SqlCustomBinaryExpression(
                         _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[0]),

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlNetworkTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlNetworkTranslator.cs
@@ -69,7 +69,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             nameof(NpgsqlNetworkExtensions.ContainsOrEqual)       => BoolReturningOnTwoNetworkTypes(">>="),
             nameof(NpgsqlNetworkExtensions.ContainsOrContainedBy) => BoolReturningOnTwoNetworkTypes("&&"),
 
-            nameof(NpgsqlNetworkExtensions.BitwiseNot)            => new SqlUnaryExpression(ExpressionType.Not,
+            // TODO: Hack, see #1118
+            nameof(NpgsqlNetworkExtensions.BitwiseNot)            => new SqlUnaryExpression(ExpressionType.Negate,
                 arguments[1],
                 arguments[1].Type,
                 arguments[1].TypeMapping),

--- a/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
@@ -193,7 +193,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
             }
 
             // Bitwise complement on networking types
-            case ExpressionType.Not when
+            // TODO: Hack, see #1118
+            case ExpressionType.Negate when
                 sqlUnaryExpression.Operand.TypeMapping.ClrType == typeof(IPAddress) ||
                 sqlUnaryExpression.Operand.TypeMapping.ClrType == typeof((IPAddress, int)) ||
                 sqlUnaryExpression.Operand.TypeMapping.ClrType == typeof(PhysicalAddress):
@@ -202,7 +203,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
                 return sqlUnaryExpression;
 
             // Negation on full-text queries
-            case ExpressionType.Not when sqlUnaryExpression.Operand.TypeMapping.ClrType == typeof(NpgsqlTsQuery):
+            // TODO: Hack, see #1118
+            case ExpressionType.Negate when sqlUnaryExpression.Operand.TypeMapping.ClrType == typeof(NpgsqlTsQuery):
                 Sql.Append("!!");
                 Visit(sqlUnaryExpression.Operand);
                 return sqlUnaryExpression;

--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
@@ -52,10 +52,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
         // PostgreSQL COUNT() always returns bigint, so we need to downcast to int
         // TODO: Translate Count with predicate for GroupBy (see base implementation)
         public override SqlExpression TranslateCount(Expression expression = null)
-            => _sqlExpressionFactory.Convert(
+        {
+            if (expression != null)
+            {
+                // TODO: Translate Count with predicate for GroupBy
+                return null;
+            }
+
+            return _sqlExpressionFactory.Convert(
                 _sqlExpressionFactory.ApplyDefaultTypeMapping(
                     _sqlExpressionFactory.Function("COUNT", new[] { _sqlExpressionFactory.Fragment("*") }, typeof(long))),
                 typeof(int), _sqlExpressionFactory.FindMapping(typeof(int)));
+        }
 
         // In PostgreSQL SUM() doesn't return the same type as its argument for smallint, int and bigint.
         // Cast to get the same type.

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -90,6 +90,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                                           new RelationalCommandParameterObject(
                                               connection,
                                               null,
+                                              null,
                                               Dependencies.CurrentContext.Context,
                                               Dependencies.CommandLogger)));
 
@@ -100,6 +101,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                                               .ExecuteScalarAsync(
                                                   new RelationalCommandParameterObject(
                                                       connection,
+                                                      null,
                                                       null,
                                                       Dependencies.CurrentContext.Context,
                                                       Dependencies.CommandLogger),

--- a/src/EFCore.PG/ValueGeneration/Internal/NpgsqlSequenceHiLoValueGenerator.cs
+++ b/src/EFCore.PG/ValueGeneration/Internal/NpgsqlSequenceHiLoValueGenerator.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal
 {
@@ -56,8 +55,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal
                     .ExecuteScalar(
                         new RelationalCommandParameterObject(
                             _connection,
-                            null,
-                            null,
+                            parameterValues: null,
+                            readerColumns: null,
+                            context: null,
                             _commandLogger)),
                 typeof(long),
                 CultureInfo.InvariantCulture);
@@ -73,8 +73,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal
                     .ExecuteScalarAsync(
                         new RelationalCommandParameterObject(
                             _connection,
-                            null,
-                            null,
+                            parameterValues: null,
+                            readerColumns: null,
+                            context: null,
                             _commandLogger),
                         cancellationToken),
                 typeof(long),

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -41,7 +41,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             AssertSql(
                 @"SELECT m.""Int""
 FROM ""MappedNullableDataTypes"" AS m
-WHERE (m.""TimeSpanAsTime"" = TIME '00:01:02') AND (m.""TimeSpanAsTime"" IS NOT NULL)");
+WHERE m.""TimeSpanAsTime"" = TIME '00:01:02'");
         }
 
         [Fact]
@@ -61,7 +61,7 @@ WHERE (m.""TimeSpanAsTime"" = TIME '00:01:02') AND (m.""TimeSpanAsTime"" IS NOT 
 
 SELECT m.""Int""
 FROM ""MappedNullableDataTypes"" AS m
-WHERE (m.""TimeSpanAsTime"" = @__timeSpan_0) AND (m.""TimeSpanAsTime"" IS NOT NULL)");
+WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
         }
 
         [Fact]

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
@@ -62,7 +62,7 @@ WHERE s.""SomeArray""[1] = 3");
 
 SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE (s.""SomeArray""[@__x_0 + 1] = 3) AND (s.""SomeArray""[@__x_0 + 1] IS NOT NULL)");
+WHERE s.""SomeArray""[@__x_0 + 1] = 3");
         }
 
         [Fact]
@@ -75,7 +75,7 @@ WHERE (s.""SomeArray""[@__x_0 + 1] = 3) AND (s.""SomeArray""[@__x_0 + 1] IS NOT 
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE (get_byte(s.""SomeBytea"", 0) = 3) AND (get_byte(s.""SomeBytea"", 0) IS NOT NULL)");
+WHERE get_byte(s.""SomeBytea"", 0) = 3");
         }
 
         [Fact(Skip = "Disabled since EF Core 3.0")]
@@ -108,7 +108,7 @@ WHERE (get_byte(s.""SomeBytea"", 0) = 3) AND get_byte(s.""SomeBytea"", 0) IS NOT
 
 SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE (s.""SomeArray"" = @__arr_0) AND (s.""SomeArray"" IS NOT NULL)
+WHERE s.""SomeArray"" = @__arr_0
 LIMIT 2");
         }
 
@@ -122,7 +122,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE (s.""SomeArray"" = ARRAY[3,4]::integer[]) AND (s.""SomeArray"" IS NOT NULL)
+WHERE s.""SomeArray"" = ARRAY[3,4]::integer[]
 LIMIT 2");
         }
 
@@ -130,7 +130,7 @@ LIMIT 2");
 
         #region Containment
 
-        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
+        [Fact]
         public void Contains_with_literal()
         {
             using var ctx = Fixture.CreateContext();
@@ -140,11 +140,11 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE 3 = ANY (s.""SomeArray"")
+WHERE COALESCE(3 = ANY (s.""SomeArray""), FALSE)
 LIMIT 2");
         }
 
-        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
+        [Fact]
         public void Contains_with_parameter()
         {
             using var ctx = Fixture.CreateContext();
@@ -158,11 +158,11 @@ LIMIT 2");
 
 SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE @__p_0 = ANY (s.""SomeArray"")
+WHERE COALESCE(@__p_0 = ANY (s.""SomeArray""), FALSE)
 LIMIT 2");
         }
 
-        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
+        [Fact]
         public void Contains_with_column()
         {
             using var ctx = Fixture.CreateContext();
@@ -172,7 +172,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE s.""Id"" + 2 = ANY (s.""SomeArray"")
+WHERE COALESCE(s.""Id"" + 2 = ANY (s.""SomeArray""), FALSE)
 LIMIT 2");
         }
 
@@ -190,7 +190,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE (cardinality(s.""SomeArray"") = 2) AND (cardinality(s.""SomeArray"") IS NOT NULL)
+WHERE cardinality(s.""SomeArray"") = 2
 LIMIT 2");
         }
 
@@ -204,7 +204,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE (cardinality(s.""SomeArray"") = 2) AND (cardinality(s.""SomeArray"") IS NOT NULL)
+WHERE cardinality(s.""SomeArray"") = 2
 LIMIT 2");
         }
 
@@ -221,7 +221,7 @@ LIMIT 2");
 
         #region AnyAll
 
-        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
+        [Fact]
         public void Any_no_predicate()
         {
             using var ctx = Fixture.CreateContext();

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsQueryNpgsqlTest.cs
@@ -19,14 +19,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             Fixture.TestSqlLoggerFactory.Clear();
         }
 
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Include13(bool isAsync) => base.Include13(isAsync);
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Include14(bool isAsync) => base.Include13(isAsync);
-
         // Should be fixed but could not verify as temporarily disabled upstream
 //        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/12970")]
 //        [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsWeakQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsWeakQueryNpgsqlTest.cs
@@ -14,13 +14,5 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Include13(bool isAsync) => base.Include13(isAsync);
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18679")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Include14(bool isAsync) => base.Include13(isAsync);
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
@@ -19,16 +19,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         public override Task String_concat_with_null_conditional_argument2(bool isAsync)
             => base.String_concat_with_null_conditional_argument2(isAsync);
 
-        [Theory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Concat_with_collection_navigations(bool isAsync)
-            => base.Concat_with_collection_navigations(isAsync);
-
-        [Theory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Select_navigation_with_concat_and_count(bool isAsync)
-            => base.Select_navigation_with_concat_and_count(isAsync);
-
         #region Ignore DateTimeOffset tests
 
         // PostgreSQL has no datatype that corresponds to DateTimeOffset.

--- a/test/EFCore.PG.FunctionalTests/Query/GroupByQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GroupByQueryNpgsqlTest.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,34 +17,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [ConditionalTheory]  // https://github.com/aspnet/EntityFrameworkCore/pull/18675
-        [MemberData(nameof(IsAsyncData))]
-        public override Task GroupBy_aggregate_projecting_conditional_expression(bool isAsync)
-        {
-            return AssertQuery(
-                isAsync,
-                ss => ss.Set<Order>().GroupBy(o => o.OrderDate).Select(
-                    g =>
-                        new { g.Key, SomeValue = g.Count() == 0 ? 1 : g.Sum(o => o.OrderID % 2 == 0 ? 1 : 0) / g.Count() }),
-                e => (e.Key, e.SomeValue));
-        }
+        public override Task GroupBy_Property_Select_Count_with_predicate(bool isAsync)
+            => Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupBy_Property_Select_Count_with_predicate(isAsync));
 
-        [ConditionalTheory]  // https://github.com/aspnet/EntityFrameworkCore/pull/18675
-        [MemberData(nameof(IsAsyncData))]
-        public override Task GroupBy_with_order_by_skip_and_another_order_by(bool isAsync)
-        {
-            return AssertQueryScalar(
-                isAsync,
-                ss => ss.Set<Order>()
-                    .OrderBy(o => o.CustomerID)
-                    .ThenBy(o => o.OrderID)
-                    .Skip(80)
-                    .OrderBy(o => o.CustomerID)
-                    .ThenBy(o => o.OrderID)
-                    .GroupBy(o => o.CustomerID)
-                    .Select(g => g.Sum(o => o.OrderID))
-            );
-        }
+        public override Task GroupBy_Property_Select_LongCount_with_predicate(bool isAsync)
+            => Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.GroupBy_Property_Select_LongCount_with_predicate(isAsync));
 
         protected override void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
@@ -64,7 +64,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             AssertSql(
                 @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""CustomerDocument"" = '{""Name"":""Test customer"",""Age"":80}') AND (j.""CustomerDocument"" IS NOT NULL)");
+WHERE j.""CustomerDocument"" = '{""Name"":""Test customer"",""Age"":80}'");
         }
 
         [Fact]
@@ -87,7 +87,7 @@ LIMIT 1",
 
 SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""CustomerDocument"" = @__expected_0) AND (j.""CustomerDocument"" IS NOT NULL)
+WHERE j.""CustomerDocument"" = @__expected_0
 LIMIT 2");
         }
 
@@ -284,7 +284,7 @@ LIMIT 2");
 
 SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE (CAST(j.""CustomerElement""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) = 4) AND (CAST(j.""CustomerElement""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) IS NOT NULL)
+WHERE CAST(j.""CustomerElement""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) = 4
 LIMIT 2");
         }
 
@@ -316,22 +316,6 @@ WHERE json_array_length(j.""CustomerElement""->'Orders') = 2
 LIMIT 2");
         }
 
-#if ISSUE_17374
-        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
-        public void Array_Any_toplevel()
-        {
-            using var ctx = Fixture.CreateContext();
-            var x = ctx.JsonbEntities.Single(e => e.ToplevelArray.Any());
-
-            Assert.Equal("Joe", x.Customer.Name);
-            AssertSql(
-                @"SELECT j.""Id"", j.""Customer""
-FROM ""JsonbEntities"" AS j
-WHERE jsonb_array_length(j.""ToplevelArray"") > 0
-LIMIT 2");
-        }
-#endif
-
         [Fact]
         public void Like()
         {
@@ -342,7 +326,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT j.""Id"", j.""CustomerDocument"", j.""CustomerElement""
 FROM ""JsonbEntities"" AS j
-WHERE j.""CustomerElement""->>'Name' LIKE 'J%'
+WHERE (j.""CustomerElement""->>'Name' IS NOT NULL) AND (j.""CustomerElement""->>'Name' LIKE 'J%')
 LIMIT 2");
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
@@ -71,7 +71,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             AssertSql(
                 @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""Customer"" = '{""Name"":""Test customer"",""Age"":80,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":null,""Orders"":null}') AND (j.""Customer"" IS NOT NULL)");
+WHERE j.""Customer"" = '{""Name"":""Test customer"",""Age"":80,""ID"":""00000000-0000-0000-0000-000000000000"",""IsVip"":false,""Statistics"":null,""Orders"":null}'");
         }
 
         [Fact]
@@ -94,7 +94,7 @@ LIMIT 1",
 
 SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE (j.""Customer"" = @__expected_0) AND (j.""Customer"" IS NOT NULL)
+WHERE j.""Customer"" = @__expected_0
 LIMIT 2");
         }
 
@@ -251,7 +251,7 @@ LIMIT 2");
 
 SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE (CAST(j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) = 4) AND (CAST(j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) IS NOT NULL)
+WHERE CAST(j.""Customer""#>>ARRAY['Statistics','Nested','IntArray',@__i_0]::TEXT[] AS integer) = 4
 LIMIT 2");
         }
 
@@ -283,7 +283,7 @@ WHERE json_array_length(j.""Customer""->'Orders') = 2
 LIMIT 2");
         }
 
-        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/17374")]
+        [Fact]
         public void Array_Any_toplevel()
         {
             using var ctx = Fixture.CreateContext();
@@ -307,7 +307,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT j.""Id"", j.""Customer"", j.""ToplevelArray""
 FROM ""JsonbEntities"" AS j
-WHERE j.""Customer""->>'Name' LIKE 'J%'
+WHERE (j.""Customer""->>'Name' IS NOT NULL) AND (j.""Customer""->>'Name' LIKE 'J%')
 LIMIT 2");
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
@@ -60,7 +60,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             AssertSql(
                 @"SELECT j.""Id"", j.""CustomerJson"", j.""CustomerJsonb""
 FROM ""JsonEntities"" AS j
-WHERE (j.""CustomerJsonb"" = '{""Name"":""Test customer"",""Age"":80,""IsVip"":false,""Statistics"":null,""Orders"":null}') AND (j.""CustomerJsonb"" IS NOT NULL)");
+WHERE j.""CustomerJsonb"" = '{""Name"":""Test customer"",""Age"":80,""IsVip"":false,""Statistics"":null,""Orders"":null}'");
         }
 
         [Fact]
@@ -96,7 +96,7 @@ LIMIT 1",
 
 SELECT j.""Id"", j.""CustomerJson"", j.""CustomerJsonb""
 FROM ""JsonEntities"" AS j
-WHERE (j.""CustomerJsonb"" = @__expected_0) AND (j.""CustomerJsonb"" IS NOT NULL)
+WHERE j.""CustomerJsonb"" = @__expected_0
 LIMIT 2");
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/QueryNoClientEvalNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/QueryNoClientEvalNpgsqlTest.cs
@@ -9,11 +9,5 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             : base(fixture)
         {
         }
-
-        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
-        public override void Throws_when_join() {}
-
-        [ConditionalFact(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
-        public override void Throws_when_group_join() {}
     }
 }

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Functions.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.Functions.cs
@@ -16,7 +16,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             AssertSql(
                 @"SELECT c.""CustomerID"", c.""Address"", c.""City"", c.""CompanyName"", c.""ContactName"", c.""ContactTitle"", c.""Country"", c.""Fax"", c.""Phone"", c.""PostalCode"", c.""Region""
 FROM ""Customers"" AS c
-WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTRIM(c.""Region"", E' \t\n\r') IS NOT NULL))");
+WHERE (c.""Region"" IS NULL) OR (BTRIM(c.""Region"", E' \t\n\r') = '')");
         }
 
         public override async Task Query_expression_with_to_string_and_contains(bool isAsync)
@@ -117,7 +117,7 @@ WHERE (c.""Region"" IS NULL) OR ((BTRIM(c.""Region"", E' \t\n\r') = '') AND (BTR
         {
             await base.Where_guid_newguid(isAsync);
 
-            AssertContainsSqlFragment(@"WHERE uuid_generate_v4() <> '00000000-0000-0000-0000-000000000000'");
+            AssertContainsSqlFragment(@"uuid_generate_v4() <> '00000000-0000-0000-0000-000000000000'");
         }
 
         [ConditionalTheory]

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.ResultOperators.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.ResultOperators.cs
@@ -1,8 +1,0 @@
-namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
-{
-    public partial class SimpleQueryNpgsqlTest
-    {
-        // Already removed in 3.1, waiting for nightly build
-        public override void Paging_operation_on_string_doesnt_issue_warning() {}
-    }
-}

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
@@ -15,26 +15,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Default_if_empty_top_level_arg(bool isAsync)
-            => base.Default_if_empty_top_level_arg(isAsync);
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/18674")]
-        [MemberData(nameof(IsAsyncData))]
-        public override Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool isAsync)
-            => base.Default_if_empty_top_level_arg_followed_by_projecting_constant(isAsync);
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/17379")]
-        public override Task SelectMany_correlated_with_outer_2(bool isAsync)
-            => base.SelectMany_correlated_with_outer_2(isAsync);
-
-        [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFrameworkCore/pull/17379")]
-        public override Task SelectMany_correlated_with_outer_4(bool isAsync)
-            => base.SelectMany_correlated_with_outer_4(isAsync);
 
         #region Overrides
 
@@ -82,13 +64,13 @@ WHERE (o.""OrderDate"" IS NOT NULL)");
 
 SELECT e.""EmployeeID"", e.""City"", e.""Country"", e.""FirstName"", e.""ReportsTo"", e.""Title""
 FROM ""Employees"" AS e
-WHERE COALESCE(e.""EmployeeID"" = ANY (@__ids_0), FALSE) OR ((e.""EmployeeID"" IS NULL) AND (array_position(@__ids_0, NULL) IS NOT NULL))",
+WHERE COALESCE(e.""EmployeeID"" = ANY (@__ids_0), FALSE)",
                 //
                 @"@__ids_0='System.Int64[]' (DbType = Object)
 
 SELECT e.""EmployeeID"", e.""City"", e.""Country"", e.""FirstName"", e.""ReportsTo"", e.""Title""
 FROM ""Employees"" AS e
-WHERE COALESCE(e.""EmployeeID"" = ANY (@__ids_0), FALSE) OR ((e.""EmployeeID"" IS NULL) AND (array_position(@__ids_0, NULL) IS NOT NULL))");
+WHERE COALESCE(e.""EmployeeID"" = ANY (@__ids_0), FALSE)");
         }
 
         public override async Task Contains_with_local_nullable_uint_array_closure(bool isAsync)

--- a/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
@@ -31,7 +31,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             AssertSql(
                 @"SELECT COUNT(*)::INT
 FROM ""Customers"" AS c
-WHERE (""IsDate""(c.""FirstName"") = FALSE) AND (""IsDate""(c.""FirstName"") IS NOT NULL)");
+WHERE ""IsDate""(c.""FirstName"") = FALSE");
         }
 
         [Fact]
@@ -138,7 +138,7 @@ WHERE ""IsTopCustomer""(c.""Id"")");
 
 SELECT c.""Id""
 FROM ""Customers"" AS c
-WHERE (""GetCustomerWithMostOrdersAfterDate""(@__startDate_0) = c.""Id"") AND (""GetCustomerWithMostOrdersAfterDate""(@__startDate_0) IS NOT NULL)
+WHERE ""GetCustomerWithMostOrdersAfterDate""(@__startDate_0) = c.""Id""
 LIMIT 2");
         }
 
@@ -152,7 +152,7 @@ LIMIT 2");
 
 SELECT c.""Id""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = ""GetCustomerWithMostOrdersAfterDate""(""GetReportingPeriodStartDate""(@__period_0))) AND (""GetCustomerWithMostOrdersAfterDate""(""GetReportingPeriodStartDate""(@__period_0)) IS NOT NULL)
+WHERE c.""Id"" = ""GetCustomerWithMostOrdersAfterDate""(""GetReportingPeriodStartDate""(@__period_0))
 LIMIT 2");
         }
 
@@ -413,7 +413,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT COUNT(*)::INT
 FROM ""Customers"" AS c
-WHERE (""IsDate""(c.""FirstName"") = FALSE) AND (""IsDate""(c.""FirstName"") IS NOT NULL)");
+WHERE ""IsDate""(c.""FirstName"") = FALSE");
         }
 
         [Fact]
@@ -516,7 +516,7 @@ WHERE ""IsTopCustomer""(c.""Id"")");
 
 SELECT c.""Id""
 FROM ""Customers"" AS c
-WHERE (""GetCustomerWithMostOrdersAfterDate""(@__startDate_1) = c.""Id"") AND (""GetCustomerWithMostOrdersAfterDate""(@__startDate_1) IS NOT NULL)
+WHERE ""GetCustomerWithMostOrdersAfterDate""(@__startDate_1) = c.""Id""
 LIMIT 2");
         }
 
@@ -530,7 +530,7 @@ LIMIT 2");
 
 SELECT c.""Id""
 FROM ""Customers"" AS c
-WHERE (c.""Id"" = ""GetCustomerWithMostOrdersAfterDate""(""GetReportingPeriodStartDate""(@__period_1))) AND (""GetCustomerWithMostOrdersAfterDate""(""GetReportingPeriodStartDate""(@__period_1)) IS NOT NULL)
+WHERE c.""Id"" = ""GetCustomerWithMostOrdersAfterDate""(""GetReportingPeriodStartDate""(@__period_1))
 LIMIT 2");
         }
 


### PR DESCRIPTION
As EF Core 3.1.0 is now frozen this should be the last sync.

The only notable change here is that some null optimizations on the EF Core side seem to have broken our use of ExpressionType.Not for network types and full text search. https://github.com/aspnet/EntityFrameworkCore/issues/18788 tracks fixing this on the EF Core side for 5.0, in the meantime I've hacked around this by using ExpressionType.Negate instead.

I've also tightened our array method translator to skip array expressions who's type mapping isn't an array mapping (to allow array properties mapped via value converters to work).

/cc @maumar @smitpatel @ajcvickers