### PR TITLE
Map hstore to ImmutableDictionary

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using NpgsqlTypes;
@@ -7,24 +10,24 @@ using NpgsqlTypes;
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
 {
     /// <summary>
-    /// The type mapping for the PostgreSQL hstore type.
+    /// The type mapping for the PostgreSQL hstore type. Supports both <see cref="Dictionary{TKey,TValue} "/>
+    /// and <see cref="ImmutableDictionary{TKey,TValue}" /> over strings.
     /// </summary>
     /// <remarks>
     /// See: https://www.postgresql.org/docs/current/static/hstore.html
     /// </remarks>
     public class NpgsqlHstoreTypeMapping : NpgsqlTypeMapping
     {
-        static readonly HstoreComparer ComparerInstance = new HstoreComparer();
+        static readonly HstoreMutableComparer MutableComparerInstance = new HstoreMutableComparer();
 
-        /// <summary>
-        /// Constructs an instance of the <see cref="NpgsqlHstoreTypeMapping"/> class.
-        /// </summary>
-        public NpgsqlHstoreTypeMapping()
+        public NpgsqlHstoreTypeMapping([NotNull] Type clrType)
             : base(
                 new RelationalTypeMappingParameters(
-                    new CoreTypeMappingParameters(typeof(Dictionary<string, string>), null, ComparerInstance),
-                    "hstore"
-                ), NpgsqlDbType.Hstore) {}
+                    new CoreTypeMappingParameters(clrType, comparer: GetComparer(clrType)),
+                    "hstore"),
+                NpgsqlDbType.Hstore)
+        {
+        }
 
         protected NpgsqlHstoreTypeMapping(RelationalTypeMappingParameters parameters)
             : base(parameters, NpgsqlDbType.Hstore) {}
@@ -35,7 +38,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
         protected override string GenerateNonNullSqlLiteral(object value)
         {
             var sb = new StringBuilder("HSTORE '");
-            foreach (var kv in (Dictionary<string, string>)value)
+            foreach (var kv in (IReadOnlyDictionary<string, string>)value)
             {
                 sb.Append('"');
                 sb.Append(kv.Key);   // TODO: Escape
@@ -56,19 +59,36 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             return sb.ToString();
         }
 
-        sealed class HstoreComparer : ValueComparer<Dictionary<string, string>>
+        static ValueComparer GetComparer(Type clrType)
         {
-            public HstoreComparer() : base(
+            if (clrType == typeof(Dictionary<string, string>))
+                return MutableComparerInstance;
+
+            if (clrType == typeof(ImmutableDictionary<string, string>))
+            {
+                // Because ImmutableDictionary is immutable, we can use the default value comparer, which doesn't
+                // clone for snapshot and just does reference comparison.
+                // We could compare contents here if the references are different, but that would penalize the 99% case
+                // where a different reference means different contents, which would only save a very rare database update.
+                return null;
+            }
+
+            throw new ArgumentException($"CLR type must be {nameof(Dictionary<string,string>)} or {nameof(ImmutableDictionary<string,string>)}");
+        }
+
+        sealed class HstoreMutableComparer : ValueComparer<Dictionary<string, string>>
+        {
+            public HstoreMutableComparer() : base(
                 (a, b) => Compare(a,b),
                 o => o.GetHashCode(),
                 o => o == null ? null : new Dictionary<string, string>(o))
             {}
 
-            static bool Compare(Dictionary<string, string> a, Dictionary<string, string> b)
+            static bool Compare(IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
             {
-                if (a == null)
-                    return b == null;
-                if (b == null)
+                if (a is null)
+                    return b is null;
+                if (b is null)
                     return false;
                 if (a.Count != b.Count)
                     return false;

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Net.NetworkInformation;
@@ -115,6 +116,7 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                         StringAsJsonb = @"{""a"": ""b""}",
                         StringAsJson = @"{""a"": ""b""}",
                         DictionaryAsHstore = new Dictionary<string, string> { { "a", "b" } },
+                        ImmutableDictionaryAsHstore = ImmutableDictionary<string, string>.Empty.Add("c", "d"),
                         NpgsqlRangeAsRange = new NpgsqlRange<int>(4, true, 8, false),
 
                         IntArrayAsIntArray= new[] { 2, 3 },
@@ -248,36 +250,39 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 var param30 = new Dictionary<string, string> { { "a", "b" } };
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.DictionaryAsHstore == param30));
 
-                var param31 = new NpgsqlRange<int>(4, true, 8, false);
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.NpgsqlRangeAsRange == param31));
+                var param31 = ImmutableDictionary<string, string>.Empty.Add("c", "d");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.ImmutableDictionaryAsHstore == param31));
 
-                var param32 = new[] { 2, 3 };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntArrayAsIntArray == param32));
+                var param32 = new NpgsqlRange<int>(4, true, 8, false);
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.NpgsqlRangeAsRange == param32));
 
