### PR TITLE
Test that BCL Types work with NodaTime plugin activated

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <EFCoreVersion>5.0.0-rc.1.20451.13</EFCoreVersion>
     <MicrosoftExtensionsVersion>5.0.0-rc.1.20451.14</MicrosoftExtensionsVersion>
-    <NpgsqlVersion>5.0.0-ci.20201003T171056</NpgsqlVersion>
+    <NpgsqlVersion>5.0.0-ci.20201017T090100</NpgsqlVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -1,31 +1,28 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Net.NetworkInformation;
-using Xunit;
-using Xunit.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 using NpgsqlTypes;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
-    public class BuiltInDataTypesNpgsqlTest : BuiltInDataTypesTestBase<BuiltInDataTypesNpgsqlTest.BuiltInDataTypesNpgsqlFixture>
+    public abstract class BuiltInDataTypesNpgsqlTestBase<TFixture> : BuiltInDataTypesTestBase<TFixture>
+        where TFixture : BuiltInDataTypesNpgsqlTestBase<TFixture>.BuiltInDataTypesNpgsqlTestBaseFixture, new()
     {
-        // ReSharper disable once UnusedParameter.Local
-        public BuiltInDataTypesNpgsqlTest(BuiltInDataTypesNpgsqlFixture fixture, ITestOutputHelper testOutputHelper)
-            : base(fixture)
+        protected BuiltInDataTypesNpgsqlTestBase(TFixture fixture) : base(fixture)
         {
-            Fixture.TestSqlLoggerFactory.Clear();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [Fact]
@@ -119,8 +116,8 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                         ImmutableDictionaryAsHstore = ImmutableDictionary<string, string>.Empty.Add("c", "d"),
                         NpgsqlRangeAsRange = new NpgsqlRange<int>(4, true, 8, false),
 
-                        IntArrayAsIntArray= new[] { 2, 3 },
-                        PhysicalAddressArrayAsMacaddrArray= new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") },
+                        IntArrayAsIntArray = new[] { 2, 3 },
+                        PhysicalAddressArrayAsMacaddrArray = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") },
 
                         UintAsXid = (uint)int.MaxValue + 1,
 
@@ -423,7 +420,7 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param33));
 
                 PhysicalAddress[] param34 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param34));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray == param34));
 
                 uint? param35 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param35));
@@ -705,11 +702,11 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
             Assert.Null(entity.Mood);
         }
 
