### PR TITLE
Consider enums as integral types for value generation.

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlPropertyExtensions.cs
@@ -242,7 +242,7 @@ namespace Microsoft.EntityFrameworkCore
 
         static bool IsIntegerForValueGeneration(this Type type)
         {
-            type = type.UnwrapNullableType();
+            type = type.UnwrapNullableType().UnwrapEnumType();
             return type == typeof(int) || type == typeof(long) || type == typeof(short);
         }
 


### PR DESCRIPTION
This tiny code change makes it practical for numeric enums to be used as strongly-typed primary keys.

A strongly typed primary key is desirable as it prevents mixing up IDs from different entities. One very simple way of achieving this for a numeric PK is to use an empty enum type for the PK property. Consider this contrived example:

```csharp
public enum CustomerId : long { }

public class Customer {
   public CustomerId Id { get; private set; }
   ...
}
```

The Id property can now be configured as follows:

```csharp
var converter = new ValueConverter<CustomerId, long>(
    v => (long)v,
    v => (CustomerId)v,
    new ConverterMappingHints(valueGeneratorFactory: (p, t) => new TemporaryLongValueGenerator()));

modelBuilder
    .Entity<Customer>()
        .Property(e => e.Id)
            .UseIdentityByDefaultColumn()
            .HasConversion(converter);
```

And everything works fine.

Further discussion here: https://github.com/dotnet/efcore/issues/11970
