### PR TITLE
Bump dependencies for preview5 (#1810)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
 
     <Copyright>Copyright 2021 © The Npgsql Development Team</Copyright>
     <Company>Npgsql</Company>
-    <VersionPrefix>6.0.0-preview4</VersionPrefix>
+    <VersionPrefix>6.0.0-preview5</VersionPrefix>
     <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <EFCoreVersion>6.0.0-preview.4.21216.2</EFCoreVersion>
-    <MicrosoftExtensionsVersion>6.0.0-preview.4.21216.6</MicrosoftExtensionsVersion>
+    <EFCoreVersion>6.0.0-preview.5.21216.1</EFCoreVersion>
+    <MicrosoftExtensionsVersion>6.0.0-preview.4.21211.7</MicrosoftExtensionsVersion>
     <NpgsqlVersion>6.0.0-ci.20210415T191850</NpgsqlVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
EFCore -> 6.0.0-preview.5.21216.1 (a1216b1de00f7443a38f8efe3387adfc5d7c21d0)
MicrosoftExtensions -> 6.0.0-preview.4.21211.7
Npgsql -> 6.0.0-ci.20210415T191850