### PR TITLE
Execution strategy fixes and sync

### DIFF
--- a/src/EFCore.PG/Query/Internal/NpgsqlCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlCompiledQueryCacheKeyGenerator.cs
@@ -34,8 +34,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
 
             public override bool Equals(object obj)
                 => !(obj is null)
-                   && obj is NpgsqlCompiledQueryCacheKey
-                   && Equals((NpgsqlCompiledQueryCacheKey)obj);
+                   && obj is NpgsqlCompiledQueryCacheKey key
+                   && Equals(key);
 
             bool Equals(NpgsqlCompiledQueryCacheKey other)
                 => _relationalCompiledQueryCacheKey.Equals(other._relationalCompiledQueryCacheKey)

--- a/src/EFCore.PG/Storage/Internal/NpgsqlExecutionStrategy.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlExecutionStrategy.cs
@@ -9,12 +9,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
 {
     public class NpgsqlExecutionStrategy : IExecutionStrategy
     {
-        private ExecutionStrategyDependencies Dependencies { get; }
+        ExecutionStrategyDependencies Dependencies { get; }
 
         public NpgsqlExecutionStrategy([NotNull] ExecutionStrategyDependencies dependencies)
-        {
-            Dependencies = dependencies;
-        }
+            => Dependencies = dependencies;
 
         public virtual bool RetriesOnFailure => false;
 
@@ -27,14 +25,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             {
                 return operation(Dependencies.CurrentContext.Context, state);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ExecutionStrategy.CallOnWrappedException(ex, NpgsqlTransientExceptionDetector.ShouldRetryOn))
             {
-                if (ExecutionStrategy.CallOnWrappedException(ex, NpgsqlTransientExceptionDetector.ShouldRetryOn))
-                {
-                    throw new InvalidOperationException("An exception has been raised that is likely due to a transient failure.", ex);
-                }
-
-                throw;
+                throw new InvalidOperationException("An exception has been raised that is likely due to a transient failure.", ex);
             }
         }
 
@@ -48,14 +41,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             {
                 return await operation(Dependencies.CurrentContext.Context, state, cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ExecutionStrategy.CallOnWrappedException(ex, NpgsqlTransientExceptionDetector.ShouldRetryOn))
             {
-                if (ExecutionStrategy.CallOnWrappedException(ex, NpgsqlTransientExceptionDetector.ShouldRetryOn))
-                {
-                    throw new InvalidOperationException("An exception has been raised that is likely due to a transient failure.", ex);
-                }
-
-                throw;
+                throw new InvalidOperationException("An exception has been raised that is likely due to a transient failure.", ex);
             }
         }
     }

--- a/test/EFCore.PG.FunctionalTests/CommandInterceptionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/CommandInterceptionNpgsqlTest.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 using Xunit;
 
@@ -66,6 +68,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             public class InterceptionNpgsqlFixture : InterceptionNpgsqlFixtureBase
             {
                 protected override bool ShouldSubscribeToDiagnosticListener => false;
+
+                public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+                {
+                    new NpgsqlDbContextOptionsBuilder(base.AddOptions(builder))
+                        .ExecutionStrategy(d => new NpgsqlExecutionStrategy(d));
+                    return builder;
+                }
             }
         }
 
@@ -80,6 +89,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
             public class InterceptionNpgsqlFixture : InterceptionNpgsqlFixtureBase
             {
                 protected override bool ShouldSubscribeToDiagnosticListener => true;
+
+                public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+                {
+                    new NpgsqlDbContextOptionsBuilder(base.AddOptions(builder))
+                        .ExecutionStrategy(d => new NpgsqlExecutionStrategy(d));
+                    return builder;
+                }
             }
         }
     }

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/NpgsqlDbContextOptionsBuilderExtensions.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/NpgsqlDbContextOptionsBuilderExtensions.cs
@@ -6,7 +6,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities
     {
         public static NpgsqlDbContextOptionsBuilder ApplyConfiguration(this NpgsqlDbContextOptionsBuilder optionsBuilder)
         {
-            //optionsBuilder.ExecutionStrategy(d => new TestNpgsqlRetryingExecutionStrategy(d));
+            optionsBuilder.ExecutionStrategy(d => new TestNpgsqlRetryingExecutionStrategy(d));
             optionsBuilder.CommandTimeout(NpgsqlTestStore.CommandTimeout);
 
             return optionsBuilder;

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/TestNpgsqlConnection.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/TestNpgsqlConnection.cs
@@ -52,7 +52,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities
 
             if (fail.HasValue)
             {
-                throw new NpgsqlException();
+                throw new PostgresException("Simulated failure", "ERROR", "ERROR", ErrorCode);
             }
         }
     }

--- a/test/EFCore.PG.FunctionalTests/TransactionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/TransactionNpgsqlTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
-    public class TransactionNpgsqlTest : TransactionTestBase<TransactionNpgsqlTest.TransactionNpgsqlFixture>, IDisposable
+    public class TransactionNpgsqlTest : TransactionTestBase<TransactionNpgsqlTest.TransactionNpgsqlFixture>
     {
         public TransactionNpgsqlTest(TransactionNpgsqlFixture fixture)
             : base(fixture)
@@ -21,8 +21,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
 
         [Fact(Skip = "Npgsql batches the inserts, creating an implicit transaction which fails the test (see https://github.com/npgsql/npgsql/issues/1307)")]
         public override Task SaveChangesAsync_can_be_used_with_no_transaction() => null;
-
-        public void Dispose() => TestNpgsqlRetryingExecutionStrategy.Suspended = true;
 
         protected override DbContext CreateContextWithConnectionString()
         {


### PR DESCRIPTION
Includes test changes done in https://github.com/dotnet/efcore/pull/18691

Tests now run using retrying strategy, hopefully working around the transient exceptions we're seeing on CI since the migration tests.

Closes #1244