### PR TITLE
Fix connection leak in NpgsqlDatabaseCreator.Exists

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -189,10 +189,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             {
                 if (async)
                 {
+                    await unpooledRelationalConnection.CloseAsync().ConfigureAwait(false);
                     await unpooledRelationalConnection.DisposeAsync().ConfigureAwait(false);
                 }
                 else
                 {
+                    unpooledRelationalConnection.Close();
                     unpooledRelationalConnection.Dispose();
                 }
             }


### PR DESCRIPTION
Fixes #1812

This is a workaround; the root issue here is that NpgsqlRelationalConnection.CloneWith returns an instance with _connectionOwned=false, since the NpgsqlConnection is externally-provided. This means that disposing the NpgsqlRelationalConnection does not close/dispose the NpgsqlConnection, hence the leak.

Ideally CloneWith should return an instance with _connectionOwned=true.