### PR TITLE
Fix migrations for index included properties

### DIFF
--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -60,7 +60,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal
             if (index.GetNullSortOrder() is IReadOnlyList<SortOrder> nullSortOrder)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexNullSortOrder, nullSortOrder);
             if (index.GetIncludeProperties() is IReadOnlyList<string> includeProperties)
-                yield return new Annotation(NpgsqlAnnotationNames.IndexInclude, includeProperties);
+            {
+                var includeColumns = includeProperties
+                    .Select(p => index.DeclaringEntityType.FindProperty(p).GetColumnName())
+                    .ToArray();
+
+                yield return new Annotation(
+                    NpgsqlAnnotationNames.IndexInclude,
+                    includeColumns);
+            }
 
             var isCreatedConcurrently = index.IsCreatedConcurrently();
             if (isCreatedConcurrently.HasValue)

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -670,11 +670,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
         protected override void IndexOptions(CreateIndexOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
-            if (operation[NpgsqlAnnotationNames.IndexInclude] is string[] includeProperties && includeProperties.Length > 0)
+            if (operation[NpgsqlAnnotationNames.IndexInclude] is string[] includeColumns && includeColumns.Length > 0)
             {
                 builder
                     .Append(" INCLUDE (")
-                    .Append(ColumnList(includeProperties))
+                    .Append(ColumnList(includeColumns))
                     .Append(")");
             }
 


### PR DESCRIPTION
This failed when the column name wasn't the same as the property name.

Fixes #1201

~The same bug seems to exist in the SQL Server, opened https://github.com/dotnet/efcore/issues/19602. Once a regression test is done there (with the new migration tests, https://github.com/dotnet/efcore/issues/19039), we should port it to Npgsql too.~