### PR TITLE
Added geometry subtype GEOMETRY association

### DIFF
--- a/src/EFCore.PG.NTS/Storage/Internal/NpgsqlNetTopologySuiteTypeMappingSourcePlugin.cs
+++ b/src/EFCore.PG.NTS/Storage/Internal/NpgsqlNetTopologySuiteTypeMappingSourcePlugin.cs
@@ -23,7 +23,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             { "MULTIPOINT",         typeof(MultiPoint) },
             { "MULTILINESTRING",    typeof(MultiLineString) },
             { "MULTIPOLYGON",       typeof(MultiPolygon) },
-            { "GEOMETRYCOLLECTION", typeof(GeometryCollection) }
+            { "GEOMETRYCOLLECTION", typeof(GeometryCollection) },
+            { "GEOMETRY",           typeof(Geometry) }
         };
 
         public NpgsqlNetTopologySuiteTypeMappingSourcePlugin([NotNull] INpgsqlNetTopologySuiteOptions options)


### PR DESCRIPTION
As developer I want to manage type and SRID of geometry fields for using and migrations creating, but this case

```
            modelBuilder.Entity<Estate>()
                .ToTable("estates")
                .Property(x => x.Geom).HasColumnName("geom")
                .HasColumnType("geometry(Geometry,3857)")
```
raises exception

> System.InvalidOperationException: "The property 'Estate.Geom' is of type 'Geometry' which is not supported by current database provider. Either change the property CLR type or ignore the property using the '[NotMapped]' attribute or by using 'EntityTypeBuilder.Ignore' in 'OnModelCreating'."

In previous version of NetTopologySuite for npgsql (for core 2.x) it works