-        [Fact(Skip="https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
-        public override void Can_query_using_any_data_type_nullable_shadow() {}
+        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
+        public override void Can_query_using_any_data_type_nullable_shadow() { }
 
-        [Fact(Skip="https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
-        public override void Can_query_using_any_data_type_shadow() {}
+        [Fact(Skip = "https://github.com/aspnet/EntityFrameworkCore/issues/14159")]
+        public override void Can_query_using_any_data_type_shadow() { }
 
         public override void Can_query_with_null_parameters_using_any_nullable_data_type()
         {
@@ -915,7 +912,7 @@ FROM ""MappedDataTypes"" AS m");
         void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 
-        public class BuiltInDataTypesNpgsqlFixture : BuiltInDataTypesFixtureBase
+        public class BuiltInDataTypesNpgsqlTestBaseFixture : BuiltInDataTypesFixtureBase
         {
             public override bool StrictEquality => false;
 
@@ -1359,6 +1356,21 @@ FROM ""MappedDataTypes"" AS m");
             [Column(TypeName = "mood")]
             public Mood? Mood { get; set; }
         }
+    }
+
+
+    public class BuiltInDataTypesNpgsqlTest : BuiltInDataTypesNpgsqlTestBase<BuiltInDataTypesNpgsqlTest.BuiltInDataTypesNpgsqlFixture>
+    {
+        // ReSharper disable once UnusedParameter.Local
+        public BuiltInDataTypesNpgsqlTest(BuiltInDataTypesNpgsqlFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public class BuiltInDataTypesNpgsqlFixture : BuiltInDataTypesNpgsqlTestBaseFixture
+        { }
     }
 
     // ReSharper disable once UnusedMember.Global

--- a/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
@@ -6,7 +6,8 @@ using Xunit.Abstractions;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
-    public class BuiltInDataTypesWithNodaTimePluginEnabledTest : BuiltInDataTypesNpgsqlTest, IClassFixture<BuiltInDataTypesWithNodaTimePluginEnabledTest.BuiltInDataTypesWithNodaTimePluginEnabledFixture>
+    public class BuiltInDataTypesWithNodaTimePluginEnabledTest : BuiltInDataTypesNpgsqlTest,
+        IClassFixture<BuiltInDataTypesWithNodaTimePluginEnabledTest.BuiltInDataTypesWithNodaTimePluginEnabledFixture>
     {
         public BuiltInDataTypesWithNodaTimePluginEnabledTest(BuiltInDataTypesWithNodaTimePluginEnabledFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture, testOutputHelper)

--- a/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL
+{
+    public class BuiltInDataTypesWithNodaTimePluginEnabledTest : BuiltInDataTypesNpgsqlTest, IClassFixture<BuiltInDataTypesWithNodaTimePluginEnabledTest.BuiltInDataTypesWithNodaTimePluginEnabledFixture>
+    {
+        public BuiltInDataTypesWithNodaTimePluginEnabledTest(BuiltInDataTypesWithNodaTimePluginEnabledFixture fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture, testOutputHelper)
+        { }
+
+        public class BuiltInDataTypesWithNodaTimePluginEnabledFixture : BuiltInDataTypesNpgsqlFixture
+        {
+            protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+                => base.AddServices(serviceCollection).AddEntityFrameworkNpgsqlNodaTime();
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            {
+                var optionsBuilder = base.AddOptions(builder);
+                new NpgsqlDbContextOptionsBuilder(optionsBuilder).UseNodaTime();
+
+                return optionsBuilder;
+            }
+        }
+    }
+}

--- a/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
@@ -8,10 +8,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
     public class BuiltInDataTypesWithNodaTimePluginEnabledTest : BuiltInDataTypesNpgsqlTestBase<BuiltInDataTypesWithNodaTimePluginEnabledTest.BuiltInDataTypesWithNodaTimePluginEnabledFixture>
     {
         public BuiltInDataTypesWithNodaTimePluginEnabledTest(BuiltInDataTypesWithNodaTimePluginEnabledFixture fixture)
-            : base(fixture)
-        {
-            Fixture.TestSqlLoggerFactory.Clear();
-        }
+            : base(fixture) => Fixture.TestSqlLoggerFactory.Clear();
 
         public class BuiltInDataTypesWithNodaTimePluginEnabledFixture : BuiltInDataTypesNpgsqlTestBaseFixture
         {

--- a/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/BuiltInDataTypesWithNodaTimePluginEnabledTest.cs
@@ -1,20 +1,22 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
-using Xunit;
-using Xunit.Abstractions;
+using static Npgsql.EntityFrameworkCore.PostgreSQL.NodaTimeTest;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL
 {
-    public class BuiltInDataTypesWithNodaTimePluginEnabledTest : BuiltInDataTypesNpgsqlTest,
-        IClassFixture<BuiltInDataTypesWithNodaTimePluginEnabledTest.BuiltInDataTypesWithNodaTimePluginEnabledFixture>
+    public class BuiltInDataTypesWithNodaTimePluginEnabledTest : BuiltInDataTypesNpgsqlTestBase<BuiltInDataTypesWithNodaTimePluginEnabledTest.BuiltInDataTypesWithNodaTimePluginEnabledFixture>
     {
-        public BuiltInDataTypesWithNodaTimePluginEnabledTest(BuiltInDataTypesWithNodaTimePluginEnabledFixture fixture, ITestOutputHelper testOutputHelper)
-            : base(fixture, testOutputHelper)
-        { }
-
-        public class BuiltInDataTypesWithNodaTimePluginEnabledFixture : BuiltInDataTypesNpgsqlFixture
+        public BuiltInDataTypesWithNodaTimePluginEnabledTest(BuiltInDataTypesWithNodaTimePluginEnabledFixture fixture)
+            : base(fixture)
         {
+            Fixture.TestSqlLoggerFactory.Clear();
+        }
+
+        public class BuiltInDataTypesWithNodaTimePluginEnabledFixture : BuiltInDataTypesNpgsqlTestBaseFixture
+        {
+            protected override string StoreName => "BuiltInDataTypesWithNodaTimeEnabled";
+
             protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
                 => base.AddServices(serviceCollection).AddEntityFrameworkNpgsqlNodaTime();
 
@@ -24,6 +26,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL
                 new NpgsqlDbContextOptionsBuilder(optionsBuilder).UseNodaTime();
 
                 return optionsBuilder;
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                base.OnModelCreating(modelBuilder, context);
+                modelBuilder.Entity<NodaTimeTypes>();
             }
         }
     }


### PR DESCRIPTION
Run BuiltInDataTypesNpgsqlTest again with the NodaTime plugin activated to verify that all BCL date/time types are properly supported.

Closes #1490