### PR TITLE
Allow hstore columns to be represented as ImmutableDictionary<string, string>

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
@@ -41,18 +41,5 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             sb.Append('\'');
             return sb.ToString();
         }
-        protected static bool Compare(IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
-        {
-            if (a == null)
-                return b == null;
-            if (b == null)
-                return false;
-            if (a.Count != b.Count)
-                return false;
-            foreach (var kv in a)
-                if (!b.TryGetValue(kv.Key, out var bValue) || kv.Value != bValue)
-                    return false;
-            return true;
-        }
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -12,30 +13,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/hstore.html
     /// </remarks>
-    public class NpgsqlHstoreTypeMapping : NpgsqlTypeMapping
+    public abstract class NpgsqlHstoreTypeMapping : NpgsqlTypeMapping
     {
-        static readonly HstoreComparer ComparerInstance = new HstoreComparer();
-
-        /// <summary>
-        /// Constructs an instance of the <see cref="NpgsqlHstoreTypeMapping"/> class.
-        /// </summary>
-        public NpgsqlHstoreTypeMapping()
-            : base(
-                new RelationalTypeMappingParameters(
-                    new CoreTypeMappingParameters(typeof(Dictionary<string, string>), null, ComparerInstance),
-                    "hstore"
-                ), NpgsqlDbType.Hstore) {}
-
         protected NpgsqlHstoreTypeMapping(RelationalTypeMappingParameters parameters)
             : base(parameters, NpgsqlDbType.Hstore) {}
-
-        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new NpgsqlHstoreTypeMapping(parameters);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {
             var sb = new StringBuilder("HSTORE '");
-            foreach (var kv in (Dictionary<string, string>)value)
+            foreach (var kv in (IReadOnlyDictionary<string, string>)value)
             {
                 sb.Append('"');
                 sb.Append(kv.Key);   // TODO: Escape
@@ -55,28 +41,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             sb.Append('\'');
             return sb.ToString();
         }
-
-        class HstoreComparer : ValueComparer<Dictionary<string, string>>
+        protected static bool Compare(IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
         {
-            public HstoreComparer() : base(
-                (a, b) => Compare(a,b),
-                o => o.GetHashCode(),
-                o => o == null ? null : new Dictionary<string, string>(o))
-            {}
-
-            static bool Compare(Dictionary<string, string> a, Dictionary<string, string> b)
-            {
-                if (a == null)
-                    return b == null;
-                if (b == null)
+            if (a == null)
+                return b == null;
+            if (b == null)
+                return false;
+            if (a.Count != b.Count)
+                return false;
+            foreach (var kv in a)
+                if (!b.TryGetValue(kv.Key, out var bValue) || kv.Value != bValue)
                     return false;
-                if (a.Count != b.Count)
-                    return false;
-                foreach (var kv in a)
-                    if (!b.TryGetValue(kv.Key, out var bValue) || kv.Value != bValue)
-                        return false;
-                return true;
-            }
+            return true;
         }
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
     /// <summary>
-    /// The type mapping for the PostgreSQL hstore type to immutable .NET Dictionaries.
+    /// The type mapping for the PostgreSQL hstore type to <see cref="ImmutableDictionary"/>.
     /// </summary>
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/hstore.html

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
@@ -32,30 +32,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new NpgsqlImmutableHstoreTypeMapping(parameters);
 
-        protected override string GenerateNonNullSqlLiteral(object value)
-        {
-            var sb = new StringBuilder("HSTORE '");
-            foreach (var kv in (IReadOnlyDictionary<string, string>)value)
-            {
-                sb.Append('"');
-                sb.Append(kv.Key);   // TODO: Escape
-                sb.Append("\"=>");
-                if (kv.Value == null)
-                    sb.Append("NULL");
-                else
-                {
-                    sb.Append('"');
-                    sb.Append(kv.Value);   // TODO: Escape
-                    sb.Append("\",");
-                }
-            }
-
-            sb.Remove(sb.Length - 1, 1);
-
-            sb.Append('\'');
-            return sb.ToString();
-        }
-
         class HstoreComparer : ValueComparer<IReadOnlyDictionary<string, string>>
         {
             public HstoreComparer() : base(

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
@@ -1,0 +1,44 @@
+using System.Collections.Immutable;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
+{
+    /// <summary>
+    /// The type mapping for the PostgreSQL hstore type to immutable .NET Dictionaries.
+    /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/hstore.html
+    /// </remarks>
+    public class NpgsqlImmutableHstoreTypeMapping : NpgsqlHstoreTypeMapping
+    {
+        static readonly HstoreComparer ComparerInstance = new HstoreComparer();
+
+        /// <summary>
+        /// Constructs an instance of the <see cref="NpgsqlReadOnlyHstoreTypeMapping"/> class.
+        /// </summary>
+        public NpgsqlImmutableHstoreTypeMapping()
+            : base(
+                new RelationalTypeMappingParameters(
+                    new CoreTypeMappingParameters(typeof(ImmutableDictionary<string, string>), null, ComparerInstance),
+                    "hstore"
+                )) {}
+
+        protected NpgsqlImmutableHstoreTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters) {}
+
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new NpgsqlImmutableHstoreTypeMapping(parameters);
+
+        class HstoreComparer : ValueComparer<ImmutableDictionary<string, string>>
+        {
+            public HstoreComparer() : base(
+                // We could compare contents here if the references are different, but that would penalize the 99% case
+                // where a different reference means different contents, which would only save a very rare database update.
+                (a, b) => ReferenceEquals(a, b),
+                o => o.GetHashCode(),
+                o => o)
+            {}
+        }
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlImmutableHstoreTypeMapping.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
+{
+    /// <summary>
+    /// The type mapping for the PostgreSQL hstore type to immutable .NET Dictionaries.
+    /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/hstore.html
+    /// </remarks>
+    public class NpgsqlImmutableHstoreTypeMapping : NpgsqlHstoreTypeMapping
+    {
+        static readonly HstoreComparer ComparerInstance = new HstoreComparer();
+
+        /// <summary>
+        /// Constructs an instance of the <see cref="NpgsqlImmutableHstoreTypeMapping"/> class.
+        /// </summary>
+        public NpgsqlImmutableHstoreTypeMapping()
+            : base(
+                new RelationalTypeMappingParameters(
+                    new CoreTypeMappingParameters(typeof(IReadOnlyDictionary<string, string>), null, ComparerInstance),
+                    "hstore"
+                )) {}
+
+        protected NpgsqlImmutableHstoreTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters) {}
+
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new NpgsqlImmutableHstoreTypeMapping(parameters);
+
+        protected override string GenerateNonNullSqlLiteral(object value)
+        {
+            var sb = new StringBuilder("HSTORE '");
+            foreach (var kv in (IReadOnlyDictionary<string, string>)value)
+            {
+                sb.Append('"');
+                sb.Append(kv.Key);   // TODO: Escape
+                sb.Append("\"=>");
+                if (kv.Value == null)
+                    sb.Append("NULL");
+                else
+                {
+                    sb.Append('"');
+                    sb.Append(kv.Value);   // TODO: Escape
+                    sb.Append("\",");
+                }
+            }
+
+            sb.Remove(sb.Length - 1, 1);
+
+            sb.Append('\'');
+            return sb.ToString();
+        }
+
+        class HstoreComparer : ValueComparer<IReadOnlyDictionary<string, string>>
+        {
+            public HstoreComparer() : base(
+                (a, b) => Compare(a,b),
+                o => o.GetHashCode(),
+                o => o)
+            {}
+        }
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -31,30 +30,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new NpgsqlMutableHstoreTypeMapping(parameters);
 
-        protected override string GenerateNonNullSqlLiteral(object value)
-        {
-            var sb = new StringBuilder("HSTORE '");
-            foreach (var kv in (IReadOnlyDictionary<string, string>)value)
-            {
-                sb.Append('"');
-                sb.Append(kv.Key);   // TODO: Escape
-                sb.Append("\"=>");
-                if (kv.Value == null)
-                    sb.Append("NULL");
-                else
-                {
-                    sb.Append('"');
-                    sb.Append(kv.Value);   // TODO: Escape
-                    sb.Append("\",");
-                }
-            }
-
-            sb.Remove(sb.Length - 1, 1);
-
-            sb.Append('\'');
-            return sb.ToString();
-        }
-
         class HstoreComparer : ValueComparer<Dictionary<string, string>>
         {
             public HstoreComparer() : base(
@@ -62,20 +37,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
                 o => o.GetHashCode(),
                 o => o == null ? null : new Dictionary<string, string>(o))
             {}
-
-            static bool Compare(IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
-            {
-                if (a == null)
-                    return b == null;
-                if (b == null)
-                    return false;
-                if (a.Count != b.Count)
-                    return false;
-                foreach (var kv in a)
-                    if (!b.TryGetValue(kv.Key, out var bValue) || kv.Value != bValue)
-                        return false;
-                return true;
-            }
         }
     }
 }

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
     /// <summary>
-    /// The type mapping for the PostgreSQL hstore type to immutable .NET Dictionaries.
+    /// The type mapping for the PostgreSQL hstore type to <see cref="Dictionary"/>.
     /// </summary>
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/hstore.html

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
+{
+    /// <summary>
+    /// The type mapping for the PostgreSQL hstore type to immutable .NET Dictionaries.
+    /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/static/hstore.html
+    /// </remarks>
+    public class NpgsqlMutableHstoreTypeMapping : NpgsqlHstoreTypeMapping
+    {
+        static readonly HstoreComparer ComparerInstance = new HstoreComparer();
+
+        /// <summary>
+        /// Constructs an instance of the <see cref="NpgsqlMutableHstoreTypeMapping"/> class.
+        /// </summary>
+        public NpgsqlMutableHstoreTypeMapping()
+            : base(
+                new RelationalTypeMappingParameters(
+                    new CoreTypeMappingParameters(typeof(Dictionary<string, string>), null, ComparerInstance),
+                    "hstore"
+                )) {}
+
+        protected NpgsqlMutableHstoreTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters) {}
+
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => new NpgsqlMutableHstoreTypeMapping(parameters);
+
+        protected override string GenerateNonNullSqlLiteral(object value)
+        {
+            var sb = new StringBuilder("HSTORE '");
+            foreach (var kv in (IReadOnlyDictionary<string, string>)value)
+            {
+                sb.Append('"');
+                sb.Append(kv.Key);   // TODO: Escape
+                sb.Append("\"=>");
+                if (kv.Value == null)
+                    sb.Append("NULL");
+                else
+                {
+                    sb.Append('"');
+                    sb.Append(kv.Value);   // TODO: Escape
+                    sb.Append("\",");
+                }
+            }
+
+            sb.Remove(sb.Length - 1, 1);
+
+            sb.Append('\'');
+            return sb.ToString();
+        }
+
+        class HstoreComparer : ValueComparer<Dictionary<string, string>>
+        {
+            public HstoreComparer() : base(
+                (a, b) => Compare(a,b),
+                o => o.GetHashCode(),
+                o => o == null ? null : new Dictionary<string, string>(o))
+            {}
+
+            static bool Compare(IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
+            {
+                if (a == null)
+                    return b == null;
+                if (b == null)
+                    return false;
+                if (a.Count != b.Count)
+                    return false;
+                foreach (var kv in a)
+                    if (!b.TryGetValue(kv.Key, out var bValue) || kv.Value != bValue)
+                        return false;
+                return true;
+            }
+        }
+    }
+}

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlMutableHstoreTypeMapping.cs
@@ -30,6 +30,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new NpgsqlMutableHstoreTypeMapping(parameters);
 
+        private static bool Compare(IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
+        {
+            if (a == null)
+                return b == null;
+            if (b == null)
+                return false;
+            if (a.Count != b.Count)
+                return false;
+            foreach (var kv in a)
+                if (!b.TryGetValue(kv.Key, out var bValue) || kv.Value != bValue)
+                    return false;
+            return true;
+        }
+
         class HstoreComparer : ValueComparer<Dictionary<string, string>>
         {
             public HstoreComparer() : base(

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlReadOnlyHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlReadOnlyHstoreTypeMapping.cs
@@ -12,30 +12,32 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/hstore.html
     /// </remarks>
-    public class NpgsqlImmutableHstoreTypeMapping : NpgsqlHstoreTypeMapping
+    public class NpgsqlReadOnlyHstoreTypeMapping : NpgsqlHstoreTypeMapping
     {
         static readonly HstoreComparer ComparerInstance = new HstoreComparer();
 
         /// <summary>
-        /// Constructs an instance of the <see cref="NpgsqlImmutableHstoreTypeMapping"/> class.
+        /// Constructs an instance of the <see cref="NpgsqlReadOnlyHstoreTypeMapping"/> class.
         /// </summary>
-        public NpgsqlImmutableHstoreTypeMapping()
+        public NpgsqlReadOnlyHstoreTypeMapping()
             : base(
                 new RelationalTypeMappingParameters(
                     new CoreTypeMappingParameters(typeof(IReadOnlyDictionary<string, string>), null, ComparerInstance),
                     "hstore"
                 )) {}
 
-        protected NpgsqlImmutableHstoreTypeMapping(RelationalTypeMappingParameters parameters)
+        protected NpgsqlReadOnlyHstoreTypeMapping(RelationalTypeMappingParameters parameters)
             : base(parameters) {}
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-            => new NpgsqlImmutableHstoreTypeMapping(parameters);
+            => new NpgsqlReadOnlyHstoreTypeMapping(parameters);
 
         class HstoreComparer : ValueComparer<IReadOnlyDictionary<string, string>>
         {
             public HstoreComparer() : base(
-                (a, b) => Compare(a,b),
+                // We could compare contents here if the references are different, but that would penalize the 99% case
+                // where a different reference means different contents, which would only save a very rare database update.
+                (a, b) => ReferenceEquals(a, b),
                 o => o.GetHashCode(),
                 o => o)
             {}

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -104,13 +104,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         readonly NpgsqlRangeTypeMapping        _daterange;
 
         // Other types
-        readonly NpgsqlBoolTypeMapping          _bool               = new NpgsqlBoolTypeMapping();
-        readonly NpgsqlBitTypeMapping           _bit                = new NpgsqlBitTypeMapping();
-        readonly NpgsqlVarbitTypeMapping        _varbit             = new NpgsqlVarbitTypeMapping();
-        readonly NpgsqlByteArrayTypeMapping     _bytea              = new NpgsqlByteArrayTypeMapping();
-        readonly NpgsqlMutableHstoreTypeMapping _mutableHstore      = new NpgsqlMutableHstoreTypeMapping();
-        readonly NpgsqlImmutableHstoreTypeMapping _immutableHstore    = new NpgsqlImmutableHstoreTypeMapping();
-        readonly NpgsqlTidTypeMapping           _tid                = new NpgsqlTidTypeMapping();
+        readonly NpgsqlBoolTypeMapping           _bool           = new NpgsqlBoolTypeMapping();
+        readonly NpgsqlBitTypeMapping            _bit            = new NpgsqlBitTypeMapping();
+        readonly NpgsqlVarbitTypeMapping         _varbit         = new NpgsqlVarbitTypeMapping();
+        readonly NpgsqlByteArrayTypeMapping      _bytea          = new NpgsqlByteArrayTypeMapping();
+        readonly NpgsqlMutableHstoreTypeMapping  _hstore         = new NpgsqlMutableHstoreTypeMapping();
+        readonly NpgsqlReadOnlyHstoreTypeMapping _readOnlyHstore = new NpgsqlReadOnlyHstoreTypeMapping();
+        readonly NpgsqlTidTypeMapping            _tid            = new NpgsqlTidTypeMapping();
 
         // Special stuff
         // ReSharper disable once InconsistentNaming
@@ -185,7 +185,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { "bit",                         new[] { _bit                          } },
                 { "bit varying",                 new[] { _varbit                       } },
                 { "varbit",                      new[] { _varbit                       } },
-                { "hstore",                      new RelationalTypeMapping[] { _mutableHstore, _immutableHstore } },
+                { "hstore",                      new RelationalTypeMapping[] { _hstore, _readOnlyHstore } },
                 { "point",                       new[] { _point                        } },
                 { "box",                         new[] { _box                          } },
                 { "line",                        new[] { _line                         } },
@@ -235,8 +235,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { typeof(IPAddress),                           _inet                 },
                 { typeof((IPAddress, int)),                    _cidr                 },
                 { typeof(BitArray),                            _varbit               },
-                { typeof(IReadOnlyDictionary<string, string>), _immutableHstore      },
-                { typeof(Dictionary<string, string>),          _mutableHstore        },
+                { typeof(IReadOnlyDictionary<string, string>), _readOnlyHstore       },
+                { typeof(Dictionary<string, string>),          _hstore               },
                 { typeof(NpgsqlTid),                           _tid                  },
 
                 { typeof(NpgsqlPoint),                         _point                },

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -104,12 +104,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         readonly NpgsqlRangeTypeMapping        _daterange;
 
         // Other types
-        readonly NpgsqlBoolTypeMapping         _bool               = new NpgsqlBoolTypeMapping();
-        readonly NpgsqlBitTypeMapping          _bit                = new NpgsqlBitTypeMapping();
-        readonly NpgsqlVarbitTypeMapping       _varbit             = new NpgsqlVarbitTypeMapping();
-        readonly NpgsqlByteArrayTypeMapping    _bytea              = new NpgsqlByteArrayTypeMapping();
-        readonly NpgsqlHstoreTypeMapping       _hstore             = new NpgsqlHstoreTypeMapping();
-        readonly NpgsqlTidTypeMapping          _tid                = new NpgsqlTidTypeMapping();
+        readonly NpgsqlBoolTypeMapping          _bool               = new NpgsqlBoolTypeMapping();
+        readonly NpgsqlBitTypeMapping           _bit                = new NpgsqlBitTypeMapping();
+        readonly NpgsqlVarbitTypeMapping        _varbit             = new NpgsqlVarbitTypeMapping();
+        readonly NpgsqlByteArrayTypeMapping     _bytea              = new NpgsqlByteArrayTypeMapping();
+        readonly NpgsqlMutableHstoreTypeMapping _mutableHstore      = new NpgsqlMutableHstoreTypeMapping();
+        readonly NpgsqlImmutableHstoreTypeMapping _immutableHstore    = new NpgsqlImmutableHstoreTypeMapping();
+        readonly NpgsqlTidTypeMapping           _tid                = new NpgsqlTidTypeMapping();
 
         // Special stuff
         // ReSharper disable once InconsistentNaming
@@ -184,7 +185,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { "bit",                         new[] { _bit                          } },
                 { "bit varying",                 new[] { _varbit                       } },
                 { "varbit",                      new[] { _varbit                       } },
-                { "hstore",                      new[] { _hstore                       } },
+                { "hstore",                      new RelationalTypeMapping[] { _mutableHstore, _immutableHstore } },
                 { "point",                       new[] { _point                        } },
                 { "box",                         new[] { _box                          } },
                 { "line",                        new[] { _line                         } },
@@ -213,46 +214,47 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 
             var clrTypeMappings = new Dictionary<Type, RelationalTypeMapping>
             {
-                { typeof(bool),                         _bool                 },
-                { typeof(byte[]),                       _bytea                },
-                { typeof(float),                        _float4               },
-                { typeof(double),                       _float8               },
-                { typeof(decimal),                      _numeric              },
-                { typeof(Guid),                         _uuid                 },
-                { typeof(byte),                         _int2Byte             },
-                { typeof(short),                        _int2                 },
-                { typeof(int),                          _int4                 },
-                { typeof(long),                         _int8                 },
-                { typeof(string),                       _text                 },
-                { typeof(JsonDocument),                 _jsonbDocument        },
-                { typeof(JsonElement),                  _jsonbElement         },
-                { typeof(char),                         _singleChar           },
-                { typeof(DateTime),                     _timestamp            },
-                { typeof(TimeSpan),                     _interval             },
-                { typeof(DateTimeOffset),               _timestamptzDto       },
-                { typeof(PhysicalAddress),              _macaddr              },
-                { typeof(IPAddress),                    _inet                 },
-                { typeof((IPAddress, int)),             _cidr                 },
-                { typeof(BitArray),                     _varbit               },
-                { typeof(Dictionary<string, string>),   _hstore               },
-                { typeof(NpgsqlTid),                    _tid                  },
+                { typeof(bool),                                _bool                 },
+                { typeof(byte[]),                              _bytea                },
+                { typeof(float),                               _float4               },
+                { typeof(double),                              _float8               },
+                { typeof(decimal),                             _numeric              },
+                { typeof(Guid),                                _uuid                 },
+                { typeof(byte),                                _int2Byte             },
+                { typeof(short),                               _int2                 },
+                { typeof(int),                                 _int4                 },
+                { typeof(long),                                _int8                 },
+                { typeof(string),                              _text                 },
+                { typeof(JsonDocument),                        _jsonbDocument        },
+                { typeof(JsonElement),                         _jsonbElement         },
+                { typeof(char),                                _singleChar           },
+                { typeof(DateTime),                            _timestamp            },
+                { typeof(TimeSpan),                            _interval             },
+                { typeof(DateTimeOffset),                      _timestamptzDto       },
+                { typeof(PhysicalAddress),                     _macaddr              },
+                { typeof(IPAddress),                           _inet                 },
+                { typeof((IPAddress, int)),                    _cidr                 },
+                { typeof(BitArray),                            _varbit               },
+                { typeof(IReadOnlyDictionary<string, string>), _immutableHstore      },
+                { typeof(Dictionary<string, string>),          _mutableHstore        },
+                { typeof(NpgsqlTid),                           _tid                  },
 
-                { typeof(NpgsqlPoint),                  _point                },
-                { typeof(NpgsqlBox),                    _box                  },
-                { typeof(NpgsqlLine),                   _line                 },
-                { typeof(NpgsqlLSeg),                   _lseg                 },
-                { typeof(NpgsqlPath),                   _path                 },
-                { typeof(NpgsqlPolygon),                _polygon              },
-                { typeof(NpgsqlCircle),                 _circle               },
+                { typeof(NpgsqlPoint),                         _point                },
+                { typeof(NpgsqlBox),                           _box                  },
+                { typeof(NpgsqlLine),                          _line                 },
+                { typeof(NpgsqlLSeg),                          _lseg                 },
+                { typeof(NpgsqlPath),                          _path                 },
+                { typeof(NpgsqlPolygon),                       _polygon              },
+                { typeof(NpgsqlCircle),                        _circle               },
 
-                { typeof(NpgsqlRange<int>),             _int4range            },
-                { typeof(NpgsqlRange<long>),            _int8range            },
-                { typeof(NpgsqlRange<decimal>),         _numrange             },
-                { typeof(NpgsqlRange<DateTime>),        _tsrange              },
+                { typeof(NpgsqlRange<int>),                    _int4range            },
+                { typeof(NpgsqlRange<long>),                   _int8range            },
+                { typeof(NpgsqlRange<decimal>),                _numrange             },
+                { typeof(NpgsqlRange<DateTime>),               _tsrange              },
 
-                { typeof(NpgsqlTsQuery),                _tsquery              },
-                { typeof(NpgsqlTsVector),               _tsvector             },
-                { typeof(NpgsqlTsRankingNormalization), _rankingNormalization }
+                { typeof(NpgsqlTsQuery),                       _tsquery              },
+                { typeof(NpgsqlTsVector),                      _tsvector             },
+                { typeof(NpgsqlTsRankingNormalization),        _rankingNormalization }
             };
 
             StoreTypeMappings = new ConcurrentDictionary<string, RelationalTypeMapping[]>(storeTypeMappings, StringComparer.OrdinalIgnoreCase);

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Data;
 using System.Diagnostics;
 using System.Linq;
@@ -104,13 +105,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         readonly NpgsqlRangeTypeMapping        _daterange;
 
         // Other types
-        readonly NpgsqlBoolTypeMapping           _bool           = new NpgsqlBoolTypeMapping();
-        readonly NpgsqlBitTypeMapping            _bit            = new NpgsqlBitTypeMapping();
-        readonly NpgsqlVarbitTypeMapping         _varbit         = new NpgsqlVarbitTypeMapping();
-        readonly NpgsqlByteArrayTypeMapping      _bytea          = new NpgsqlByteArrayTypeMapping();
-        readonly NpgsqlMutableHstoreTypeMapping  _hstore         = new NpgsqlMutableHstoreTypeMapping();
-        readonly NpgsqlReadOnlyHstoreTypeMapping _readOnlyHstore = new NpgsqlReadOnlyHstoreTypeMapping();
-        readonly NpgsqlTidTypeMapping            _tid            = new NpgsqlTidTypeMapping();
+        readonly NpgsqlBoolTypeMapping            _bool            = new NpgsqlBoolTypeMapping();
+        readonly NpgsqlBitTypeMapping             _bit             = new NpgsqlBitTypeMapping();
+        readonly NpgsqlVarbitTypeMapping          _varbit          = new NpgsqlVarbitTypeMapping();
+        readonly NpgsqlByteArrayTypeMapping       _bytea           = new NpgsqlByteArrayTypeMapping();
+        readonly NpgsqlMutableHstoreTypeMapping   _hstore          = new NpgsqlMutableHstoreTypeMapping();
+        readonly NpgsqlReadOnlyHstoreTypeMapping  _readOnlyHstore  = new NpgsqlReadOnlyHstoreTypeMapping();
+        readonly NpgsqlImmutableHstoreTypeMapping _immutableHstore = new NpgsqlImmutableHstoreTypeMapping();
+        readonly NpgsqlTidTypeMapping             _tid             = new NpgsqlTidTypeMapping();
 
         // Special stuff
         // ReSharper disable once InconsistentNaming
@@ -185,7 +187,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { "bit",                         new[] { _bit                          } },
                 { "bit varying",                 new[] { _varbit                       } },
                 { "varbit",                      new[] { _varbit                       } },
-                { "hstore",                      new RelationalTypeMapping[] { _hstore, _readOnlyHstore } },
+                { "hstore",                      new RelationalTypeMapping[] { _hstore, _readOnlyHstore, _immutableHstore } },
                 { "point",                       new[] { _point                        } },
                 { "box",                         new[] { _box                          } },
                 { "line",                        new[] { _line                         } },
@@ -236,6 +238,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { typeof((IPAddress, int)),                    _cidr                 },
                 { typeof(BitArray),                            _varbit               },
                 { typeof(IReadOnlyDictionary<string, string>), _readOnlyHstore       },
+                { typeof(ImmutableDictionary<string, string>), _immutableHstore      },
                 { typeof(Dictionary<string, string>),          _hstore               },
                 { typeof(NpgsqlTid),                           _tid                  },
 

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Net.NetworkInformation;
@@ -115,6 +116,8 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                         StringAsJsonb = @"{""a"": ""b""}",
                         StringAsJson = @"{""a"": ""b""}",
                         DictionaryAsHstore = new Dictionary<string, string> { { "a", "b" } },
+                        IReadOnlyDictionaryAsHstore = new Dictionary<string, string> { { "c", "d" } },
+                        ImmutableDictionaryAsHstore = ImmutableDictionary<string, string>.Empty.Add("e", "f"),
                         NpgsqlRangeAsRange = new NpgsqlRange<int>(4, true, 8, false),
 
                         IntArrayAsIntArray= new[] { 2, 3 },
@@ -248,36 +251,42 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 var param30 = new Dictionary<string, string> { { "a", "b" } };
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.DictionaryAsHstore == param30));
 
-                var param31 = new NpgsqlRange<int>(4, true, 8, false);
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.NpgsqlRangeAsRange == param31));
+                var param31 = (IReadOnlyDictionary<string, string>)new Dictionary<string, string> { { "c", "d" } };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IReadOnlyDictionaryAsHstore == param31));
 
-                var param32 = new[] { 2, 3 };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntArrayAsIntArray == param32));
+                var param32 = ImmutableDictionary<string, string>.Empty.Add("e", "f");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.ImmutableDictionaryAsHstore == param32));
 
-                var param33 = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressArrayAsMacaddrArray == param33));
+                var param33 = new NpgsqlRange<int>(4, true, 8, false);
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.NpgsqlRangeAsRange == param33));
 
