### PR TITLE
Basic scaffolding for CockroachDB

### DIFF
--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -186,8 +186,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Scaffolding.Internal
             var commandText = @"SELECT datcollate FROM pg_database WHERE datname=current_database()";
             using var command = new NpgsqlCommand(commandText, connection);
             using var reader = command.ExecuteReader();
-            reader.Read();
-            databaseModel.Collation = reader.GetString(0);
+            if (reader.Read())
+                databaseModel.Collation = reader.GetString(0);
         }
 
         /// <summary>


### PR DESCRIPTION
This unblocks EF Core scaffolding for CockroachDB database. It's mainly about skipping failures for certain non-essential database objects which CockroachDB does not have (e.g. collations), and is generally useful to make our scaffolding more resilient.

/cc @rafiss