### PR TITLE
Support for database and column collation

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -119,6 +119,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
                     rangeTypeDef.SubtypeDiff);
             }
 
+            if (annotation.Name == NpgsqlAnnotationNames.Collation)
+                return new MethodCallCodeFragment(nameof(NpgsqlModelBuilderExtensions.HasCollation));
+
             return null;
         }
 
@@ -159,6 +162,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
                     identityOptions.MaxValue,
                     identityOptions.IsCyclic ? true : (bool?)null,
                     identityOptions.NumbersToCache == 1 ? null : (long?)identityOptions.NumbersToCache);
+
+            case NpgsqlAnnotationNames.Collation:
+                return new MethodCallCodeFragment(nameof(NpgsqlPropertyBuilderExtensions.HasCollation), annotation.Value);
             }
 
             return null;
@@ -167,12 +173,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
         public override MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
             => annotation.Name switch
             {
+                NpgsqlAnnotationNames.Collation
+                    => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasCollation), annotation.Value),
                 NpgsqlAnnotationNames.IndexMethod
                     => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasMethod), annotation.Value),
                 NpgsqlAnnotationNames.IndexOperators
                     => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasOperators), annotation.Value),
-                NpgsqlAnnotationNames.IndexCollation
-                    => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasCollation), annotation.Value),
                 NpgsqlAnnotationNames.IndexSortOrder
                     => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasSortOrder), annotation.Value),
                 NpgsqlAnnotationNames.IndexNullSortOrder

--- a/src/EFCore.PG/Extensions/NpgsqlIndexBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlIndexBuilderExtensions.cs
@@ -372,7 +372,10 @@ namespace Microsoft.EntityFrameworkCore
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
-            return indexBuilder.CanSetAnnotation(NpgsqlAnnotationNames.IndexCollation, values, fromDataAnnotation);
+#pragma warning disable 618
+            return indexBuilder.CanSetAnnotation(NpgsqlAnnotationNames.Collation, values, fromDataAnnotation) &&
+                   indexBuilder.CanSetAnnotation(NpgsqlAnnotationNames.IndexCollation, values, fromDataAnnotation);
+#pragma warning restore 618
         }
 
         #endregion Collation

--- a/src/EFCore.PG/Extensions/NpgsqlIndexExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlIndexExtensions.cs
@@ -85,8 +85,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <remarks>
         /// https://www.postgresql.org/docs/current/static/indexes-collations.html
         /// </remarks>
+#pragma warning disable 618
         public static IReadOnlyList<string> GetCollation([NotNull] this IIndex index)
-            => (IReadOnlyList<string>)index[NpgsqlAnnotationNames.IndexCollation];
+            => (IReadOnlyList<string>)(
+                index[NpgsqlAnnotationNames.Collation] ?? index[NpgsqlAnnotationNames.IndexCollation]);
+#pragma warning restore 618
 
         /// <summary>
         /// Sets the column collations to be used, or <c>null</c> if they have not been specified.
@@ -95,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore
         /// https://www.postgresql.org/docs/current/static/indexes-collations.html
         /// </remarks>
         public static void SetCollation([NotNull] this IMutableIndex index, [CanBeNull] IReadOnlyList<string> collations)
-            => index.SetOrRemoveAnnotation(NpgsqlAnnotationNames.IndexCollation, collations);
+            => index.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Collation, collations);
 
         /// <summary>
         /// Sets the column collations to be used, or <c>null</c> if they have not been specified.
@@ -104,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore
         /// https://www.postgresql.org/docs/current/static/indexes-collations.html
         /// </remarks>
         public static void SetCollation([NotNull] this IConventionIndex index, [CanBeNull] IReadOnlyList<string> collations, bool fromDataAnnotation)
-            => index.SetOrRemoveAnnotation(NpgsqlAnnotationNames.IndexCollation, collations, fromDataAnnotation);
+            => index.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Collation, collations, fromDataAnnotation);
 
         #endregion Collation
 

--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -456,6 +456,77 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion
 
