### PR TITLE
Suppress transaction when creating an index concurrently

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -640,7 +640,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
             builder.Append("INDEX ");
 
-            if (operation[NpgsqlAnnotationNames.CreatedConcurrently] is bool concurrently && concurrently)
+            var concurrently = (operation[NpgsqlAnnotationNames.CreatedConcurrently] as bool?).GetValueOrDefault();
+            if (concurrently)
                 builder.Append("CONCURRENTLY ");
 
             builder
@@ -664,7 +665,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
             if (terminate)
             {
                 builder.AppendLine(';');
-                EndStatement(builder);
+                // Concurrent indexes cannot be created within a transaction
+                EndStatement(builder, suppressTransaction: concurrently);
             }
         }
 

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -640,7 +640,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
             builder.Append("INDEX ");
 
-            var concurrently = (operation[NpgsqlAnnotationNames.CreatedConcurrently] as bool?).GetValueOrDefault();
+            var concurrently = operation[NpgsqlAnnotationNames.CreatedConcurrently] as bool? == true;
             if (concurrently)
                 builder.Append("CONCURRENTLY ");
 


### PR DESCRIPTION
Fixes #1210

No regression test, #1203 tracks that.