### PR TITLE
Fix concurrency issue in tests

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -275,7 +275,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         /// </summary>
         void SetupEnumMappings([NotNull] ISqlGenerationHelper sqlGenerationHelper)
         {
-            foreach (var adoMapping in NpgsqlConnection.GlobalTypeMapper.Mappings.Where(m => m.TypeHandlerFactory is IEnumTypeHandlerFactory))
+            foreach (var adoMapping in NpgsqlConnection.GlobalTypeMapper.Mappings.Where(m => m.TypeHandlerFactory is IEnumTypeHandlerFactory).ToArray())
             {
                 var storeType = adoMapping.PgTypeName;
                 var clrType = adoMapping.ClrTypes.SingleOrDefault();


### PR DESCRIPTION
Got a "collection modified while enumerating" failure in the tests, probably because enums are being registered as the type mapping source is enumerating them. For all practical purposes this is a test-only fix.