+        #region Collation
+
+        /// <summary>
+        /// Configures the database to use the given collation as the default for all columns.
+        /// The collation must already exist in PostgreSQL. Once a database has been created, its collation cannot be
+        /// altered.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="collation">The collation.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static ModelBuilder HasCollation([NotNull] this ModelBuilder modelBuilder, [CanBeNull] string collation)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NullButNotEmpty(collation, nameof(collation));
+
+            modelBuilder.Model.SetCollation(collation);
+
+            return modelBuilder;
+        }
+
+        /// <summary>
+        /// Configures the database to use the given collation as the default for all columns.
+        /// The collation must already exist in PostgreSQL. Once a database has been created, its collation cannot be
+        /// altered.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="collation">The collation.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns>A builder to further configure the property.</returns>
+        public static IConventionModelBuilder HasCollation(
+            [NotNull] this IConventionModelBuilder modelBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            if (modelBuilder.CanSetHasCollation(collation, fromDataAnnotation))
+            {
+                modelBuilder.Metadata.SetCollation(collation);
+                return modelBuilder;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the given value can be set as the collation.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="collation">The collation.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns><c>true</c> if the given value can be set as the collation.</returns>
+        public static bool CanSetHasCollation(
+            [NotNull] this IConventionModelBuilder modelBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            return modelBuilder.CanSetAnnotation(NpgsqlAnnotationNames.Collation, collation, fromDataAnnotation);
+        }
+
+        #endregion
+
         #region Tablespaces
 
         public static ModelBuilder UseTablespace(

--- a/src/EFCore.PG/Extensions/NpgsqlModelExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelExtensions.cs
@@ -208,6 +208,48 @@ namespace Microsoft.EntityFrameworkCore
             => model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.DatabaseTemplate, template);
         #endregion
 
+        #region Collation
+
+        /// <summary>
+        /// Returns the collation to be used, or <c>null</c> if it hasn't been specified.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        public static string GetCollation([NotNull] this IModel model)
+            => (string)model[NpgsqlAnnotationNames.Collation];
+
+        /// <summary>
+        /// Sets the collation to be used, or <c>null</c> to make it unspecified.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        public static void SetCollation([NotNull] this IMutableModel model, [CanBeNull] string collation)
+            => model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Collation, collation);
+
+        /// <summary>
+        /// Sets the collation to be used, or <c>null</c> to make it unspecified.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        public static string SetCollation([NotNull] this IConventionModel model, [CanBeNull] string collation, bool fromDataAnnotation = false)
+        {
+            model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Collation, collation, fromDataAnnotation);
+            return collation;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="ConfigurationSource" /> for the collation of the database.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <returns>The <see cref="ConfigurationSource" /> for the collation of the database.</returns>
+        public static ConfigurationSource? GetCollationConfigurationSource([NotNull] this IConventionModel model)
+            => model.FindAnnotation(NpgsqlAnnotationNames.Collation)?.GetConfigurationSource();
+
+        #endregion Collation
+
         #region Tablespace
 
         public static string GetTablespace([NotNull] this IModel model)
@@ -217,6 +259,5 @@ namespace Microsoft.EntityFrameworkCore
             => model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Tablespace, tablespace);
 
         #endregion
-
     }
 }

--- a/src/EFCore.PG/Extensions/NpgsqlPropertyBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyBuilderExtensions.cs
@@ -744,5 +744,86 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         #endregion Generated tsvector column
+
+        #region Collation
+
+        /// <summary>
+        /// Configures the property to use the given collation. The collation must already exist in PostgreSQL.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="collation">The collation.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static PropertyBuilder HasCollation([NotNull] this PropertyBuilder propertyBuilder, [CanBeNull] string collation)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+            Check.NullButNotEmpty(collation, nameof(collation));
+
+            propertyBuilder.Metadata.SetCollation(collation);
+
+            return propertyBuilder;
+        }
+
+        /// <summary>
+        /// Configures the property to use the given collation. The collation must already exist in PostgreSQL.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="collation">The collation.</param>
+        /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+        public static PropertyBuilder<TProperty> HasCollation<TProperty>(
+            [NotNull] this PropertyBuilder<TProperty> propertyBuilder, [CanBeNull] string collation)
+            => (PropertyBuilder<TProperty>)HasCollation((PropertyBuilder)propertyBuilder, collation);
+
+        /// <summary>
+        /// Configures the property to use the given collation. The collation must already exist in PostgreSQL.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="collation">The collation.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns>A builder to further configure the property.</returns>
+        public static IConventionPropertyBuilder HasCollation(
+            [NotNull] this IConventionPropertyBuilder propertyBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            if (propertyBuilder.CanSetHasCollation(collation, fromDataAnnotation))
+            {
+                propertyBuilder.Metadata.SetCollation(collation);
+
+                return propertyBuilder;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the given value can be set as the collation.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        /// <param name="propertyBuilder">The builder for the property being configured.</param>
+        /// <param name="collation">The collation.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns><c>true</c> if the given value can be set as the collation.</returns>
+        public static bool CanSetHasCollation(
+            [NotNull] this IConventionPropertyBuilder propertyBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            Check.NotNull(propertyBuilder, nameof(propertyBuilder));
+
+            return propertyBuilder.CanSetAnnotation(NpgsqlAnnotationNames.Collation, collation, fromDataAnnotation);
+        }
+
+        #endregion Collation
     }
 }

--- a/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
@@ -590,5 +590,50 @@ namespace Microsoft.EntityFrameworkCore
             => property.FindAnnotation(NpgsqlAnnotationNames.TsVectorConfig)?.GetConfigurationSource();
 
         #endregion Generated tsvector column
