### PR TITLE
Add Unaccent extension for the stable version

### DIFF
--- a/EFCore.PG.sln
+++ b/EFCore.PG.sln
@@ -1,4 +1,4 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -29,6 +29,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.PG.Trigrams", "src\EFCore.PG.Trigrams\EFCore.PG.Trigrams.csproj", "{4DEDE46C-FABB-4AD3-A7DF-BF4A3AF00B06}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.PG.FuzzyStringMatch", "src\EFCore.PG.FuzzyStringMatch\EFCore.PG.FuzzyStringMatch.csproj", "{86525F23-3EB0-4B0D-9BBB-55FF247D4DD6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFCore.PG.Unaccent", "src\EFCore.PG.Unaccent\EFCore.PG.Unaccent.csproj", "{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -124,6 +126,18 @@ Global
 		{86525F23-3EB0-4B0D-9BBB-55FF247D4DD6}.Release|x64.Build.0 = Release|Any CPU
 		{86525F23-3EB0-4B0D-9BBB-55FF247D4DD6}.Release|x86.ActiveCfg = Release|Any CPU
 		{86525F23-3EB0-4B0D-9BBB-55FF247D4DD6}.Release|x86.Build.0 = Release|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Debug|x64.Build.0 = Debug|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Debug|x86.Build.0 = Debug|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Release|x64.ActiveCfg = Release|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Release|x64.Build.0 = Release|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Release|x86.ActiveCfg = Release|Any CPU
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -137,6 +151,7 @@ Global
 		{D7106D61-C7CA-4005-B31F-43281BB397AD} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{4DEDE46C-FABB-4AD3-A7DF-BF4A3AF00B06} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 		{86525F23-3EB0-4B0D-9BBB-55FF247D4DD6} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
+		{D62425A1-2BE4-4F6A-B8F4-14B0DA932441} = {8537E50E-CF7F-49CB-B4EF-3E2A1B11F050}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F4EAAE6D-758C-4184-9D8C-7113384B61A8}

--- a/src/EFCore.PG.Unaccent/EFCore.PG.Unaccent.csproj
+++ b/src/EFCore.PG.Unaccent/EFCore.PG.Unaccent.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Authors>Kevin Martin</Authors>
+    <Description>unaccent module support plugin for PostgreSQL/Npgsql Entity Framework Core provider.</Description>
+    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql;unaccent;diacritics</PackageTags>
+
+    <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.Unaccent</AssemblyName>
+    <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL.Unaccent</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EFCore.PG\EFCore.PG.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+
+    <Compile Include="..\Shared\*.cs" />
+
+    <None Include="build\**\*">
+      <Pack>True</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
+
+  </ItemGroup>
+
+</Project>
+

--- a/src/EFCore.PG.Unaccent/Extensions/NpgsqlUnaccentDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.PG.Unaccent/Extensions/NpgsqlUnaccentDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// unaccent module specific extension methods for <see cref="NpgsqlDbContextOptionsBuilder"/>.
+    /// </summary>
+    public static class NpgsqlUnaccentDbContextOptionsBuilderExtensions
+    {
+        /// <summary>
+        /// Enable unaccent module methods and operators.
+        /// </summary>
+        /// <param name="optionsBuilder">The build being used to configure Postgres.</param>
+        /// <returns>The options builder so that further configuration can be chained.</returns>
+        public static NpgsqlDbContextOptionsBuilder UseUnaccent(
+            this NpgsqlDbContextOptionsBuilder optionsBuilder)
+        {
+            var coreOptionsBuilder = ((IRelationalDbContextOptionsBuilderInfrastructure)optionsBuilder).OptionsBuilder;
+
+            var extension = coreOptionsBuilder.Options.FindExtension<NpgsqlUnaccentOptionsExtension>()
+                ?? new NpgsqlUnaccentOptionsExtension();
+
+            ((IDbContextOptionsBuilderInfrastructure)coreOptionsBuilder).AddOrUpdateExtension(extension);
+
+            return optionsBuilder;
+        }
+    }
+}