-                // ReSharper disable once ConvertToConstant.Local
-                var param34 = (uint)int.MaxValue + 1;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsXid == param34));
+                var param34 = new[] { 2, 3 };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntArrayAsIntArray == param34));
 
-                var param35 = NpgsqlTsQuery.Parse("a & b");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchQuery == param35));
-
-                var param36 = NpgsqlTsVector.Parse("a b");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchVector == param36));
+                var param35 = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressArrayAsMacaddrArray == param35));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param37 = NpgsqlTsRankingNormalization.DivideByLength;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.RankingNormalization == param37));
+                var param36 = (uint)int.MaxValue + 1;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsXid == param36));
+
+                var param37 = NpgsqlTsQuery.Parse("a & b");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchQuery == param37));
+
+                var param38 = NpgsqlTsVector.Parse("a b");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchVector == param38));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param38 = 12724u;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Regconfig == param38));
+                var param39 = NpgsqlTsRankingNormalization.DivideByLength;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.RankingNormalization == param39));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param39 = Mood.Sad;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Mood == param39));
+                var param40 = 12724u;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Regconfig == param40));
+
+                // ReSharper disable once ConvertToConstant.Local
+                var param41 = Mood.Sad;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Mood == param41));
             }
         }
 
@@ -408,32 +417,38 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 Dictionary<string, string> param30 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.DictionaryAsHstore == param30));
 
