### PR TITLE
Exploratory work on custom aggregate methods

### DIFF
--- a/src/EFCore.PG/Extensions/NpgsqlDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlDbFunctionsExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -50,6 +52,12 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="value">The string that is to be reversed.</param>
         /// <returns>The reversed string.</returns>
         public static string Reverse([CanBeNull] this DbFunctions _, [CanBeNull] string value)
+            => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Reverse)));
+
+        public static string StringAggregate<TSource, TResult>(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] IEnumerable<TSource> source,
+            [NotNull] Expression<Func<TSource, TResult>> selector)
             => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Reverse)));
     }
 }

--- a/src/EFCore.PG/Extensions/NpgsqlQueryableExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlQueryableExtensions.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class NpgsqlQueryableExtensions
+    {
+        #region StringAggregate
+
+        internal static readonly MethodInfo StringAggregateWithoutSelectorMethod
+            = typeof(NpgsqlQueryableExtensions).GetTypeInfo().GetDeclaredMethods(nameof(StringAggregate))
+                .Single(m => m.GetParameters().Length == 2 && m.GetParameters()[1].ParameterType == typeof(string));
+
+        internal static readonly MethodInfo StringAggregateWithSelectorMethod
+            = typeof(NpgsqlQueryableExtensions).GetTypeInfo().GetDeclaredMethods(nameof(StringAggregate))
+                .Single(m => m.GetParameters().Length == 3);
+
+        /// <summary>
+        /// Concatenates the non-null input values into a string.
+        /// Each value after the first is preceded by the corresponding delimiter (if it's not null).
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</param>
+        /// <param name="delimiter">The delimiter for the concatenation. Defaults to empty string.</param>
+        /// <typeparam name="TSource">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</typeparam>
+        /// <returns>A task that represents the asynchronous operation. The task result contains sequence concatenation.</returns>
+        /// <remarks>
+        /// Calls PostgreSQL <c>string_agg</c>, see https://www.postgresql.org/docs/current/functions-aggregate.html.
+        /// </remarks>
+        public static string StringAggregate<TSource>([NotNull] this IQueryable<TSource> source, [CanBeNull] string delimiter = null)
+        {
+            Check.NotNull(source, nameof(source));
+
+            return source.Provider.Execute<string>(
+                    Expression.Call(
+                        instance: null,
+                        StringAggregateWithoutSelectorMethod.MakeGenericMethod(typeof(TSource)),
+                        source.Expression,
+                        Expression.Constant(delimiter ?? string.Empty)));
+        }
+
+        /// <summary>
+        /// Concatenates the non-null input values into a string.
+        /// Each value after the first is preceded by the corresponding delimiter (if it's not null).
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</param>
+        /// <param name="delimiter">The delimiter for the concatenation. Defaults to empty string.</param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <typeparam name="TSource">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</typeparam>
+        /// <typeparam name="TResult">
+        /// The type of the value returned by the function represented by <paramref name="selector" />.
+        /// </typeparam>
+        /// <returns>A task that represents the asynchronous operation. The task result contains sequence concatenation.</returns>
+        /// <remarks>
+        /// Calls PostgreSQL <c>string_agg</c>, see https://www.postgresql.org/docs/current/functions-aggregate.html.
+        /// </remarks>
+        public static string StringAggregate<TSource, TResult>(
+            [NotNull] this IQueryable<TSource> source,
+            [CanBeNull] string delimiter,
+            [NotNull] Expression<Func<TSource, TResult>> selector)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(selector, nameof(selector));
+
+            return source.Provider.Execute<string>(
+                    Expression.Call(
+                        instance: null,
+                        StringAggregateWithSelectorMethod.MakeGenericMethod(typeof(TSource), typeof(TResult)),
+                        source.Expression,
+                        Expression.Constant(delimiter ?? string.Empty),
+                        Expression.Quote(selector)));
+        }
+
+        /// <summary>
+        /// Concatenates the non-null input values into a string.
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <typeparam name="TSource">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</typeparam>
+        /// <typeparam name="TResult">
+        /// The type of the value returned by the function represented by <paramref name="selector" />.
+        /// </typeparam>
+        /// <returns>A task that represents the asynchronous operation. The task result contains sequence concatenation.</returns>
+        /// <remarks>
+        /// Calls PostgreSQL <c>string_agg</c>, see https://www.postgresql.org/docs/current/functions-aggregate.html.
+        /// </remarks>
+        public static string StringAggregate<TSource, TResult>(
+            [NotNull] this IQueryable<TSource> source,
+            [NotNull] Expression<Func<TSource, TResult>> selector)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(selector, nameof(selector));
+
+            return source.Provider.Execute<string>(
+                Expression.Call(
+                    instance: null,
+                    StringAggregateWithSelectorMethod.MakeGenericMethod(typeof(TSource), typeof(TResult)),
+                    source.Expression,
+                    Expression.Constant(string.Empty),
+                    Expression.Quote(selector)));
+        }
+
+        /// <summary>
+        /// Concatenates the non-null input values into a string.
+        /// Each value after the first is preceded by the corresponding delimiter (if it's not null).
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</param>
+        /// <param name="delimiter">The delimiter for the concatenation. Defaults to empty string.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <typeparam name="TSource">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</typeparam>
+        /// <returns>A task that represents the asynchronous operation. The task result contains sequence concatenation.</returns>
+        /// <remarks>
+        /// Calls PostgreSQL <c>string_agg</c>, see https://www.postgresql.org/docs/current/functions-aggregate.html.
+        /// </remarks>
+        public static Task<string> StringAggregateAsync<TSource>(
+            [NotNull] this IQueryable<TSource> source,
+            [CanBeNull] string delimiter = null,
+            CancellationToken cancellationToken = default)
+        {
+            Check.NotNull(source, nameof(source));
+
+            return ExecuteAsync<TSource, Task<string>>(
+                StringAggregateWithoutSelectorMethod,
+                source,
+                Expression.Constant(delimiter ?? string.Empty),
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Concatenates the non-null input values into a string.
+        /// Each value after the first is preceded by the corresponding delimiter (if it's not null).
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</param>
+        /// <param name="delimiter">The delimiter for the concatenation. Defaults to empty string.</param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <typeparam name="TSource">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</typeparam>
+        /// <typeparam name="TResult">
+        /// The type of the value returned by the function represented by <paramref name="selector" />.
+        /// </typeparam>
+        /// <returns>A task that represents the asynchronous operation. The task result contains sequence concatenation.</returns>
+        /// <remarks>
+        /// Calls PostgreSQL <c>string_agg</c>, see https://www.postgresql.org/docs/current/functions-aggregate.html.
+        /// </remarks>
+        public static Task<string> StringAggregateAsync<TSource, TResult>(
+            [NotNull] this IQueryable<TSource> source,
+            [CanBeNull] string delimiter,
+            [NotNull] Expression<Func<TSource, TResult>> selector,
+            CancellationToken cancellationToken = default)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(selector, nameof(selector));
+
+            return ExecuteAsync<TSource, Task<string>>(
+                StringAggregateWithSelectorMethod,
+                source,
+                Expression.Constant(delimiter ?? string.Empty),
+                Expression.Quote(selector),
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Concatenates the non-null input values into a string.
+        /// </summary>
+        /// <param name="source">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</param>
+        /// <param name="selector"> A projection function to apply to each element. </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <typeparam name="TSource">An <see cref="IQueryable{T}" /> that contains the elements to concatenate.</typeparam>
+        /// <typeparam name="TResult">
+        /// The type of the value returned by the function represented by <paramref name="selector" />.
+        /// </typeparam>
+        /// <returns>A task that represents the asynchronous operation. The task result contains sequence concatenation.</returns>
+        /// <remarks>
+        /// Calls PostgreSQL <c>string_agg</c>, see https://www.postgresql.org/docs/current/functions-aggregate.html.
+        /// </remarks>
+        public static Task<string> StringAggregateAsync<TSource, TResult>(
+            [NotNull] this IQueryable<TSource> source,
+            [NotNull] Expression<Func<TSource, TResult>> selector,
+            CancellationToken cancellationToken = default)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(selector, nameof(selector));
+
+            return ExecuteAsync<TSource, Task<string>>(
+                StringAggregateWithSelectorMethod,
+                source,
+                Expression.Constant(string.Empty),
+                Expression.Quote(selector),
+                cancellationToken);
+        }
+
+        #endregion StringAggregate
+
+        #region Impl.
+
+        // Copied from EntityFrameworkQueryableExtensions
+
+        static TResult ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            Expression arg1,
+            CancellationToken cancellationToken = default)
+        {
+            if (source.Provider is IAsyncQueryProvider provider)
+            {
+                if (operatorMethodInfo.IsGenericMethod)
+                {
+                    operatorMethodInfo
+                        = operatorMethodInfo.GetGenericArguments().Length == 2
+                            ? operatorMethodInfo.MakeGenericMethod(typeof(TSource), typeof(TResult).GetGenericArguments().Single())
+                            : operatorMethodInfo.MakeGenericMethod(typeof(TSource));
+                }
+
+                return provider.ExecuteAsync<TResult>(
+                    Expression.Call(instance: null, operatorMethodInfo, source.Expression, arg1),
+                    cancellationToken);
+            }
+
+            throw new InvalidOperationException(CoreStrings.IQueryableProviderNotAsync);
+        }
+
+        static TResult ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            Expression arg1,
+            Expression arg2,
+            CancellationToken cancellationToken = default)
+        {
+            if (source.Provider is IAsyncQueryProvider provider)
+            {
+                if (operatorMethodInfo.IsGenericMethod)
+                {
+                    operatorMethodInfo
+                        = operatorMethodInfo.GetGenericArguments().Length == 2
+                            ? operatorMethodInfo.MakeGenericMethod(typeof(TSource), typeof(TResult).GetGenericArguments().Single())
+                            : operatorMethodInfo.MakeGenericMethod(typeof(TSource));
+                }
+
+                return provider.ExecuteAsync<TResult>(
+                    Expression.Call(instance: null, operatorMethodInfo, source.Expression, arg1, arg2),
+                    cancellationToken);
+            }
+
+            throw new InvalidOperationException(CoreStrings.IQueryableProviderNotAsync);
+        }
+
+        #endregion
+    }
+}

