### PR TITLE
Default column collations which propagate via EF

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelBuilderExtensions.cs
@@ -604,6 +604,89 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion Collation management
 
+        #region Default column collation
+
+        /// <summary>
+        /// Configures the default collation for all columns in the database. This causes EF Core to specify an explicit
+        /// collation when creating each column (unless overridden).
+        /// </summary>
+        /// <remarks>
+        /// <p>
+        /// An alternative is to specify a database collation via <see cref="RelationalModelBuilderExtensions.UseCollation(Microsoft.EntityFrameworkCore.ModelBuilder,string)"/>,
+        /// which will specify the query on <c>CREATE DATABASE</c> instead of for each and every column. However,
+        /// PostgreSQL support is limited for the collations that can be specific via this mechanism; ICU collations -
+        /// which include all case-insensitive collations - are currently unsupported.
+        /// </p>
+        /// <p>
+        /// For more information, see https://www.postgresql.org/docs/current/collation.html.
+        /// </p>
+        /// </remarks>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="collation">The collation.</param>
+        /// <returns>A builder to further configure the property.</returns>
+        public static ModelBuilder UseDefaultColumnCollation([NotNull] this ModelBuilder modelBuilder, [CanBeNull] string collation)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+            Check.NullButNotEmpty(collation, nameof(collation));
+
+            modelBuilder.Model.SetDefaultColumnCollation(collation);
+
+            return modelBuilder;
+        }
+
+        /// <summary>
+        /// Configures the default collation for all columns in the database. This causes EF Core to specify an explicit
+        /// collation when creating each column (unless overridden).
+        /// </summary>
+        /// <remarks>
+        /// <p>
+        /// An alternative is to specify a database collation via <see cref="RelationalModelBuilderExtensions.UseCollation(Microsoft.EntityFrameworkCore.ModelBuilder,string)"/>,
+        /// which will specify the query on <c>CREATE DATABASE</c> instead of for each and every column. However,
+        /// PostgreSQL support is limited for the collations that can be specific via this mechanism; ICU collations -
+        /// which include all case-insensitive collations - are currently unsupported.
+        /// </p>
+        /// <p>
+        /// For more information, see https://www.postgresql.org/docs/current/collation.html.
+        /// </p>
+        /// </remarks>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="collation">The collation.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns>A builder to further configure the property.</returns>
+        public static IConventionModelBuilder UseDefaultColumnCollation(
+            [NotNull] this IConventionModelBuilder modelBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            if (modelBuilder.CanSetDefaultColumnCollation(collation, fromDataAnnotation))
+            {
+                modelBuilder.Metadata.SetDefaultColumnCollation(collation);
+                return modelBuilder;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the given value can be set as the default column collation.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="collation">The collation.</param>
+        /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+        /// <returns><c>true</c> if the given value can be set as the collation.</returns>
+        public static bool CanSetDefaultColumnCollation(
+            [NotNull] this IConventionModelBuilder modelBuilder,
+            [CanBeNull] string collation,
+            bool fromDataAnnotation = false)
+        {
+            Check.NotNull(modelBuilder, nameof(modelBuilder));
+
+            return modelBuilder.CanSetAnnotation(
+                NpgsqlAnnotationNames.DefaultColumnCollation, collation, fromDataAnnotation);
+        }
+
+        #endregion Default column collation
+
         #region Helpers
 
         // See: https://github.com/npgsql/npgsql/blob/dev/src/Npgsql/TypeMapping/TypeMapperBase.cs#L132-L138

--- a/src/EFCore.PG/Extensions/NpgsqlModelExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlModelExtensions.cs
@@ -282,5 +282,71 @@ namespace Microsoft.EntityFrameworkCore
             => PostgresCollation.GetCollations(model).ToArray();
 
         #endregion Collation management
+
+        #region Default column collation
+
+        /// <summary>
+        /// Gets the default collation for all columns in the database, or <see langword="null" /> if none is defined.
+        /// This causes EF Core to specify an explicit collation when creating all column, unless one is overridden
+        /// on a column.
+        /// </summary>
+        /// <remarks>
+        /// <p>
+        /// See <see cref="RelationalModelExtensions.GetCollation" /> for another approach to defining a
+        /// database-wide collation.
+        /// </p>
+        /// <p>
+        /// For more information, see https://www.postgresql.org/docs/current/collation.html.
+        /// </p>
+        /// </remarks>
+        public static string GetDefaultColumnCollation([NotNull] this IModel model)
+            => (string)model[NpgsqlAnnotationNames.DefaultColumnCollation];
+
+        /// <summary>
+        /// Sets the default collation for all columns in the database, or <c>null</c> if none is defined.
+        /// This causes EF Core to specify an explicit collation when creating all column, unless one is overridden
+        /// on a column.
+        /// </summary>
+        /// <remarks>
+        /// <p>
+        /// See <see cref="RelationalModelExtensions.GetCollation" /> for another approach to defining a
+        /// database-wide collation.
+        /// </p>
+        /// <p>
+        /// For more information, see https://www.postgresql.org/docs/current/collation.html.
+        /// </p>
+        /// </remarks>
+        public static void SetDefaultColumnCollation([NotNull] this IMutableModel model, [CanBeNull] string collation)
+            => model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.DefaultColumnCollation, collation);
+
+        /// <summary>
+        /// Sets the default collation for all columns in the database, or <c>null</c> if none is defined.
+        /// This causes EF Core to specify an explicit collation when creating all column, unless one is overridden
+        /// on a column.
+        /// </summary>
+        /// <remarks>
+        /// <p>
+        /// See <see cref="RelationalModelExtensions.SetCollation(Microsoft.EntityFrameworkCore.Metadata.IMutableModel,string)" />
+        /// for another approach to defining a database-wide collation.
+        /// </p>
+        /// <p>
+        /// For more information, see https://www.postgresql.org/docs/current/collation.html.
+        /// </p>
+        /// </remarks>
+        public static string SetDefaultColumnCollation([NotNull] this IConventionModel model, [CanBeNull] string collation, bool fromDataAnnotation = false)
+        {
+            model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.DefaultColumnCollation, collation, fromDataAnnotation);
+            return collation;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="ConfigurationSource" /> for the default column collation.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <returns>The <see cref="ConfigurationSource" /> for the default column collation.</returns>
+        public static ConfigurationSource? GetDefaultColumnCollationConfigurationSource([NotNull] this IConventionModel model)
+            => model.FindAnnotation(NpgsqlAnnotationNames.DefaultColumnCollation)?.GetConfigurationSource();
+
+        #endregion Default column collation
     }
 }