-                NpgsqlRange<int>? param31 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlRangeAsRange == param31));
+                IReadOnlyDictionary<string, string> param31 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IReadOnlyDictionaryAsHstore == param31));
 
-                int[] param32 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param32));
+                ImmutableDictionary<string, string> param32 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.ImmutableDictionaryAsHstore == param32));
 
-                PhysicalAddress[] param33 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param33));
+                NpgsqlRange<int>? param33 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlRangeAsRange == param33));
 
-                uint? param34 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param34));
+                int[] param34 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param34));
 
-                NpgsqlTsQuery param35 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchQuery == param35));
+                PhysicalAddress[] param35 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param35));
 
-                NpgsqlTsVector param36 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchVector == param36));
+                uint? param36 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param36));
 
-                NpgsqlTsRankingNormalization? param37 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.RankingNormalization == param37));
+                NpgsqlTsQuery param37 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchQuery == param37));
 
-                uint? param38 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Regconfig == param38));
+                NpgsqlTsVector param38 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchVector == param38));
 
-                Mood? param39 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Mood == param39));
+                NpgsqlTsRankingNormalization? param39 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.RankingNormalization == param39));
+
+                uint? param40 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Regconfig == param40));
+
+                Mood? param41 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Mood == param41));
             }
         }
 
@@ -682,6 +697,8 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
             Assert.Null(entity.StringAsJsonb);
             Assert.Null(entity.StringAsJson);
             Assert.Null(entity.DictionaryAsHstore);
