### PR TITLE
Fix SQL for DateTime.Add*

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
@@ -86,7 +86,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                 interval = _sqlExpressionFactory.Convert(
                     new SqlBinaryExpression(
                         ExpressionType.Add,
-                        _sqlExpressionFactory.ApplyDefaultTypeMapping(interval),
+                        _sqlExpressionFactory.Convert(interval, typeof(string), _textMapping),
                         _sqlExpressionFactory.Constant(' ' + datePart, _textMapping),
                         typeof(string),
                         _textMapping),

--- a/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SimpleQueryNpgsqlTest.cs
@@ -49,7 +49,7 @@ WHERE (o.""OrderDate"" IS NOT NULL)");
             AssertSql(
                 @"@__years_0='2'
 
-SELECT o.""OrderDate"" + CAST((@__years_0 || ' years') AS interval) AS ""OrderDate""
+SELECT o.""OrderDate"" + CAST((@__years_0::text || ' years') AS interval) AS ""OrderDate""
 FROM ""Orders"" AS o
 WHERE (o.""OrderDate"" IS NOT NULL)");
         }


### PR DESCRIPTION
Fixes #1230

Regression test introduced in 5.0 (ComplexNavigationsQueryTestBase.Optional_navigation_inside_nested_method_call_translated_to_join_keeps_original_nullability_also_for_arguments)