### PR TITLE
Fixed generation of BIT literal.

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlBitTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlBitTypeMapping.cs
@@ -30,7 +30,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var bits = (BitArray)value;
             var sb = new StringBuilder();
-            sb.Append("BIT B'");
+            sb.Append("B'");
             for (var i = 0; i < bits.Count; i++)
                 sb.Append(bits[i] ? '1' : '0');
             sb.Append('\'');

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlVarbitTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlVarbitTypeMapping.cs
@@ -21,7 +21,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         {
             var bits = (BitArray)value;
             var sb = new StringBuilder();
-            sb.Append("VARBIT B'");
+            sb.Append("B'");
             for (var i = 0; i < bits.Count; i++)
                 sb.Append(bits[i] ? '1' : '0');
             sb.Append('\'');

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net;
@@ -237,7 +237,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
 
         [Fact]
         public void GenerateSqlLiteral_returns_varbit_literal()
-            => Assert.Equal("VARBIT B'10'", GetMapping("varbit").GenerateSqlLiteral(new BitArray(new[] { true, false })));
+            => Assert.Equal("B'10'", GetMapping("varbit").GenerateSqlLiteral(new BitArray(new[] { true, false })));
 
         [Fact]
         public void GenerateCodeLiteral_returns_varbit_literal()
@@ -245,7 +245,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
 
         [Fact]
         public void GenerateSqlLiteral_returns_bit_literal()
-            => Assert.Equal("BIT B'10'", GetMapping("bit").GenerateSqlLiteral(new BitArray(new[] { true, false })));
+            => Assert.Equal("B'10'", GetMapping("bit").GenerateSqlLiteral(new BitArray(new[] { true, false })));
 
         [Fact]
         public void GenerateCodeLiteral_returns_bit_literal()


### PR DESCRIPTION
When working with BIT and VARBIT columns, BIT literals are generated incorrectly, because of excessive prefix.

Resolves #1256