### PR TITLE
Fix type mapping for DateTime.Date translation

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
@@ -64,7 +64,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     new[] { _sqlExpressionFactory.Constant("day"), instance! },
                     nullable: true,
                     argumentsPropagateNullability: TrueArrays[2],
-                    returnType),
+                    returnType,
+                    instance!.TypeMapping),
 
                 // TODO: Technically possible simply via casting to PG time, should be better in EF Core 3.0
                 // but ExplicitCastExpression only allows casting to PG types that

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindMiscellaneousQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindMiscellaneousQueryNpgsqlTest.cs
@@ -76,6 +76,22 @@ FROM ""Orders"" AS o
 WHERE (o.""OrderDate"" - INTERVAL '1 00:00:00') = TIMESTAMP '1997-10-08 00:00:00'");
         }
 
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task DateTimeFunction_subtract_DateTime(bool async)
+        {
+            await AssertFirst(
+                async,
+                ss => ss.Set<Order>().Where(o => o.OrderDate != null)
+                    .Select(o => new { Elapsed = (DateTime.Today - ((DateTime)o.OrderDate).Date).Days }));
+
+            AssertSql(
+                @"SELECT floor(date_part('day', date_trunc('day', now()) - date_trunc('day', o.""OrderDate"")))::INT AS ""Elapsed""
+FROM ""Orders"" AS o
+WHERE (o.""OrderDate"" IS NOT NULL)
+LIMIT 1");
+        }
+
         // TODO: Array tests can probably move to the dedicated ArrayQueryTest suite
 
         #region Array contains


### PR DESCRIPTION
Thanks to @kakone for the initial work.

Fixes #1830