### PR TITLE
Migrations compatibility with sqlite

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -155,6 +155,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { "boolean",                     new[] { _bool                         } },
                 { "bool",                        new[] { _bool                         } },
                 { "bytea",                       new[] { _bytea                        } },
+                { "blob",                        new[] { _bytea                        } },
                 { "real",                        new[] { _float4                       } },
                 { "float4",                      new[] { _float4                       } },
                 { "double precision",            new[] { _float8                       } },


### PR DESCRIPTION
I know `blob` is not a postgres standard datatype, but this sure would be useful for unit tests in sqlite and production server in postgres, and being able to share a single migration file when blob is the only syntax that warrants creating different migration files.

Please consider merging this, it should easily be backwards compatible and do no harm. I am using this code change in some production postgres databases and it works great with a sqlite migrations file.

As a solo dev for several server side products that offer support for sqlite, mysql, postgres and sqlserver, maintaining a single migrations file saves me a lot of time. With blob not working in postgres, I have to use my fork of this repo instead of this nuget package, which would be much preferred. Maybe others would see similar benefits...