### PR TITLE
Add rich code navigation specific pipeline 

### DIFF
--- a/.github/workflows/richnav.yml
+++ b/.github/workflows/richnav.yml
@@ -1,0 +1,30 @@
+name: Rich Navigation Indexing
+
+on: [push, pull_request]
+
+env:
+  postgis_version: 3
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build:
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.dotnet_sdk_version }}
+
+      - name: Build
+        run: dotnet build --configuration Debug
+        shell: bash
+
+      - name: Rich Navigation Indexing
+        uses: microsoft/RichCodeNavigationIndexer@v0.1
+        with:
+          repo-token: ${{ github.token }}
+          languages: csharp

--- a/.github/workflows/richnav.yml
+++ b/.github/workflows/richnav.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
 
       - name: Rich Navigation Indexing
-        uses: microsoft/RichCodeNavigationIndexer@v0.1
+        uses: microsoft/RichCodeNavIndexer@v0.1
         with:
           repo-token: ${{ github.token }}
           languages: csharp


### PR DESCRIPTION
I've added a Rich Navigation specific build (which will appear as a new GitHub workflow), indexing on every push. This will allow you to use Rich Navigation in Visual Studio to enable cross-repository searches, serverless navigation at https://online.visualstudio.com/github/dotnet/msbuild, and integrated GitHub C# navigation once that is released. It also indexes your pull requests for a richer code review experience.

## Rich Code Navigation

[Docs Link](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/1047/Rich-Code-Navigation)
With Rich Code Navigation, you can use editor-level navigation capabilities (like peek definition, find all references, and even diagnostics) on a pull request, without requiring a local checkout. This is available across all files and dependencies of your repository.

Rich Code Navigation is available for Visual Studio (for repos hosted on GitHub or Azure Repos) and Visual Studio Code (for repos hosted on GitHub).

Rich Code Navigation supports these capabilities:

- Hover
- Peek definition and Go to definition
- Peek references and Find all references
- Go to type definition
- Go to implementation
- Diagnostics