-                var param33 = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressArrayAsMacaddrArray == param33));
+                var param33 = new[] { 2, 3 };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntArrayAsIntArray == param33));
 
-                // ReSharper disable once ConvertToConstant.Local
-                var param34 = (uint)int.MaxValue + 1;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsXid == param34));
-
-                var param35 = NpgsqlTsQuery.Parse("a & b");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchQuery == param35));
-
-                var param36 = NpgsqlTsVector.Parse("a b");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchVector == param36));
+                var param34 = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressArrayAsMacaddrArray == param34));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param37 = NpgsqlTsRankingNormalization.DivideByLength;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.RankingNormalization == param37));
+                var param35 = (uint)int.MaxValue + 1;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsXid == param35));
+
+                var param36 = NpgsqlTsQuery.Parse("a & b");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchQuery == param36));
+
+                var param37 = NpgsqlTsVector.Parse("a b");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchVector == param37));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param38 = 12724u;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Regconfig == param38));
+                var param38 = NpgsqlTsRankingNormalization.DivideByLength;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.RankingNormalization == param38));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param39 = Mood.Sad;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Mood == param39));
+                var param39 = 12724u;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Regconfig == param39));
+
+                // ReSharper disable once ConvertToConstant.Local
+                var param40 = Mood.Sad;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Mood == param40));
             }
         }
 
@@ -408,32 +413,35 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 Dictionary<string, string> param30 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.DictionaryAsHstore == param30));
 
-                NpgsqlRange<int>? param31 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlRangeAsRange == param31));
+                ImmutableDictionary<string, string> param31 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.ImmutableDictionaryAsHstore == param31));
 
-                int[] param32 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param32));
+                NpgsqlRange<int>? param32 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlRangeAsRange == param32));
 
-                PhysicalAddress[] param33 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param33));
+                int[] param33 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param33));
 
-                uint? param34 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param34));
+                PhysicalAddress[] param34 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param34));
 
-                NpgsqlTsQuery param35 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchQuery == param35));
+                uint? param35 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param35));
 
-                NpgsqlTsVector param36 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchVector == param36));
+                NpgsqlTsQuery param36 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchQuery == param36));
 
-                NpgsqlTsRankingNormalization? param37 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.RankingNormalization == param37));
+                NpgsqlTsVector param37 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchVector == param37));
 
-                uint? param38 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Regconfig == param38));
+                NpgsqlTsRankingNormalization? param38 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.RankingNormalization == param38));
 
-                Mood? param39 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Mood == param39));
+                uint? param39 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Regconfig == param39));
+
+                Mood? param40 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Mood == param40));
             }
         }
 
@@ -682,6 +690,7 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
             Assert.Null(entity.StringAsJsonb);
             Assert.Null(entity.StringAsJson);
             Assert.Null(entity.DictionaryAsHstore);
+            Assert.Null(entity.ImmutableDictionaryAsHstore);
             Assert.Null(entity.NpgsqlRangeAsRange);
 
             Assert.Null(entity.IntArrayAsIntArray);
@@ -1326,6 +1335,9 @@ FROM ""MappedDataTypes"" AS m");
 
             [Column(TypeName = "hstore")]
             public Dictionary<string, string> DictionaryAsHstore { get; set; }
+
+            [Column(TypeName = "hstore")]
+            public ImmutableDictionary<string, string> ImmutableDictionaryAsHstore { get; set; }
 
             [Column(TypeName = "int4range")]
             public NpgsqlRange<int>? NpgsqlRangeAsRange { get; set; }

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Text.Json;
@@ -308,7 +309,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
                 }));
 
         [Fact]
-        public void ValueComparer_hstore()
+        public void ValueComparer_hstore_as_Dictionary()
         {
             var source = new Dictionary<string, string>
             {
@@ -322,6 +323,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
             Assert.NotSame(source, snapshot);
             Assert.True(comparer.Equals(source, snapshot));
             snapshot.Remove("k1");
+            Assert.False(comparer.Equals(source, snapshot));
+        }
+
+        [Fact]
+        public void ValueComparer_hstore_as_ImmutableDictionary()
+        {
+            var source = ImmutableDictionary<string, string>.Empty
+                .Add("k1", "v1")
+                .Add("k2", "v2");
+
+            var comparer = Mapper.FindMapping(typeof(ImmutableDictionary<string, string>), "hstore").Comparer;
+            var snapshot = comparer.Snapshot(source);
+            Assert.Equal(source, snapshot);
+            Assert.True(comparer.Equals(source, snapshot));
+            source = source.Remove("k1");
             Assert.False(comparer.Equals(source, snapshot));
         }
 


### PR DESCRIPTION
Closes #1491
Replaces #1184

Note: this PR currently fails since the provider uses Npgsql 4.1, which doesn't yet have support for ImmutableDictionary (https://github.com/npgsql/npgsql/pull/2776). Once we take a dependency on a newer 5.0 preview everything should work.

/cc @Quogu