### PR TITLE
Fixes to DateTime arithmetics involving TimeSpan (#1777)

### DIFF
--- a/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
@@ -279,34 +279,29 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                 var leftType = left.Type.UnwrapNullableType();
                 var rightType = right.Type.UnwrapNullableType();
 
-                if (binary.OperatorType == ExpressionType.Add)
-                {
-                    // Note that we apply the given type mapping from above to the left operand (which has the same CLR type as
-                    // the binary expression's)
+                // Note that we apply the given type mapping from above to the left operand (which has the same CLR type as
+                // the binary expression's)
 
-                    // DateTime + TimeSpan => DateTime
-                    // DateTimeOffset + TimeSpan => DateTimeOffset
-                    if (rightType == typeof(TimeSpan) && (
-                            leftType == typeof(DateTime) ||
-                            leftType == typeof(DateTimeOffset)) ||
-                        rightType.FullName == "NodaTime.Period" && (
-                            leftType.FullName == "NodaTime.LocalDateTime" ||
-                            leftType.FullName == "NodaTime.LocalDate" ||
-                            leftType.FullName == "NodaTime.LocalTime") ||
-                        rightType.FullName == "NodaTime.Duration" && (
-                            leftType.FullName == "NodaTime.Instant" ||
-                            leftType.FullName == "NodaTime.ZonedDateTime"))
-                    {
-                        var newLeft = ApplyTypeMapping(left, typeMapping);
-                        var newRight = ApplyDefaultTypeMapping(right);
-                        return new SqlBinaryExpression(binary.OperatorType, newLeft, newRight, binary.Type, newLeft.TypeMapping);
-                    }
+                // DateTime + TimeSpan => DateTime
+                // DateTimeOffset + TimeSpan => DateTimeOffset
+                if (rightType == typeof(TimeSpan) && (
+                        leftType == typeof(DateTime) ||
+                        leftType == typeof(DateTimeOffset)) ||
+                    rightType.FullName == "NodaTime.Period" && (
+                        leftType.FullName == "NodaTime.LocalDateTime" ||
+                        leftType.FullName == "NodaTime.LocalDate" ||
+                        leftType.FullName == "NodaTime.LocalTime") ||
+                    rightType.FullName == "NodaTime.Duration" && (
+                        leftType.FullName == "NodaTime.Instant" ||
+                        leftType.FullName == "NodaTime.ZonedDateTime"))
+                {
+                    var newLeft = ApplyTypeMapping(left, typeMapping);
+                    var newRight = ApplyDefaultTypeMapping(right);
+                    return new SqlBinaryExpression(binary.OperatorType, newLeft, newRight, binary.Type, newLeft.TypeMapping);
                 }
 
                 if (binary.OperatorType == ExpressionType.Subtract)
                 {
-                    var inferredTypeMapping = typeMapping ?? ExpressionExtensions.InferTypeMapping(left, right);
-
                     // DateTime - DateTime => TimeSpan
                     // DateTimeOffset - DateTimeOffset => TimeSpan
                     // Instant - Instant => Duration
@@ -319,6 +314,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                         leftType.FullName == "NodaTime.LocalDate" && rightType.FullName == "NodaTime.LocalDate" ||
                         leftType.FullName == "NodaTime.LocalTime" && rightType.FullName == "NodaTime.LocalTime")
                     {
+                        var inferredTypeMapping = typeMapping ?? ExpressionExtensions.InferTypeMapping(left, right);
+
                         return new SqlBinaryExpression(
                             ExpressionType.Subtract,
                             ApplyTypeMapping(left, inferredTypeMapping),

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindMiscellaneousQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindMiscellaneousQueryNpgsqlTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -15,7 +16,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
             : base(fixture)
         {
             ClearLog();
-            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override async Task Query_expression_with_to_string_and_contains(bool async)
@@ -56,6 +57,21 @@ WHERE (o.""OrderDate"" IS NOT NULL)");
 SELECT o.""OrderDate"" + CAST((@__years_0::text || ' years') AS interval) AS ""OrderDate""
 FROM ""Orders"" AS o
 WHERE (o.""OrderDate"" IS NOT NULL)");
+        }
+
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task DateTime_subtract_TimeSpan(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderDate - TimeSpan.FromDays(1) == new DateTime(1997, 10, 8)),
+                entryCount: 2);
+
+            AssertSql(
+                @"SELECT o.""OrderID"", o.""CustomerID"", o.""EmployeeID"", o.""OrderDate""
+FROM ""Orders"" AS o
+WHERE (o.""OrderDate"" - INTERVAL '1 00:00:00') = TIMESTAMP '1997-10-08 00:00:00'");
         }
 
         // TODO: Array tests can probably move to the dedicated ArrayQueryTest suite


### PR DESCRIPTION
Removes the check for ExpressionType.Add around the DateTime + TimeSpan type mapping.
This case should allow both addition and subtraction, and this is already checked by the enclosing if.

Fixes #1777