--- a/src/EFCore.PG/Extensions/NpgsqlServiceCollectionExtensions.cs
+++ b/src/EFCore.PG/Extensions/NpgsqlServiceCollectionExtensions.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     .TryAdd<IMemberTranslatorProvider, NpgsqlMemberTranslatorProvider>()
                     .TryAdd<IEvaluatableExpressionFilter, NpgsqlEvaluatableExpressionFilter>()
                     .TryAdd<IQuerySqlGeneratorFactory, NpgsqlQuerySqlGeneratorFactory>()
+                    .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, NpgsqlQueryableMethodTranslatingExpressionVisitorFactory>()
                     .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, NpgsqlSqlTranslatingExpressionVisitorFactory>()
                     .TryAdd<IRelationalParameterBasedSqlProcessorFactory, NpgsqlParameterBasedSqlProcessorFactory>()
                     .TryAdd<ISqlExpressionFactory, NpgsqlSqlExpressionFactory>()

--- a/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
+{
+    public class NpgsqlQueryableMethodTranslatingExpressionVisitor : RelationalQueryableMethodTranslatingExpressionVisitor
+    {
+        readonly NpgsqlSqlTranslatingExpressionVisitor _sqlTranslator;
+
+        public NpgsqlQueryableMethodTranslatingExpressionVisitor(
+            [NotNull] QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
+            [NotNull] RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies,
+            [NotNull] QueryCompilationContext queryCompilationContext)
+            : base(dependencies, relationalDependencies, queryCompilationContext)
+        {
+            _sqlTranslator = (NpgsqlSqlTranslatingExpressionVisitor)
+                relationalDependencies.RelationalSqlTranslatingExpressionVisitorFactory.Create(queryCompilationContext, this);
+        }
+
+        protected NpgsqlQueryableMethodTranslatingExpressionVisitor(
+            [NotNull] RelationalQueryableMethodTranslatingExpressionVisitor parentVisitor)
+            : base(parentVisitor)
+        {
+        }
+
+        protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
+            => new NpgsqlQueryableMethodTranslatingExpressionVisitor(this);
+
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            Check.NotNull(methodCallExpression, nameof(methodCallExpression));
+
+            ShapedQueryExpression CheckTranslated(ShapedQueryExpression translated)
+            {
+                return translated
+                       ?? throw new InvalidOperationException(
+                           TranslationErrorDetails == null
+                               ? CoreStrings.TranslationFailed(methodCallExpression.Print())
+                               : CoreStrings.TranslationFailedWithDetails(
+                                   methodCallExpression.Print(),
+                                   TranslationErrorDetails));
+            }
+
+            var method = methodCallExpression.Method;
+            if (method.DeclaringType == typeof(NpgsqlQueryableExtensions))
+            {
+                var source = Visit(methodCallExpression.Arguments[0]);
+                if (source is ShapedQueryExpression shapedQueryExpression)
+                {
+                    var genericMethod = method.IsGenericMethod ? method.GetGenericMethodDefinition() : null;
+                    switch (method.Name)
+                    {
+                        case nameof(NpgsqlQueryableExtensions.StringAggregate)
+                            when genericMethod == NpgsqlQueryableExtensions.StringAggregateWithoutSelectorMethod:
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
+                            return CheckTranslated(
+                                TranslateStringAggregate(shapedQueryExpression, methodCallExpression.Arguments[1], selector: null));
+
+                        case nameof(NpgsqlQueryableExtensions.StringAggregate)
+                            when genericMethod == NpgsqlQueryableExtensions.StringAggregateWithSelectorMethod:
+                            shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(ResultCardinality.Single);
+                            return CheckTranslated(
+                                TranslateStringAggregate(
+                                    shapedQueryExpression,
+                                    methodCallExpression.Arguments[1],
+                                    selector: GetLambdaExpressionFromArgument(2)));
+
+                    }
+
+                    LambdaExpression GetLambdaExpressionFromArgument(int argumentIndex)
+                        => methodCallExpression.Arguments[argumentIndex].UnwrapLambdaFromQuote();
+                }
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        // Copied from RelationalQueryableMethodTranslatingExpressionVisitor.TranslateMax
+        protected virtual ShapedQueryExpression TranslateStringAggregate(
+            ShapedQueryExpression source, Expression delimiter, LambdaExpression selector)
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotNull(delimiter, nameof(delimiter));
+
+            var delimiterTranslation = TranslateExpression(delimiter);
+            if (delimiterTranslation is null)
+            {
+                return null;
+            }
+
+            var selectExpression = (SelectExpression)source.QueryExpression;
+            selectExpression.PrepareForAggregate();
+            HandleGroupByForAggregate(selectExpression);
+
+            var newSelector = selector == null
+                              || selector.Body == selector.Parameters[0]
+                ? selectExpression.Projection.Count == 0
+                    ? selectExpression.GetMappedProjection(new ProjectionMember())
+                    : null
+                : RemapLambdaBody(source, selector);
+
+            if (newSelector == null)
+            {
+                return null;
+            }
+
+            var translatedSelector = TranslateExpression(newSelector);
+            if (translatedSelector == null)
+            {
+                return null;
+            }
+
+            var projection = _sqlTranslator.TranslateStringAggregate(translatedSelector, delimiterTranslation);
+
+            return AggregateResultShaper(source, projection, throwWhenEmpty: true, typeof(string));
+        }
+
+        #region Copied from RelationalQueryableMethodTranslatingExpressionVisitor
+
+        static void HandleGroupByForAggregate(SelectExpression selectExpression, bool eraseProjection = false)
+        {
+            if (selectExpression.GroupBy.Count > 0)
+            {
+                if (eraseProjection)
+                {
+                    selectExpression.ReplaceProjectionMapping(new Dictionary<ProjectionMember, Expression>());
+                    selectExpression.AddToProjection(selectExpression.GroupBy[0]);
+                    selectExpression.PushdownIntoSubquery();
+                    selectExpression.ClearProjection();
+                }
+                else
+                {
+                    selectExpression.PushdownIntoSubquery();
+                }
+            }
+        }
+
+        Expression RemapLambdaBody(ShapedQueryExpression shapedQueryExpression, LambdaExpression lambdaExpression)
+        {
+            var lambdaBody = ReplacingExpressionVisitor.Replace(
+                lambdaExpression.Parameters.Single(), shapedQueryExpression.ShaperExpression, lambdaExpression.Body);
+
+            // TODO: Can't duplicate WeakEntityExpandingExpressionVisitor (ColumnExpression ctors are internal)
+            // return ExpandWeakEntities((SelectExpression)shapedQueryExpression.QueryExpression, lambdaBody);
+
+            return lambdaBody;
+        }
+
+        SqlExpression TranslateExpression(Expression expression)
+        {
+            var translation = _sqlTranslator.Translate(expression);
+            if (translation == null && _sqlTranslator.TranslationErrorDetails != null)
+            {
+                AddTranslationErrorDetails(_sqlTranslator.TranslationErrorDetails);
+            }
+
+            return translation;
+        }
+
+        ShapedQueryExpression AggregateResultShaper(
+            ShapedQueryExpression source,
+            Expression projection,
+            bool throwWhenEmpty,
+            Type resultType)
+        {
+            if (projection == null)
+            {
+                return null;
+            }
+
+            var selectExpression = (SelectExpression)source.QueryExpression;
+            selectExpression.ReplaceProjectionMapping(
+                new Dictionary<ProjectionMember, Expression> { { new ProjectionMember(), projection } });
+
+            selectExpression.ClearOrdering();
+            Expression shaper;
+
+            if (throwWhenEmpty)
+            {
+                // Avg/Max/Min case.
+                // We always read nullable value
+                // If resultType is nullable then we always return null. Only non-null result shows throwing behavior.
+                // otherwise, if projection.Type is nullable then server result is passed through DefaultIfEmpty, hence we return default
+                // otherwise, server would return null only if it is empty, and we throw
+                var nullableResultType = resultType.MakeNullable();
+                shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), nullableResultType);
+                var resultVariable = Expression.Variable(nullableResultType, "result");
+                var returnValueForNull = resultType.IsNullableType()
+                    ? Expression.Constant(null, resultType)
+                    : projection.Type.IsNullableType()
+                        ? (Expression)Expression.Default(resultType)
+                        : Expression.Throw(
+                            Expression.New(
+                                typeof(InvalidOperationException).GetConstructors()
+                                    .Single(ci => ci.GetParameters().Length == 1),
+                                Expression.Constant(CoreStrings.SequenceContainsNoElements)),
+                            resultType);
+
+                shaper = Expression.Block(
+                    new[] { resultVariable },
+                    Expression.Assign(resultVariable, shaper),
+                    Expression.Condition(
+                        Expression.Equal(resultVariable, Expression.Default(nullableResultType)),
+                        returnValueForNull,
+                        resultType != resultVariable.Type
+                            ? Expression.Convert(resultVariable, resultType)
+                            : (Expression)resultVariable));
+            }
+            else
+            {
+                // Sum case. Projection is always non-null. We read nullable value.
+                shaper = new ProjectionBindingExpression(source.QueryExpression, new ProjectionMember(), projection.Type.MakeNullable());
+
+                if (resultType != shaper.Type)
+                {
+                    shaper = Expression.Convert(shaper, resultType);
+                }
+            }
+
+            return source.UpdateShaperExpression(shaper);
+        }
+
+        #endregion
+    }
+}

