### PR TITLE
Switch to using the upstream collation annotation for indexes

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -167,12 +167,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
         public override MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
             => annotation.Name switch
             {
+                RelationalAnnotationNames.Collation
+                    => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.UseCollation), annotation.Value),
+
                 NpgsqlAnnotationNames.IndexMethod
                     => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasMethod), annotation.Value),
                 NpgsqlAnnotationNames.IndexOperators
                     => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasOperators), annotation.Value),
-                NpgsqlAnnotationNames.IndexCollation
-                    => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasCollation), annotation.Value),
                 NpgsqlAnnotationNames.IndexSortOrder
                     => new MethodCallCodeFragment(nameof(NpgsqlIndexBuilderExtensions.HasSortOrder), annotation.Value),
                 NpgsqlAnnotationNames.IndexNullSortOrder

--- a/src/EFCore.PG/Extensions/NpgsqlIndexBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlIndexBuilderExtensions.cs
@@ -304,7 +304,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="indexBuilder">The builder for the index being configured.</param>
         /// <param name="values">The sort options to use for each column.</param>
         /// <returns>A builder to further configure the index.</returns>
-        public static IndexBuilder HasCollation(
+        public static IndexBuilder UseCollation(
             [NotNull] this IndexBuilder indexBuilder,
             [CanBeNull] params string[] values)
         {
@@ -325,10 +325,10 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="indexBuilder">The builder for the index being configured.</param>
         /// <param name="values">The sort options to use for each column.</param>
         /// <returns>A builder to further configure the index.</returns>
-        public static IndexBuilder<TEntity> HasCollation<TEntity>(
+        public static IndexBuilder<TEntity> UseCollation<TEntity>(
             [NotNull] this IndexBuilder<TEntity> indexBuilder,
             [CanBeNull] params string[] values)
-            => (IndexBuilder<TEntity>)HasCollation((IndexBuilder)indexBuilder, values);
+            => (IndexBuilder<TEntity>)UseCollation((IndexBuilder)indexBuilder, values);
 
         /// <summary>
         /// The PostgreSQL index collation to be used.
@@ -340,12 +340,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="values">The sort options to use for each column.</param>
         /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
         /// <returns>A builder to further configure the index.</returns>
-        public static IConventionIndexBuilder HasCollation(
+        public static IConventionIndexBuilder UseCollation(
             [NotNull] this IConventionIndexBuilder indexBuilder,
             [CanBeNull] IReadOnlyList<string> values,
             bool fromDataAnnotation)
         {
-            if (indexBuilder.CanSetHasCollation(values, fromDataAnnotation))
+            if (indexBuilder.CanSetUseCollation(values, fromDataAnnotation))
             {
                 indexBuilder.Metadata.SetCollation(values, fromDataAnnotation);
 
@@ -365,14 +365,17 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="values">The sort options to use for each column.</param>
         /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
         /// <returns>A builder to further configure the index.</returns>
-        public static bool CanSetHasCollation(
+        public static bool CanSetUseCollation(
             [NotNull] this IConventionIndexBuilder indexBuilder,
             [CanBeNull] IReadOnlyList<string> values,
             bool fromDataAnnotation)
         {
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
-            return indexBuilder.CanSetAnnotation(NpgsqlAnnotationNames.IndexCollation, values, fromDataAnnotation);
+#pragma warning disable 618
+            return indexBuilder.CanSetAnnotation(RelationalAnnotationNames.Collation, values, fromDataAnnotation) &&
+                   indexBuilder.CanSetAnnotation(NpgsqlAnnotationNames.IndexCollation, values, fromDataAnnotation);
+#pragma warning restore 618
         }
 
         #endregion Collation
@@ -740,5 +743,73 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         #endregion Created concurrently
+
+        #region Obsolete
+
+        /// <summary>
+        /// The PostgreSQL index collation to be used.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-collations.html
+        /// </remarks>
+        /// <param name="indexBuilder">The builder for the index being configured.</param>
+        /// <param name="values">The sort options to use for each column.</param>
+        /// <returns>A builder to further configure the index.</returns>
+        [Obsolete("Use UseCollation")]
+        public static IndexBuilder HasCollation(
+            [NotNull] this IndexBuilder indexBuilder,
+            [CanBeNull] params string[] values)
+            => UseCollation(indexBuilder, values);
+
+        /// <summary>
+        /// The PostgreSQL index collation to be used.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-collations.html
+        /// </remarks>
+        /// <param name="indexBuilder">The builder for the index being configured.</param>
+        /// <param name="values">The sort options to use for each column.</param>
+        /// <returns>A builder to further configure the index.</returns>
+        [Obsolete("Use UseCollation")]
+        public static IndexBuilder<TEntity> HasCollation<TEntity>(
+            [NotNull] this IndexBuilder<TEntity> indexBuilder,
+            [CanBeNull] params string[] values)
+            => UseCollation(indexBuilder, values);
+
+        /// <summary>
+        /// The PostgreSQL index collation to be used.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-collations.html
+        /// </remarks>
+        /// <param name="indexBuilder">The builder for the index being configured.</param>
+        /// <param name="values">The sort options to use for each column.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns>A builder to further configure the index.</returns>
+        [Obsolete("Use UseCollation")]
+        public static IConventionIndexBuilder HasCollation(
+            [NotNull] this IConventionIndexBuilder indexBuilder,
+            [CanBeNull] IReadOnlyList<string> values,
+            bool fromDataAnnotation)
+            => UseCollation(indexBuilder, values, fromDataAnnotation);
+
+        /// <summary>
+        /// Returns a value indicating whether the PostgreSQL index collation can be set.
+        /// </summary>
+        /// <remarks>
+        /// https://www.postgresql.org/docs/current/static/indexes-collations.html
+        /// </remarks>
+        /// <param name="indexBuilder">The builder for the index being configured.</param>
+        /// <param name="values">The sort options to use for each column.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns>A builder to further configure the index.</returns>
+        [Obsolete("Use CanSetHasCollation")]
+        public static bool CanSetHasCollation(
+            [NotNull] this IConventionIndexBuilder indexBuilder,
+            [CanBeNull] IReadOnlyList<string> values,
+            bool fromDataAnnotation)
+            => CanSetUseCollation(indexBuilder, values, fromDataAnnotation);
+
+        #endregion Obsolete
     }
 }

--- a/src/EFCore.PG/Extensions/NpgsqlIndexExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlIndexExtensions.cs
@@ -85,8 +85,11 @@ namespace Microsoft.EntityFrameworkCore
         /// <remarks>
         /// https://www.postgresql.org/docs/current/static/indexes-collations.html
         /// </remarks>
+#pragma warning disable 618
         public static IReadOnlyList<string> GetCollation([NotNull] this IIndex index)
-            => (IReadOnlyList<string>)index[NpgsqlAnnotationNames.IndexCollation];
+            => (IReadOnlyList<string>)(
+                index[RelationalAnnotationNames.Collation] ?? index[NpgsqlAnnotationNames.IndexCollation]);
+#pragma warning restore 618
 
         /// <summary>
         /// Sets the column collations to be used, or <c>null</c> if they have not been specified.
@@ -95,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore
         /// https://www.postgresql.org/docs/current/static/indexes-collations.html
         /// </remarks>
         public static void SetCollation([NotNull] this IMutableIndex index, [CanBeNull] IReadOnlyList<string> collations)
-            => index.SetOrRemoveAnnotation(NpgsqlAnnotationNames.IndexCollation, collations);
+            => index.SetOrRemoveAnnotation(RelationalAnnotationNames.Collation, collations);
 
         /// <summary>
         /// Sets the column collations to be used, or <c>null</c> if they have not been specified.
@@ -104,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore
         /// https://www.postgresql.org/docs/current/static/indexes-collations.html
         /// </remarks>
         public static void SetCollation([NotNull] this IConventionIndex index, [CanBeNull] IReadOnlyList<string> collations, bool fromDataAnnotation)
-            => index.SetOrRemoveAnnotation(NpgsqlAnnotationNames.IndexCollation, collations, fromDataAnnotation);
+            => index.SetOrRemoveAnnotation(RelationalAnnotationNames.Collation, collations, fromDataAnnotation);
 
         #endregion Collation
 

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -11,7 +11,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string HiLoSequenceSchema = Prefix + "HiLoSequenceSchema";
         public const string IndexMethod = Prefix + "IndexMethod";
         public const string IndexOperators = Prefix + "IndexOperators";
-        public const string IndexCollation = Prefix + "IndexCollation";
         public const string IndexSortOrder = Prefix + "IndexSortOrder";
         public const string IndexNullSortOrder = Prefix + "IndexNullSortOrder";
         public const string IndexInclude = Prefix + "IndexInclude";
@@ -52,5 +51,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
 
         [Obsolete("Replaced by built-in EF Core support, use HasComment on entities or properties.")]
         public const string Comment = Prefix + "Comment";
+
+        [Obsolete("Replaced by RelationalAnnotationNames.Collation")]
+        public const string IndexCollation = Prefix + "IndexCollation";
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
@@ -73,12 +73,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
             // Model validation ensures that these facets are the same on all mapped indexes
             var modelIndex = index.MappedIndexes.First();
 
+            if (modelIndex.GetCollation() is IReadOnlyList<string> collation)
+                yield return new Annotation(RelationalAnnotationNames.Collation, collation);
+
             if (modelIndex.GetMethod() is string method)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexMethod, method);
             if (modelIndex.GetOperators() is IReadOnlyList<string> operators)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexOperators, operators);
-            if (modelIndex.GetCollation() is IReadOnlyList<string> collation)
-                yield return new Annotation(NpgsqlAnnotationNames.IndexCollation, collation);
             if (modelIndex.GetSortOrder() is IReadOnlyList<SortOrder> sortOrder)
                 yield return new Annotation(NpgsqlAnnotationNames.IndexSortOrder, sortOrder);
             if (modelIndex.GetNullSortOrder() is IReadOnlyList<SortOrder> nullSortOrder)

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -1658,8 +1658,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations
 
         static IndexColumn[] GetIndexColumns(CreateIndexOperation operation)
         {
+            var collations = operation[RelationalAnnotationNames.Collation] as string[];
+
             var operators = operation[NpgsqlAnnotationNames.IndexOperators] as string[];
-            var collations = operation[NpgsqlAnnotationNames.IndexCollation] as string[];
             var sortOrders = operation[NpgsqlAnnotationNames.IndexSortOrder] as SortOrder[];
             var nullSortOrders = operation[NpgsqlAnnotationNames.IndexNullSortOrder] as NullSortOrder[];
 

--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -604,7 +604,7 @@ WHERE
                             .ToArray();
 
                         if (columnCollations.Any(coll => coll != null))
-                            index[NpgsqlAnnotationNames.IndexCollation] = columnCollations;
+                            index[RelationalAnnotationNames.Collation] = columnCollations;
 
                         if (record.GetValueOrDefault<bool>("amcanorder"))
                         {

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -1637,10 +1637,10 @@ CREATE INDEX ix_without ON ""IndexCollation"" (a, b);",
                     var table = dbModel.Tables.Single();
 
                     var indexWith = table.Indexes.Single(i => i.Name == "ix_with");
-                    Assert.Equal(new[] { null, "POSIX" }, indexWith.FindAnnotation(NpgsqlAnnotationNames.IndexCollation).Value);
+                    Assert.Equal(new[] { null, "POSIX" }, indexWith.FindAnnotation(RelationalAnnotationNames.Collation).Value);
 
                     var indexWithout = table.Indexes.Single(i => i.Name == "ix_without");
-                    Assert.Null(indexWithout.FindAnnotation(NpgsqlAnnotationNames.IndexCollation));
+                    Assert.Null(indexWithout.FindAnnotation(RelationalAnnotationNames.Collation));
                 },
                 @"DROP TABLE ""IndexCollation""");
 

--- a/test/EFCore.PG.Tests/Migrations/NpgsqlMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.PG.Tests/Migrations/NpgsqlMigrationSqlGeneratorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
@@ -78,7 +79,7 @@ TABLESPACE ""MyTablespace"";
                 Table = "People",
                 Schema = "dbo",
                 Columns = new[] { "FirstName", "LastName" },
-                [NpgsqlAnnotationNames.IndexCollation] = new[] { null, "de_DE" }
+                [RelationalAnnotationNames.Collation] = new[] { null, "de_DE" }
             });
 
             AssertSql(


### PR DESCRIPTION
Support for index collation was added some time ago, using our own annotation. With collation support now integrated upstream, use that annotation instead.