### PR TITLE
Calculate array element nullability

### DIFF
--- a/src/EFCore.PG/Extensions/PropertyInfoExtensions.cs
+++ b/src/EFCore.PG/Extensions/PropertyInfoExtensions.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+// ReSharper disable once CheckNamespace
+namespace System.Reflection
+{
+    [DebuggerStepThrough]
+    internal static class PropertyInfoExtensions
+    {
+        public static bool IsStatic(this PropertyInfo property)
+            => (property.GetMethod ?? property.SetMethod).IsStatic;
+
+        public static bool IsIndexerProperty([NotNull] this PropertyInfo propertyInfo)
+        {
+            var indexParams = propertyInfo.GetIndexParameters();
+            return indexParams.Length == 1
+                   && indexParams[0].ParameterType == typeof(string);
+        }
+    }
+}

--- a/src/EFCore.PG/Query/Expressions/Internal/PostgresArrayIndexExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/PostgresArrayIndexExpression.cs
@@ -18,6 +18,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
     /// </remarks>
     public class PostgresArrayIndexExpression : SqlExpression, IEquatable<PostgresArrayIndexExpression>
     {
+        /// <summary>
+        /// The array being indexed.
+        /// </summary>
+        [NotNull]
+        public virtual SqlExpression Array { get; }
+
+        /// <summary>
+        /// The index in the array.
+        /// </summary>
+        [NotNull]
+        public virtual SqlExpression Index { get; }
+
         public PostgresArrayIndexExpression(
             [NotNull] SqlExpression array,
             [NotNull] SqlExpression index,
@@ -47,18 +59,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal
         /// <inheritdoc />
         protected override Expression VisitChildren(ExpressionVisitor visitor)
             => Update((SqlExpression)visitor.Visit(Array), (SqlExpression)visitor.Visit(Index));
-
-        /// <summary>
-        /// The array being indexes.
-        /// </summary>
-        [NotNull]
-        public virtual SqlExpression Array { get; }
-
-        /// <summary>
-        /// The index in the array.
-        /// </summary>
-        [NotNull]
-        public virtual SqlExpression Index { get; }
 
         public virtual bool Equals(PostgresArrayIndexExpression other)
             => ReferenceEquals(this, other) ||

--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlNullabilityProcessor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlNullabilityProcessor.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Utilities;
 using static Npgsql.EntityFrameworkCore.PostgreSQL.Utilities.Statics;
 
@@ -171,7 +172,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
             var array = Visit(arrayIndexExpression.Array, allowOptimizedExpansion, out var arrayNullable);
             var index = Visit(arrayIndexExpression.Index, allowOptimizedExpansion, out var indexNullable);
 
-            nullable = arrayNullable || indexNullable;
+            nullable = arrayNullable || indexNullable || ((NpgsqlArrayTypeMapping)arrayIndexExpression.Array.TypeMapping).IsElementNullable;
 
             return arrayIndexExpression.Update(array, index);
         }

--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayListTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayListTypeMapping.cs
@@ -54,12 +54,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping
             ), elementMapping) {}
 
         protected NpgsqlArrayListTypeMapping(
-            RelationalTypeMappingParameters parameters, [NotNull] RelationalTypeMapping elementMapping)
-            : base(parameters, elementMapping)
+            RelationalTypeMappingParameters parameters, [NotNull] RelationalTypeMapping elementMapping, bool? isElementNullable = null)
+            : base(
+                parameters,
+                elementMapping,
+                CalculateElementNullability(
+                    // Note that the ClrType on elementMapping has been unwrapped for nullability, so we consult the List's CLR type instead
+                    parameters.CoreParameters.ClrType.GetGenericArguments()[0],
+                    isElementNullable))
         {
             if (!parameters.CoreParameters.ClrType.IsGenericList())
-                throw new ArgumentException("ClrType must be a List<>", nameof(parameters));
+                throw new ArgumentException("ClrType must be a generic List", nameof(parameters));
         }
+
+        public override NpgsqlArrayTypeMapping MakeNonNullable()
+            => new NpgsqlArrayListTypeMapping(Parameters, ElementMapping, isElementNullable: false);
 
         protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
             => new NpgsqlArrayListTypeMapping(parameters, ElementMapping);

