### PR TITLE
Bump dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <EFCoreVersion>6.0.0-preview.3.21158.1</EFCoreVersion>
-    <MicrosoftExtensionsVersion>6.0.0-preview.3.21157.6</MicrosoftExtensionsVersion>
-    <NpgsqlVersion>6.0.0-ci.20210303T093005+sha.cf73c6e0b</NpgsqlVersion>
+    <EFCoreVersion>6.0.0-preview.3.21163.3</EFCoreVersion>
+    <MicrosoftExtensionsVersion>6.0.0-preview.3.21164.8</MicrosoftExtensionsVersion>
+    <NpgsqlVersion>6.0.0-ci.20210310T201503</NpgsqlVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/EFCore.PG.FunctionalTests/DesignTimeNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/DesignTimeNpgsqlTest.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL
+{
+    public class DesignTimeNpgsqlTest : DesignTimeTestBase<DesignTimeNpgsqlTest.DesignTimeNpgsqlFixture>
+    {
+        public DesignTimeNpgsqlTest(DesignTimeNpgsqlFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override Assembly ProviderAssembly
+            => typeof(NpgsqlDesignTimeServices).Assembly;
+
+        public class DesignTimeNpgsqlFixture : DesignTimeFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory
+                => NpgsqlTestStoreFactory.Instance;
+        }
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsSharedTypeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsSharedTypeQueryNpgsqlTest.cs
@@ -24,14 +24,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        public override async Task SelectMany_with_navigation_and_Distinct(bool async)
-        {
-            var message = (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.SelectMany_with_navigation_and_Distinct(async))).Message;
-
-            Assert.Equal(RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin, message);
-        }
-
         [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/22532")]
         public override Task Distinct_skip_without_orderby(bool async)
             => base.Distinct_skip_without_orderby(async);

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindSelectQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindSelectQueryNpgsqlTest.cs
@@ -30,12 +30,6 @@ FROM ""Orders"" AS o");
         public override Task Member_binding_after_ctor_arguments_fails_with_client_eval(bool async)
             => AssertTranslationFailed(() => base.Member_binding_after_ctor_arguments_fails_with_client_eval(async));
 
-        public override async Task Projecting_after_navigation_and_distinct_throws(bool async)
-            => Assert.Equal(
-                RelationalStrings.InsufficientInformationToIdentifyOuterElementOfCollectionJoin,
-                (await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => base.Projecting_after_navigation_and_distinct_throws(async))).Message);
-
         void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Bumps `EFCoreVersion` from 6.0.0-preview.3.21158.1 to 6.0.0-preview.3.21163.3.
Bumps `MicrosoftExtensionsVersion` from 6.0.0-preview.3.21157.6 to 6.0.0-preview.3.21164.8.
Bumps `Npgsql` from 6.0.0-ci.20210303T093005+sha.cf73c6e0b to 6.0.0-ci.20210310T201503.