--- a/src/EFCore.PG.Unaccent/Extensions/NpgsqlUnaccentDbFunctionsExtensions.cs
+++ b/src/EFCore.PG.Unaccent/Extensions/NpgsqlUnaccentDbFunctionsExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class NpgsqlUnaccentDbFunctionsExtensions
+    {
+        /// <summary>
+        /// Returns a new string that removes diacriatics from characters in the given <paramref name="text" />.
+        /// </summary>
+        /// <remarks>
+        /// The method call is translated to <c>unaccent(regdictionary, text)</c>.
+        ///
+        /// See https://www.postgresql.org/docs/current/unaccent.html.
+        /// </remarks>
+        public static string Unaccent(this DbFunctions _, string regdictionary, string text) =>
+            throw new NotSupportedException();
+
+        /// <summary>
+        /// Returns a new string that removes diacriatics from characters in the given <paramref name="text" />.
+        /// </summary>
+        /// <remarks>
+        /// The method call is translated to <c>unaccent(regdictionary, text)</c>.
+        ///
+        /// See https://www.postgresql.org/docs/current/unaccent.html.
+        /// </remarks>
+        public static string Unaccent(this DbFunctions _, string text) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/EFCore.PG.Unaccent/Extensions/NpgsqlUnaccentServiceCollectionExtensions.cs
+++ b/src/EFCore.PG.Unaccent/Extensions/NpgsqlUnaccentServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// unaccent module extension methods for <see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class NpgsqlUnaccentServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the services required for pg_trgm support in the Npgsql provider for Entity Framework.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <returns>The same service collection so that multiple calls can be chained.</returns>
+        public static IServiceCollection AddEntityFrameworkNpgsqlUnaccent(
+            this IServiceCollection serviceCollection)
+        {
+            new EntityFrameworkRelationalServicesBuilder(serviceCollection)
+                .TryAddProviderSpecificServices(
+                    x => x.TryAddSingletonEnumerable<IMethodCallTranslatorPlugin, NpgsqlUnaccentMethodCallTranslatorPlugin>());
+
+            return serviceCollection;
+        }
+    }
+}

--- a/src/EFCore.PG.Unaccent/Infrastructure/Internal/NpgsqlUnaccentOptionsExtension.cs
+++ b/src/EFCore.PG.Unaccent/Infrastructure/Internal/NpgsqlUnaccentOptionsExtension.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal
+{
+    public class NpgsqlUnaccentOptionsExtension : IDbContextOptionsExtension
+    {
+        public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
+
+        public virtual void ApplyServices(IServiceCollection services) => services.AddEntityFrameworkNpgsqlUnaccent();
+
+        public virtual void Validate(IDbContextOptions options)
+        {
+            var internalServiceProvider = options.FindExtension<CoreOptionsExtension>()?.InternalServiceProvider;
+            if (internalServiceProvider != null)
+            {
+                using var scope = internalServiceProvider.CreateScope();
+                var plugins = scope.ServiceProvider.GetService<IEnumerable<IMethodCallTranslatorPlugin>>();
+                if (plugins is null || !plugins.Any(s => s is NpgsqlUnaccentMethodCallTranslatorPlugin))
+                {
+                    throw new InvalidOperationException($"{nameof(NpgsqlUnaccentDbContextOptionsBuilderExtensions.UseUnaccent)} requires {nameof(NpgsqlUnaccentServiceCollectionExtensions.AddEntityFrameworkNpgsqlUnaccent)} to be called on the internal service provider used.");
+                }
+            }
+        }
+
+        sealed class ExtensionInfo : DbContextOptionsExtensionInfo
+        {
+            public ExtensionInfo(IDbContextOptionsExtension extension)
+                : base(extension)
+            {
+            }
+
+            public override bool IsDatabaseProvider => false;
+
+            public override long GetServiceProviderHashCode() => 0;
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+                => debugInfo["Npgsql:" + nameof(NpgsqlUnaccentDbContextOptionsBuilderExtensions.UseUnaccent)] = "1";
+
+            public override string LogFragment => "using Unaccent ";
+        }
+    }
+}