--- a/src/EFCore.PG/Utilities/ReferenceNullabilityDecoder.cs
+++ b/src/EFCore.PG/Utilities/ReferenceNullabilityDecoder.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using CA = System.Diagnostics.CodeAnalysis;
+
+#nullable enable
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Utilities
+{
+    // Most of the code here is common with EF Core's NonNullableConventionBase
+    // Note: this is a very partial implementation that does not correctly decode all scenarios.
+    internal class ReferenceNullabilityDecoder
+    {
+        // For the interpretation of nullability metadata, see
+        // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
+
+        private readonly NonNullabilityConventionState _cache = new();
+
+        private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
+        private const string NullableContextAttributeFullName = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+        protected virtual bool IsNonNullableReferenceType([NotNull] MemberInfo memberInfo)
+        {
+            if (memberInfo.GetMemberType().IsValueType)
+            {
+                return false;
+            }
+
+            // First check for [MaybeNull] on the return value. If it exists, the member is nullable.
+            // Note: avoid using GetCustomAttribute<> below because of https://github.com/mono/mono/issues/17477
+            var isMaybeNull = memberInfo switch
+            {
+                FieldInfo f
+                    => f.CustomAttributes.Any(a => a.AttributeType == typeof(CA.MaybeNullAttribute)),
+                PropertyInfo p
+                    => p.GetMethod?.ReturnParameter?.CustomAttributes?.Any(a => a.AttributeType == typeof(CA.MaybeNullAttribute)) == true,
+                _ => false
+            };
+
+            if (isMaybeNull)
+            {
+                return false;
+            }
+
+            // For C# 8.0 nullable types, the C# compiler currently synthesizes a NullableAttribute that expresses nullability into
+            // assemblies it produces. If the model is spread across more than one assembly, there will be multiple versions of this
+            // attribute, so look for it by name, caching to avoid reflection on every check.
+            // Note that this may change - if https://github.com/dotnet/corefx/issues/36222 is done we can remove all of this.
+
+            // First look for NullableAttribute on the member itself
+            if (TryGetNullableFlags(memberInfo, out var flags))
+            {
+                return flags.FirstOrDefault() == 1;
+            }
+
+            // No attribute on the member, try to find a NullableContextAttribute on the declaring type
+            return IsContextNonNullable(memberInfo.DeclaringType!);
+        }
+
+        internal bool IsArrayOrListElementNonNullable(MemberInfo memberInfo)
+        {
+            if (!memberInfo.GetMemberType().TryGetElementType(out var elementType))
+            {
+                throw new ArgumentException("Argument isn't an array or generic List", nameof(memberInfo));
+            }
+
+            if (elementType.IsValueType)
+            {
+                return elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(Nullable<>);
+            }
+
+            // First look for NullableAttribute on the member itself.
+            // Either it has two flags - one for the array/list and one for the element - or a single compressed byte since both have the
+            // same nullability.
+            if (TryGetNullableFlags(memberInfo, out var flags))
+            {
+                return flags.Length switch
+                {
+                    1 => flags[0] == 1,
+                    2 => flags[1] == 1,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+            }
+
+            // No attribute on the member, try to find a NullableContextAttribute on the declaring type
+            return IsContextNonNullable(memberInfo.DeclaringType!);
+        }
+
+        bool TryGetNullableFlags(MemberInfo memberInfo, [CA.NotNullWhen(true)] out byte[]? flags)
+        {
+            if (memberInfo.GetCustomAttributes().FirstOrDefault(a => a.GetType().FullName == NullableAttributeFullName) is Attribute
+                attribute)
+            {
+                var attributeType = attribute.GetType();
+
+                if (attributeType != _cache.NullableAttrType)
+                {
+                    _cache.NullableFlagsFieldInfo = attributeType.GetField("NullableFlags");
+                    _cache.NullableAttrType = attributeType;
+                }
+
+                flags = (byte[]?)_cache.NullableFlagsFieldInfo?.GetValue(attribute);
+                return flags is not null;
+            }
+
+            flags = null;
+            return false;
+        }
+
+        private bool IsContextNonNullable(Type type)
+        {
+            if (_cache.TypeCache.TryGetValue(type, out var cachedTypeNonNullable))
+            {
+                return cachedTypeNonNullable;
+            }
+
+            if (Attribute.GetCustomAttributes(type)
+                .FirstOrDefault(a => a.GetType().FullName == NullableContextAttributeFullName) is Attribute contextAttr)
+            {
+                var attributeType = contextAttr.GetType();
+
+                if (attributeType != _cache.NullableContextAttrType)
+                {
+                    _cache.NullableContextFlagFieldInfo = attributeType.GetField("Flag");
+                    _cache.NullableContextAttrType = attributeType;
+                }
+
+                if (_cache.NullableContextFlagFieldInfo?.GetValue(contextAttr) is byte flag)
+                {
+                    return _cache.TypeCache[type] = flag == 1;
+                }
+            }
+
+            return _cache.TypeCache[type] = false;
+        }
+
+        private sealed class NonNullabilityConventionState
+        {
+            public Type? NullableAttrType;
+            public Type? NullableContextAttrType;
+            public FieldInfo? NullableFlagsFieldInfo;
+            public FieldInfo? NullableContextFlagFieldInfo;
+            public Dictionary<Type, bool> TypeCache { get; } = new();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1683

/cc @maumar @smitpatel for the array case things turned out nice and simple - just override `ITypeMappingSource.FindMapping(IProperty)` to tweak the type mapping to contain the extra NRT information.

In theory, the same thing could be done for JSON to walk the POCO hierarchy and inject a tree nullability information into the type mapping... Will see if I feel like doing that :)