### PR TITLE
Support for table partitioning #1035

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlAnnotationCodeGenerator.cs
@@ -139,6 +139,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal
             if (annotation.Name == NpgsqlAnnotationNames.UnloggedTable)
                 return new MethodCallCodeFragment(nameof(NpgsqlEntityTypeBuilderExtensions.IsUnlogged), annotation.Value);
 
+            if (annotation.Name == NpgsqlAnnotationNames.TablePartitioning && annotation.Value is TablePartitioning tablePartitioning)
+                return new MethodCallCodeFragment(nameof(NpgsqlEntityTypeBuilderExtensions.IsPartitioned), tablePartitioning.Type, tablePartitioning.PartitionKeyProperties.Select(x => x.Name));
+
             return null;
         }
 

--- a/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlEntityTypeBuilderExtensions.cs
@@ -289,6 +289,62 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion
 
+        #region Partitioning
+        /// <summary>
+        /// Configures the entity to use table partitioning when targeting Npsql.
+        /// </summary>
+        /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+        /// <param name="tablePartitioningType">The type of partitioning to use on the table.</param>
+        /// <param name="partitionKeyPropertyNames">The entity's properties to use as key for the partitioning.</param>
+        /// <returns></returns>
+        public static EntityTypeBuilder IsPartitioned(
+            this EntityTypeBuilder entityTypeBuilder,
+            TablePartitioningType tablePartitioningType,
+            params string[] partitionKeyPropertyNames)
+        {
+            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
+            Check.NotEmpty(partitionKeyPropertyNames, nameof(partitionKeyPropertyNames));
+
+            entityTypeBuilder.Metadata.SetTablePartitioning(tablePartitioningType, partitionKeyPropertyNames);
+
+            return entityTypeBuilder;
+        }
+
+        /// <summary>
+        /// Configures the entity to use table partitioning when targeting Npsql.
+        /// </summary>
+        /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+        /// <param name="tablePartitioningType">The type of partitioning to use on the table.</param>
+        /// <param name="partitionKeyPropertyNames">The entity's properties to use as key for the partitioning.</param>
+        /// <returns></returns>
+        public static EntityTypeBuilder IsPartitioned(
+            this EntityTypeBuilder entityTypeBuilder,
+            TablePartitioningType tablePartitioningType,
+            IEnumerable<string> partitionKeyPropertyNames)
+            => IsPartitioned(
+                entityTypeBuilder,
+                tablePartitioningType,
+                partitionKeyPropertyNames.ToArray());
+
+        /// <summary>
+        /// Configures the entity to use table partitioning when targeting Npsql.
+        /// </summary>
+        /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+        /// <param name="tablePartitioningType">The type of partitioning to use on the table.</param>
+        /// <param name="partitionKeyPropertyNames">An expression representinng the entity's properties to use as key of the partition.</param>
+        public static EntityTypeBuilder<TEntity> IsPartitioned<TEntity>(
+            this EntityTypeBuilder<TEntity> entityTypeBuilder,
+            TablePartitioningType tablePartitioningType,
+            Expression<Func<TEntity, object?>> partitionKeyPropertyExpression)
+            where TEntity : class
+            => (EntityTypeBuilder<TEntity>)IsPartitioned(
+                entityTypeBuilder,
+                tablePartitioningType,
+                Check.NotNull(partitionKeyPropertyExpression, nameof(partitionKeyPropertyExpression))
+                    .GetMemberAccessList().Select(x => x.GetSimpleMemberName()));
+
+        #endregion
+
         #region CockroachDB Interleave-in-parent
 
         public static EntityTypeBuilder UseCockroachDbInterleaveInParent(

--- a/src/EFCore.PG/Extensions/MetadataExtensions/NpgsqlEntityTypeExtensions.cs
+++ b/src/EFCore.PG/Extensions/MetadataExtensions/NpgsqlEntityTypeExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -87,6 +88,24 @@ namespace Microsoft.EntityFrameworkCore
             => index.FindAnnotation(NpgsqlAnnotationNames.UnloggedTable)?.GetConfigurationSource();
 
         #endregion Unlogged
+
+        #region Partitioning
+        public static void SetTablePartitioning(
+            this IMutableEntityType entityType,
+            TablePartitioningType tablePartitioningType,
+            params string[] partitionKeyPropertyNames)
+        {
+            Check.NotEmpty(partitionKeyPropertyNames, nameof(partitionKeyPropertyNames));
+
+            var properties = partitionKeyPropertyNames
+                .Select(x => entityType.FindProperty(x))
+                .ToArray();
+
+            entityType.SetOrRemoveAnnotation(
+                NpgsqlAnnotationNames.TablePartitioning,
+                new TablePartitioning(tablePartitioningType, properties!));
+        }
+        #endregion
 
         #region CockroachDb interleave in parent
 

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -22,6 +22,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
         public const string Tablespace = Prefix + "Tablespace";
         public const string StorageParameterPrefix = Prefix + "StorageParameter:";
         public const string UnloggedTable = Prefix + "UnloggedTable";
+        public const string TablePartitioning = Prefix + "TablePartitioning";
         public const string IdentityOptions = Prefix + "IdentitySequenceOptions";
         public const string TsVectorConfig = Prefix + "TsVectorConfig";
         public const string TsVectorProperties = Prefix + "TsVectorProperties";

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
@@ -24,6 +24,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal
                 yield return new Annotation(NpgsqlAnnotationNames.UnloggedTable, entityType.GetIsUnlogged());
             if (entityType[CockroachDbAnnotationNames.InterleaveInParent] != null)
                 yield return new Annotation(CockroachDbAnnotationNames.InterleaveInParent, entityType[CockroachDbAnnotationNames.InterleaveInParent]);
+            if (entityType[NpgsqlAnnotationNames.TablePartitioning] != null)
+                yield return new Annotation(NpgsqlAnnotationNames.TablePartitioning, entityType[NpgsqlAnnotationNames.TablePartitioning]);
             foreach (var storageParamAnnotation in entityType.GetAnnotations()
                 .Where(a => a.Name.StartsWith(NpgsqlAnnotationNames.StorageParameterPrefix, StringComparison.Ordinal)))
             {

--- a/src/EFCore.PG/Metadata/TablePartitioning.cs
+++ b/src/EFCore.PG/Metadata/TablePartitioning.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    /// Represents the Metadata for the partitioning of a table.
+    /// </summary>
+    public class TablePartitioning
+    {
+        /// <summary>
+        /// The type of partitioning to use.
+        /// </summary>
+        public TablePartitioningType Type { get; }
+
+        /// <summary>
+        /// The entity's properties to use as key for the partitioning.
+        /// </summary>
+        public IReadOnlyProperty[] PartitionKeyProperties { get; }
+
+        /// <summary>
+        /// Creates a <see cref="TablePartitioning"/>.
+        /// </summary>
+        /// <param name="type">The type of partitioning to use.</param>
+        /// <param name="partitionKeyProperties">The entity properties to use as key for the partitioning.</param>
+        /// <exception cref="ArgumentException"><paramref name="partitionKeyProperties"/></exception>
+        public TablePartitioning(TablePartitioningType type, IReadOnlyProperty[] partitionKeyProperties)
+        {
+            Check.NotEmpty(partitionKeyProperties, nameof(partitionKeyProperties));
+
+            Type = type;
+            PartitionKeyProperties = partitionKeyProperties;
+        }
+    }
+}

--- a/src/EFCore.PG/Metadata/TablePartitioningType.cs
+++ b/src/EFCore.PG/Metadata/TablePartitioningType.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    /// Represents the supported forms of postgres table partitioning as defined in the official documentation:
+    /// https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-OVERVIEW
+    /// </summary>
+    public enum TablePartitioningType
+    {
+        /// <summary>
+        /// <para>
+        /// The table is partitioned into “ranges” defined by a key column or set of columns, 
+        /// with no overlap between the ranges of values assigned to different partitions.
+        /// </para>
+        /// </summary>
+        Range,
+
+        /// <summary>
+        /// <para>
+        /// The table is partitioned by explicitly listing which key value(s) appear in each partition.
+        /// </para>
+        /// </summary>
+        List,
+
+        /// <summary>
+        /// The table is partitioned by specifying a modulus and a remainder for each partition
+        /// </summary>
+        Hash
+    }
+}

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
@@ -296,6 +296,120 @@ WITH (fillfactor=70, user_catalog_table=true);");
 );");
         }
 