--- a/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitorFactory.cs
@@ -1,0 +1,30 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
+{
+    public class NpgsqlQueryableMethodTranslatingExpressionVisitorFactory : IQueryableMethodTranslatingExpressionVisitorFactory
+    {
+        readonly QueryableMethodTranslatingExpressionVisitorDependencies _dependencies;
+        readonly RelationalQueryableMethodTranslatingExpressionVisitorDependencies _relationalDependencies;
+
+        public NpgsqlQueryableMethodTranslatingExpressionVisitorFactory(
+            [NotNull] QueryableMethodTranslatingExpressionVisitorDependencies dependencies,
+            [NotNull] RelationalQueryableMethodTranslatingExpressionVisitorDependencies relationalDependencies)
+        {
+            Check.NotNull(dependencies, nameof(dependencies));
+            Check.NotNull(relationalDependencies, nameof(relationalDependencies));
+
+            _dependencies = dependencies;
+            _relationalDependencies = relationalDependencies;
+        }
+
+        public virtual QueryableMethodTranslatingExpressionVisitor Create(QueryCompilationContext queryCompilationContext)
+        {
+            Check.NotNull(queryCompilationContext, nameof(queryCompilationContext));
+
+            return new NpgsqlQueryableMethodTranslatingExpressionVisitor(_dependencies, _relationalDependencies, queryCompilationContext);
+        }
+    }
+}