--- a/src/EFCore.PG.Unaccent/Query/ExpressionTranslators/Internal/NpgsqlUnaccentMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.PG.Unaccent/Query/ExpressionTranslators/Internal/NpgsqlUnaccentMethodCallTranslatorPlugin.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
+{
+    public class NpgsqlUnaccentMethodCallTranslatorPlugin : IMethodCallTranslatorPlugin
+    {
+        public NpgsqlUnaccentMethodCallTranslatorPlugin(
+            IRelationalTypeMappingSource typeMappingSource,
+            ISqlExpressionFactory sqlExpressionFactory)
+            => Translators = new IMethodCallTranslator[]
+            {
+                new NpgsqlUnaccentMethodTranslator((NpgsqlSqlExpressionFactory) sqlExpressionFactory, typeMappingSource),
+            };
+
+        public virtual IEnumerable<IMethodCallTranslator> Translators { get; }
+    }
+}

--- a/src/EFCore.PG.Unaccent/Query/ExpressionTranslators/Internal/NpgsqlUnaccentMethodTranslator.cs
+++ b/src/EFCore.PG.Unaccent/Query/ExpressionTranslators/Internal/NpgsqlUnaccentMethodTranslator.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal
+{
+    public class NpgsqlUnaccentMethodTranslator : IMethodCallTranslator
+    {
+        static readonly Dictionary<MethodInfo, string> Functions = new Dictionary<MethodInfo, string>
+        {
+            [GetRuntimeMethod(nameof(NpgsqlUnaccentDbFunctionsExtensions.Unaccent), new[] { typeof(DbFunctions), typeof(string) })] = "unaccent",
+            [GetRuntimeMethod(nameof(NpgsqlUnaccentDbFunctionsExtensions.Unaccent), new[] { typeof(DbFunctions), typeof(string), typeof(string) })] = "unaccent",
+        };
+
+        static MethodInfo GetRuntimeMethod(string name, params Type[] parameters)
+            => typeof(NpgsqlUnaccentDbFunctionsExtensions).GetRuntimeMethod(name, parameters);
+
+        readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+        readonly RelationalTypeMapping _boolMapping;
+        readonly RelationalTypeMapping _floatMapping;
+
+        public NpgsqlUnaccentMethodTranslator(NpgsqlSqlExpressionFactory sqlExpressionFactory, IRelationalTypeMappingSource typeMappingSource)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+            _boolMapping = typeMappingSource.FindMapping(typeof(bool));
+            _floatMapping = typeMappingSource.FindMapping(typeof(float));
+        }
+
+#pragma warning disable EF1001
+        /// <inheritdoc />
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        {
+            if (Functions.TryGetValue(method, out var function))
+                return _sqlExpressionFactory.Function(function, arguments.Skip(1), method.ReturnType);
+
+            return null;
+        }
+#pragma warning restore EF1001
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/EFCore.PG.FunctionalTests.csproj
+++ b/test/EFCore.PG.FunctionalTests/EFCore.PG.FunctionalTests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\EFCore.PG.NTS\EFCore.PG.NTS.csproj" />
     <ProjectReference Include="..\..\src\EFCore.PG.Trigrams\EFCore.PG.Trigrams.csproj" />
     <ProjectReference Include="..\..\src\EFCore.PG.FuzzyStringMatch\EFCore.PG.FuzzyStringMatch.csproj" />
+    <ProjectReference Include="..\..\src\EFCore.PG.Unaccent\EFCore.PG.Unaccent.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EFCore.PG.FunctionalTests/Query/UnaccentQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UnaccentQueryNpgsqlTest.cs
@@ -1,0 +1,157 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities.Xunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
+{
+    /// <summary>
+    /// Provides unit tests for the pg_trgm module operator and function translations.
+    /// </summary>
+    /// <remarks>
+    /// See: https://www.postgresql.org/docs/current/pgtrgm.html
+    /// </remarks>
+    public class UnaccentQueryNpgsqlTest : IClassFixture<UnaccentQueryNpgsqlTest.UnaccentQueryNpgsqlFixture>
+    {
+        UnaccentQueryNpgsqlFixture Fixture { get; }
+
+        public UnaccentQueryNpgsqlTest(UnaccentQueryNpgsqlFixture fixture, ITestOutputHelper testOutputHelper)
+        {
+            Fixture = fixture;
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        #region FunctionTests
+
+        [Fact]
+        public void Unaccent()
+        {
+            using var context = CreateContext();
+            var _ = context.UnaccentTestEntities
+                .Select(x => EF.Functions.Unaccent(x.Text))
+                .ToArray();
+
+            AssertContainsSql(@"unaccent(u.""Text"")");
+        }
+
+        [Fact]
+        public void Unaccent_with_regdictionary()
+        {
+            using var context = CreateContext();
+            var _ = context.UnaccentTestEntities
+                .Select(x => EF.Functions.Unaccent("unaccent", x.Text))
+                .ToArray();
+
+            AssertContainsSql(@"unaccent('unaccent', u.""Text"")");
+        }
+
+        #endregion
+
+        #region Fixtures
+
+        /// <summary>
+        /// Represents a fixture suitable for testing unaccent operators.
+        /// </summary>
+        public class UnaccentQueryNpgsqlFixture : SharedStoreFixtureBase<UnaccentContext>
+        {
+            protected override string StoreName => "UnaccentQueryTest";
+
+            protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+                => base.AddServices(serviceCollection).AddEntityFrameworkNpgsqlUnaccent();
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            {
+                var optionsBuilder = base.AddOptions(builder);
+                new NpgsqlDbContextOptionsBuilder(optionsBuilder).UseUnaccent();
+
+                return optionsBuilder;
+            }
+
+            protected override ITestStoreFactory TestStoreFactory => NpgsqlTestStoreFactory.Instance;
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ListLoggerFactory;
+            protected override void Seed(UnaccentContext context) => UnaccentContext.Seed(context);
+        }
+
+        /// <summary>
+        /// Represents an entity suitable for testing unaccent operators.
+        /// </summary>
+        public class UnaccentTestEntity
+        {
+            // ReSharper disable once UnusedMember.Global
+            /// <summary>
+            /// The primary key.
+            /// </summary>
+            [Key]
+            public int Id { get; set; }
+
+            /// <summary>
+            /// Some text.
+            /// </summary>
+            public string Text { get; set; }
+        }
+
+        /// <summary>
+        /// Represents a database suitable for testing unaccent operators.
+        /// </summary>
+        public class UnaccentContext : PoolableDbContext
+        {
+            /// <summary>
+            /// Represents a set of entities with <see cref="string"/> properties.
+            /// </summary>
+            public DbSet<UnaccentTestEntity> UnaccentTestEntities { get; set; }
+
+            /// <summary>
+            /// Initializes a <see cref="UnaccentContext"/>.
+            /// </summary>
+            /// <param name="options">
+            /// The options to be used for configuration.
+            /// </param>
+            public UnaccentContext(DbContextOptions options) : base(options) {}
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.HasPostgresExtension("unaccent");
+
+                base.OnModelCreating(modelBuilder);
+            }
+
+            public static void Seed(UnaccentContext context)
+            {
+                for (var i = 1; i <= 9; i++)
+                {
+                    var text = "Some text " + i;
+                    context.UnaccentTestEntities.Add(
+                       new UnaccentTestEntity
+                       {
+                           Id = i,
+                           Text = text
+                       });
+                }
+                context.SaveChanges();
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        protected UnaccentContext CreateContext() => Fixture.CreateContext();
+
+        void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        /// <summary>
+        /// Asserts that the SQL fragment appears in the logs.
+        /// </summary>
+        /// <param name="sql">The SQL statement or fragment to search for in the logs.</param>
+        void AssertContainsSql(string sql) => Assert.Contains(sql, Fixture.TestSqlLoggerFactory.Sql);
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Note: I created a PR that targets the dev branch too (https://github.com/npgsql/efcore.pg/pull/1501).

This PR contains the necessary code to handle the ```unaccent``` extension of Postgres (https://www.postgresql.org/docs/current/unaccent.html)

Essentially, there is the ```UseUnaccent``` extension to register le extension and the db functions.
Also, I created a test class.

I created this code to map with the unaccent postgres extension as sometimes is really useful to compare strings without accents (or any diacritics).

Also, later on, it could be great to use it with a text search configuration or even using it when comparing string with CompareOptions.IgnoreNonSpace option