+        [Fact]
+        public virtual async Task Create_table_with_list_partitioning()
+        {
+            await Test(
+                builder => { },
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.HasKey("Id");
+                        e.IsPartitioned(TablePartitioningType.List, "Id");
+                    }),
+                asserter: null);
+
+            AssertSql(
+                @"CREATE TABLE ""People"" (
+    ""Id"" integer NOT NULL,
+    CONSTRAINT ""PK_People"" PRIMARY KEY (""Id"")
+)
+PARTITION BY List (""Id"") ;");
+        }
+
+        [Fact]
+        public virtual async Task Create_table_with_range_partitioning()
+        {
+            await Test(
+                builder => { },
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.HasKey("Id");
+                        e.IsPartitioned(TablePartitioningType.Range, "Id");
+                    }),
+                asserter: null);
+
+            AssertSql(
+                @"CREATE TABLE ""People"" (
+    ""Id"" integer NOT NULL,
+    CONSTRAINT ""PK_People"" PRIMARY KEY (""Id"")
+)
+PARTITION BY Range (""Id"") ;");
+        }
+
+        [Fact]
+        public virtual async Task Create_table_with_hash_partitioning()
+        {
+            await Test(
+                builder => { },
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.HasKey("Id");
+                        e.IsPartitioned(TablePartitioningType.Hash, "Id");
+                    }),
+                asserter: null);
+
+            AssertSql(
+                @"CREATE TABLE ""People"" (
+    ""Id"" integer NOT NULL,
+    CONSTRAINT ""PK_People"" PRIMARY KEY (""Id"")
+)
+PARTITION BY Hash (""Id"") ;");
+        }
+
+        [Fact]
+        public virtual async Task Create_table_with_multiple_partitioning_columns()
+        {
+            await Test(
+                builder => { },
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("Location");
+                        e.HasKey("Id", "Location");
+                        e.IsPartitioned(TablePartitioningType.Hash, "Id", "Location");
+                    }),
+                asserter: null);
+
+            AssertSql(
+                @"CREATE TABLE ""People"" (
+    ""Id"" integer NOT NULL,
+    ""Location"" integer NOT NULL,
+    CONSTRAINT ""PK_People"" PRIMARY KEY (""Id"", ""Location"")
+)
+PARTITION BY Hash (""Id"", ""Location"") ;");
+        }
+
+        [Fact]
+        public virtual async Task Create_table_with_partitioning_with_custom_column_name()
+        {
+            await Test(
+                builder => { },
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("Location").HasColumnName("loc");
+                        e.HasKey("Id", "Location");
+                        e.IsPartitioned(TablePartitioningType.Hash, "Id", "Location");
+                    }),
+                asserter: null);
+
+            AssertSql(
+                @"CREATE TABLE ""People"" (
+    ""Id"" integer NOT NULL,
+    cat integer NOT NULL,
+    CONSTRAINT ""PK_People"" PRIMARY KEY (""Id"", loc)
+)
+PARTITION BY Hash (""Id"", loc) ;");
+        }
+
         public override async Task Drop_table()
         {
             await base.Drop_table();
@@ -387,6 +501,54 @@ ALTER TABLE ""People"" RESET (user_catalog_table);");
 
             AssertSql(
                 @"ALTER TABLE ""People"" SET UNLOGGED;");
+        }
+
+        [Fact]
+        public virtual async Task Alter_table_add_partitioning_throws_exception()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(async () => await Test(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.HasKey("Id");
+                    }),
+                builder => { },
+                builder => builder.Entity("People", e => e.IsPartitioned(TablePartitioningType.List, "Id")),
+                asserter: null));
+        }
+
+        [Fact]
+        public virtual async Task Alter_table_change_partitioning_type_throws_exception()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(async () => await Test(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.HasKey("Id");
+                        e.IsPartitioned(TablePartitioningType.List, "Id");
+                    }),
+                builder => { },
+                builder => builder.Entity("People", e => e.IsPartitioned(TablePartitioningType.Range, "Id")),
+                asserter: null));
+        }
+
+        [Fact]
+        public virtual async Task Alter_table_change_partitioning_key_throws_exception()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(async () => await Test(
+                builder => builder.Entity(
+                    "People", e =>
+                    {
+                        e.Property<int>("Id");
+                        e.Property<int>("Location");
+                        e.HasKey("Id", "Location");
+                        e.IsPartitioned(TablePartitioningType.List, "Id");
+                    }),
+                builder => { },
+                builder => builder.Entity("People", e => e.IsPartitioned(TablePartitioningType.List, "Id", "Location")),
+                asserter: null));
         }
 
         [Fact]


### PR DESCRIPTION
Aims to support Npgsql Table Partitioning as part of the EF Core entity  type model (#1035)

* Added Extension methods to builders to allow Partitioning
* Added SQL generation for Partitioning

Fixes #1035

@roji 
Hi, I've taken a stab at #1035.

It's my first time working with EF's annotation and I feel like there is a gap in my knowledge of them that prevents me from making this development work. I've defined a type "TablePartitioning" under Metadata which I wanted to represent the configuration used to Partition the EntityType's table, but after some testing it looks like I can't do this as annotations would require literals for their values.
What alternative would you suggest to make this work? There is the possibility of storing the TablePartitioningType and the string[] of properties as two different annotations, but maybe there is a better?

Also, to my knowledge, there is no way of altering the table partitioning once the table has been created. I handled this by throwing an exception as part of the NpgsqlMigrationsSqlGenerator. Is this the right approach?

Thank you!