--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
@@ -119,6 +119,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
                 sqlExpression.TypeMapping);
         }
 
+        public virtual SqlExpression TranslateStringAggregate(SqlExpression sqlExpression, SqlExpression delimiterExpression)
+        {
+            Check.NotNull(sqlExpression, nameof(sqlExpression));
+
+            return sqlExpression is null
+                ? null
+                : _sqlExpressionFactory.Function(
+                    "string_agg",
+                    new[] { sqlExpression, delimiterExpression },
+                    nullable: true,
+                    argumentsPropagateNullability: TrueArrays[1],
+                    sqlExpression.Type,
+                    sqlExpression.TypeMapping);
+        }
+
         /// <inheritdoc />
         protected override Expression VisitUnary(UnaryExpression unaryExpression)
         {

--- a/src/EFCore.PG/Utilities/InternalExpressionExtensions.cs
+++ b/src/EFCore.PG/Utilities/InternalExpressionExtensions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+// ReSharper disable once CheckNamespace
+namespace System.Linq.Expressions
+{
+    [DebuggerStepThrough]
+    internal static class InternalExpressionExtensions
+    {
+        public static bool IsNullConstantExpression([NotNull] this Expression expression)
+            => RemoveConvert(expression) is ConstantExpression constantExpression
+                && constantExpression.Value == null;
+
+        public static LambdaExpression UnwrapLambdaFromQuote(this Expression expression)
+            => (LambdaExpression)(expression is UnaryExpression unary && expression.NodeType == ExpressionType.Quote
+                ? unary.Operand
+                : expression);
+
+        public static Expression UnwrapTypeConversion(this Expression expression, out Type convertedType)
+        {
+            convertedType = null;
+            while (expression is UnaryExpression unaryExpression
+                && (unaryExpression.NodeType == ExpressionType.Convert
+                    || unaryExpression.NodeType == ExpressionType.ConvertChecked
+                    || unaryExpression.NodeType == ExpressionType.TypeAs))
+            {
+                expression = unaryExpression.Operand;
+                if (unaryExpression.Type != typeof(object) // Ignore object conversion
+                    && !unaryExpression.Type.IsAssignableFrom(expression.Type)) // Ignore casting to base type/interface
+                {
+                    convertedType = unaryExpression.Type;
+                }
+            }
+
+            return expression;
+        }
+
+        private static Expression RemoveConvert(Expression expression)
+        {
+            if (expression is UnaryExpression unaryExpression
+                && (expression.NodeType == ExpressionType.Convert
+                    || expression.NodeType == ExpressionType.ConvertChecked))
+            {
+                return RemoveConvert(unaryExpression.Operand);
+            }
+
+            return expression;
+        }
+    }
+}


### PR DESCRIPTION
Following discussion in https://github.com/dotnet/efcore/issues/13278, I attempted to translate [string_agg](https://www.postgresql.org/docs/current/functions-aggregate.html), which is a PostgreSQL-specific aggregate function that reduces a set of values to a single string (concatenation). There are some other similar functions.

I did successfully managed to translate top-level (IQueryable) invocations, which is really cool. However, the current query pipeline doesn't seem to allow custom functions [in the GroupBy aggregate case](https://github.com/dotnet/efcore/blob/170625d82b78e270046ba16ab30f8ae942c19e88/src/EFCore.Relational/Query/RelationalSqlTranslatingExpressionVisitor.cs#L471) (e.g. GroupingElementExpression is private). Assuming we want to fully support arbitrary aggregate functions, we can use this to understand what's needed.

/cc @smitpatel @ajcvickers