+            Assert.Null(entity.IReadOnlyDictionaryAsHstore);
+            Assert.Null(entity.ImmutableDictionaryAsHstore);
             Assert.Null(entity.NpgsqlRangeAsRange);
 
             Assert.Null(entity.IntArrayAsIntArray);
@@ -1309,6 +1326,13 @@ FROM ""MappedDataTypes"" AS m");
 
             [Column(TypeName = "hstore")]
             public Dictionary<string, string> DictionaryAsHstore { get; set; }
+
+            [Column(TypeName = "hstore")]
+            // ReSharper disable once InconsistentNaming
+            public IReadOnlyDictionary<string, string> IReadOnlyDictionaryAsHstore { get; set; }
+
+            [Column(TypeName = "hstore")]
+            public ImmutableDictionary<string, string> ImmutableDictionaryAsHstore { get; set; }
 
             [Column(TypeName = "int4range")]
             public NpgsqlRange<int>? NpgsqlRangeAsRange { get; set; }

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -308,7 +308,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                 }));
 
         [Fact]
-        public void ValueComparer_hstore_as_dictionary()
+        public void ValueComparer_hstore_as_Dictionary()
         {
             var source = new Dictionary<string, string>
             {
@@ -326,7 +326,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         }
 
         [Fact]
-        public void ValueComparer_hstore_as_readonlydictionary()
+        public void ValueComparer_hstore_as_IReadOnlyDictionary()
         {
             var sourceAsDict = new Dictionary<string, string>
             {

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Text.Json;
@@ -341,6 +342,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
             Assert.NotSame(source, snapshot);
             Assert.True(comparer.Equals(source, snapshot));
             sourceAsDict.Remove("k1");
+            Assert.False(comparer.Equals(source, snapshot));
+        }
+
+        [Fact]
+        public void ValueComparer_hstore_as_ImmutableDictionary()
+        {
+            var source = ImmutableDictionary<string, string>.Empty
+                .Add("k1", "v1")
+                .Add("k2", "v2");
+
+            var comparer = Mapper.FindMapping(typeof(ImmutableDictionary<string, string>), "hstore").Comparer;
+            var snapshot = comparer.Snapshot(source);
+            Assert.Equal(source, snapshot);
+            Assert.True(comparer.Equals(source, snapshot));
+            source = source.Remove("k1");
             Assert.False(comparer.Equals(source, snapshot));
         }
 

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
@@ -308,7 +308,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                 }));
 
         [Fact]
