### PR TITLE
Remove COALESCE from array ANY expression

### DIFF
--- a/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayQueryTest.cs
@@ -140,7 +140,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE COALESCE(3 = ANY (s.""SomeArray""), FALSE)
+WHERE 3 = ANY (s.""SomeArray"")
 LIMIT 2");
         }
 
@@ -158,7 +158,7 @@ LIMIT 2");
 
 SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE COALESCE(@__p_0 = ANY (s.""SomeArray""), FALSE)
+WHERE @__p_0 = ANY (s.""SomeArray"")
 LIMIT 2");
         }
 
@@ -172,7 +172,7 @@ LIMIT 2");
             AssertSql(
                 @"SELECT s.""Id"", s.""SomeArray"", s.""SomeBytea"", s.""SomeList"", s.""SomeMatrix"", s.""SomeText""
 FROM ""SomeEntities"" AS s
-WHERE COALESCE(s.""Id"" + 2 = ANY (s.""SomeArray""), FALSE)
+WHERE s.""Id"" + 2 = ANY (s.""SomeArray"")
 LIMIT 2");
         }
 

--- a/test/EFCore.PG.FunctionalTests/Query/NullSemanticsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NullSemanticsQueryNpgsqlTest.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestModels.NullSemanticsModel;
 using Microsoft.EntityFrameworkCore.Query;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 {
@@ -11,6 +13,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
         public NullSemanticsQueryNpgsqlTest(NullSemanticsQueryNpgsqlFixture fixture)
             : base(fixture)
             => Fixture.TestSqlLoggerFactory.Clear();
+
+        [ConditionalFact(Skip = "Null semantics for array ANY not yet implemented, #1142")]
+        public override void Contains_with_local_array_closure_false_with_null() {}
 
         protected override void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
@@ -64,13 +64,13 @@ WHERE (o.""OrderDate"" IS NOT NULL)");
 
 SELECT e.""EmployeeID"", e.""City"", e.""Country"", e.""FirstName"", e.""ReportsTo"", e.""Title""
 FROM ""Employees"" AS e
-WHERE COALESCE(e.""EmployeeID"" = ANY (@__ids_0), FALSE)",
+WHERE e.""EmployeeID"" = ANY (@__ids_0)",
                 //
                 @"@__ids_0='System.Int64[]' (DbType = Object)
 
 SELECT e.""EmployeeID"", e.""City"", e.""Country"", e.""FirstName"", e.""ReportsTo"", e.""Title""
 FROM ""Employees"" AS e
-WHERE COALESCE(e.""EmployeeID"" = ANY (@__ids_0), FALSE)");
+WHERE e.""EmployeeID"" = ANY (@__ids_0)");
         }
 
         public override async Task Contains_with_local_nullable_uint_array_closure(bool isAsync)
@@ -251,7 +251,7 @@ WHERE c.""CustomerID"" IN ('ALFKI', 'ANATR')");
 
 SELECT c.""CustomerID"", c.""Address"", c.""City"", c.""CompanyName"", c.""ContactName"", c.""ContactTitle"", c.""Country"", c.""Fax"", c.""Phone"", c.""PostalCode"", c.""Region""
 FROM ""Customers"" AS c
-WHERE COALESCE(c.""Region"" = ANY (@__regions_0), FALSE) OR ((c.""Region"" IS NULL) AND (array_position(@__regions_0, NULL) IS NOT NULL))");
+WHERE c.""Region"" = ANY (@__regions_0) OR ((c.""Region"" IS NULL) AND (array_position(@__regions_0, NULL) IS NOT NULL))");
         }
 
         [ConditionalTheory]
@@ -274,7 +274,7 @@ WHERE COALESCE(c.""Region"" = ANY (@__regions_0), FALSE) OR ((c.""Region"" IS NU
 
 SELECT c.""CustomerID"", c.""Address"", c.""City"", c.""CompanyName"", c.""ContactName"", c.""ContactTitle"", c.""Country"", c.""Fax"", c.""Phone"", c.""PostalCode"", c.""Region""
 FROM ""Customers"" AS c
-WHERE COALESCE(c.""Region"" = ANY (@__regions_0), FALSE) OR ((c.""Region"" IS NULL) AND (array_position(@__regions_0, NULL) IS NOT NULL))");
+WHERE c.""Region"" = ANY (@__regions_0) OR ((c.""Region"" IS NULL) AND (array_position(@__regions_0, NULL) IS NOT NULL))");
         }
 
         #endregion Array contains


### PR DESCRIPTION
Because it prevents index usage. Will reimplement after we can sniff the parameter for null values.

Fixes #1152