--- a/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
@@ -667,5 +668,21 @@ namespace Microsoft.EntityFrameworkCore
             => property.FindAnnotation(NpgsqlAnnotationNames.TsVectorConfig)?.GetConfigurationSource();
 
         #endregion Generated tsvector column
+
+        #region Collation
+
+        /// <summary>
+        /// Returns the collation to be used for the column - including the PostgreSQL-specific default column
+        /// collation defined at the model level (see
+        /// <see cref="NpgsqlModelExtensions.SetDefaultColumnCollation(Microsoft.EntityFrameworkCore.Metadata.IMutableModel,string)"/>).
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The collation for the column this property is mapped to. </returns>
+        public static string GetDefaultCollation([NotNull] this IProperty property)
+            => property.FindTypeMapping() is StringTypeMapping
+                ? property.DeclaringEntityType.Model.GetDefaultColumnCollation()
+                : null;
+
+        #endregion Collation
     }
 }

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -26,6 +26,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string TsVectorConfig = Prefix + "TsVectorConfig";
         public const string TsVectorProperties = Prefix + "TsVectorProperties";
         public const string CollationDefinitionPrefix = Prefix + "CollationDefinition:";
+        public const string DefaultColumnCollation = Prefix + "DefaultColumnCollation";
 
         // Database model annotations
 


### PR DESCRIPTION
Since PostgreSQL CREATE DATABASE is limited for collations (no ICU), this allows users to specify a collation on the model which propagates to column creation.

Part of #406