+
+        #region Collation
+
+        /// <summary>
+        /// Returns the collation to be used, or <c>null</c> if it hasn't been specified.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        public static string GetCollation([NotNull] this IProperty property)
+            => (string)property[NpgsqlAnnotationNames.Collation];
+
+        /// <summary>
+        /// Sets the collation to be used, or <c>null</c> to make it unspecified.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        public static void SetCollation([NotNull] this IMutableProperty property, [CanBeNull] string collation)
+            => property.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Collation, collation);
+
+        /// <summary>
+        /// Sets the collation to be used, or <c>null</c> to make it unspecified.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/collation.html
+        /// </remarks>
+        public static string SetCollation(
+            [NotNull] this IConventionProperty property,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            property.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Collation, collation, fromDataAnnotation);
+            return collation;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="ConfigurationSource" /> for the collation of the property.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <returns>The <see cref="ConfigurationSource" /> for the collation of the database.</returns>
+        public static ConfigurationSource? GetCollationConfigurationSource([NotNull] this IConventionProperty property)
+            => property.FindAnnotation(NpgsqlAnnotationNames.Collation)?.GetConfigurationSource();
+
+        #endregion Collation
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -11,7 +11,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string HiLoSequenceSchema = Prefix + "HiLoSequenceSchema";
         public const string IndexMethod = Prefix + "IndexMethod";
         public const string IndexOperators = Prefix + "IndexOperators";
-        public const string IndexCollation = Prefix + "IndexCollation";
         public const string IndexSortOrder = Prefix + "IndexSortOrder";
         public const string IndexNullSortOrder = Prefix + "IndexNullSortOrder";
         public const string IndexInclude = Prefix + "IndexInclude";
@@ -26,6 +25,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string IdentityOptions = Prefix + "IdentitySequenceOptions";
         public const string TsVectorConfig = Prefix + "TsVectorConfig";
         public const string TsVectorProperties = Prefix + "TsVectorProperties";
+        public const string Collation = Prefix + "Collation";
 
         // Database model annotations
 
@@ -51,5 +51,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
 
         [Obsolete("Replaced by built-in EF Core support, use HasComment on entities or properties.")]
         public const string Comment = Prefix + "Comment";
+
+        [Obsolete("Replaced by NpgsqlAnnotationNames.Collation.")]
+        public const string IndexCollation = Prefix + "IndexCollation";
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
@@ -66,6 +66,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
                         .Select(p2 => property.DeclaringEntityType.FindProperty(p2).GetColumnName())
                         .ToArray());
             }
+
+            if (column.PropertyMappings.Select(m => m.Property.GetCollation())
+                .FirstOrDefault(c => c != null) is string collation)
+                yield return new Annotation(NpgsqlAnnotationNames.Collation, collation);
         }
 
         public override IEnumerable<IAnnotation> For(ITableIndex index)
@@ -73,12 +77,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
             // Model validation ensures that these facets are the same on all mapped indexes
             var modelIndex = index.MappedIndexes.First();
 
+            if (modelIndex.GetCollation() is IReadOnlyList<string> collation)
+                yield return new Annotation(NpgsqlAnnotationNames.Collation, collation);
             if (modelIndex.GetMethod() is string method)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexMethod, method);
             if (modelIndex.GetOperators() is IReadOnlyList<string> operators)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexOperators, operators);
-            if (modelIndex.GetCollation() is IReadOnlyList<string> collation)
-                yield return new Annotation(NpgsqlAnnotationNames.IndexCollation, collation);
             if (modelIndex.GetSortOrder() is IReadOnlyList<SortOrder> sortOrder)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexSortOrder, sortOrder);
             if (modelIndex.GetNullSortOrder() is IReadOnlyList<SortOrder> nullSortOrder)
@@ -107,6 +111,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
             => model.Model.GetAnnotations().Where(a =>
                 a.Name.StartsWith(NpgsqlAnnotationNames.PostgresExtensionPrefix, StringComparison.Ordinal) ||
                 a.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix, StringComparison.Ordinal) ||
-                a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal));
+                a.Name.StartsWith(NpgsqlAnnotationNames.RangePrefix, StringComparison.Ordinal) ||
+                a.Name == NpgsqlAnnotationNames.Collation);
     }
 }

--- a/src/EFCore.PG/Migrations/Operations/NpgsqlCreateDatabaseOperation.cs
+++ b/src/EFCore.PG/Migrations/Operations/NpgsqlCreateDatabaseOperation.cs
@@ -9,6 +9,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Operations
         [CanBeNull]
         public virtual string Template { get; set; }
         [CanBeNull]
+        public virtual string Collation { get; set; }
+        [CanBeNull]
         public virtual string Tablespace { get; set; }
     }
 }