-        public void ValueComparer_hstore()
+        public void ValueComparer_hstore_as_dictionary()
         {
             var source = new Dictionary<string, string>
             {
@@ -322,6 +322,25 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
             Assert.NotSame(source, snapshot);
             Assert.True(comparer.Equals(source, snapshot));
             snapshot.Remove("k1");
+            Assert.False(comparer.Equals(source, snapshot));
+        }
+
+        [Fact]
+        public void ValueComparer_hstore_as_readonlydictionary()
+        {
+            var sourceAsDict = new Dictionary<string, string>
+            {
+                { "k1", "v1" },
+                { "k2", "v2" }
+            };
+            IReadOnlyDictionary<string, string> source = sourceAsDict;
+
+            var comparer = GetMapping("hstore").Comparer;
+            var snapshot = (IReadOnlyDictionary<string, string>)comparer.Snapshot(source);
+            Assert.Equal(source, snapshot);
+            Assert.NotSame(source, snapshot);
+            Assert.True(comparer.Equals(source, snapshot));
+            sourceAsDict.Remove("k1");
             Assert.False(comparer.Equals(source, snapshot));
         }
 


### PR DESCRIPTION
The motivation for this is that most other types on an EF model class supported by Npgsql offer only one type of mutability - replacing the instance of the property. Dictionaries offer an additional type of mutability, as not only can the reference be swapped but the same reference can have its internal state changed, which makes reasoning about the correctness of code harder. Supporting IReadOnlyDictionary ensures there's only one point of mutability (or none, if EF is configured to use private field access and the public contract only offers a getter).

It would be nice to offer full support for ImmutableDictionary<string, string> too but from looking at the code, I think this would require further changes to Npgsql rather than just the EF Core part, which unfortunately I don't have time to look into. Still, I think this is a net win even without that.

As well as running the existing tests locally, I put together a simple application to verify that I could add, retrieve, compare using equality and call sql functions with `IReadOnlyDictionary<string, string>` as the type on the model. Happy to stick that code in a Gist if you'd like to see it.