--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -108,6 +108,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Scaffolding.Internal
                 databaseModel.DatabaseName = connection.Database;
                 databaseModel.DefaultSchema = "public";
 
+                PopulateGlobalDatabaseInfo(connection, databaseModel);
+
                 var schemaList = options.Schemas.ToList();
                 var schemaFilter = GenerateSchemaFilter(schemaList);
                 var tableList = options.Tables.ToList();
@@ -178,6 +180,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Scaffolding.Internal
 
         #region Type information queries
 
+        static void PopulateGlobalDatabaseInfo(NpgsqlConnection connection, DatabaseModel databaseModel)
+        {
+            var commandText = @"SELECT datcollate FROM pg_database WHERE datname=current_database()";
+            using var command = new NpgsqlCommand(commandText, connection);
+            using var reader = command.ExecuteReader();
+
+            databaseModel[NpgsqlAnnotationNames.Collation] = databaseModel;
+        }
+
         /// <summary>
         /// Queries the database for defined tables and registers them with the model.
         /// </summary>
@@ -245,6 +256,7 @@ SELECT
   basetyp.typname AS basetypname,
   attname,
   description,
+  collname,
   attisdropped,
   {(connection.PostgreSqlVersion >= new Version(10, 0) ? "attidentity" : "''::\"char\" as attidentity")},
   {(connection.PostgreSqlVersion >= new Version(12, 0) ? "attgenerated" : "''::\"char\" as attgenerated")},
@@ -277,6 +289,7 @@ LEFT JOIN pg_proc ON pg_proc.oid = typ.typreceive
 LEFT JOIN pg_type AS elemtyp ON (elemtyp.oid = typ.typelem)
 LEFT JOIN pg_type AS basetyp ON (basetyp.oid = typ.typbasetype)
 LEFT JOIN pg_description AS des ON des.objoid = cls.oid AND des.objsubid = attnum
+LEFT JOIN pg_collation as coll ON coll.oid = attr.attcollation
 -- Bring in identity sequences the depend on this column
 LEFT JOIN pg_depend AS dep ON dep.refobjid = cls.oid AND dep.refobjsubid = attr.attnum AND dep.deptype = 'i'
 {(connection.PostgreSqlVersion >= new Version(10, 0) ? "LEFT JOIN pg_sequence AS seq ON seq.seqrelid = dep.objid" : "")}
@@ -409,6 +422,9 @@ ORDER BY attnum";
 
                         if (record.GetValueOrDefault<string>("description") is string comment)
                             column.Comment = comment;
+
+                        if (record.GetValueOrDefault<string>("collname") is string collation && collation != "default")
+                            column[NpgsqlAnnotationNames.Collation] = collation;
 
                         logger.ColumnFound(
                             DisplayName(tableSchema, tableName),
@@ -584,7 +600,7 @@ WHERE
                             .ToArray();
 
                         if (columnCollations.Any(coll => coll != null))
-                            index[NpgsqlAnnotationNames.IndexCollation] = columnCollations;
+                            index[NpgsqlAnnotationNames.Collation] = columnCollations;
 
                         if (record.GetValueOrDefault<bool>("amcanorder"))
                         {

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -122,6 +122,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 {
                     Name = _connection.DbConnection.Database,
                     Template = Dependencies.Model.GetDatabaseTemplate(),
+                    Collation = Dependencies.Model.GetCollation(),
                     Tablespace = Dependencies.Model.GetTablespace()
                 }
             });

--- a/test/EFCore.PG.Tests/Migrations/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.Tests/Migrations/NpgsqlMigrationSqlGeneratorTest.cs
@@ -51,26 +51,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 ");
         }
 
-        #endregion
-
-        // Which index collations are available on a given PostgreSQL varies (e.g. Linux vs. Windows)
-        // so we test support for this on the generated SQL only, and not against the database in MigrationsNpsqlTest.
         [Fact]
-        public void CreateIndexOperation_collation()
+        public virtual void CreateDatabaseOperation_with_collation()
         {
-            Generate(new CreateIndexOperation
+            Generate(new NpgsqlCreateDatabaseOperation
             {
-                Name = "IX_People_Name",
-                Table = "People",
-                Schema = "dbo",
-                Columns = new[] { "FirstName", "LastName" },
-                [NpgsqlAnnotationNames.IndexCollation] = new[] { null, "de_DE" }
+                Name = "some_db",
+                Collation = "en_US"
             });
 
             AssertSql(
-                @"CREATE INDEX ""IX_People_Name"" ON dbo.""People"" (""FirstName"", ""LastName"" COLLATE ""de_DE"");
+                @"CREATE DATABASE some_db LC_COLLATE ""en_US"";
 ");
         }
+
+        #endregion
 
         #region CockroachDB interleave-in-parent
 


### PR DESCRIPTION
Adds full support for global database collation and per-column, including reverse engineering. Note that index and range collations were already supported.

Closes #406