### PR TITLE
Support DateOnly/TimeOnly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,6 @@
     <Copyright>Copyright 2021 © The Npgsql Development Team</Copyright>
     <Company>Npgsql</Company>
     <VersionPrefix>6.0.0-preview5</VersionPrefix>
-    <TargetFramework>net5.0</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/npgsql/efcore.pg</PackageProjectUrl>

--- a/src/EFCore.PG.NTS/EFCore.PG.NTS.csproj
+++ b/src/EFCore.PG.NTS/EFCore.PG.NTS.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Authors>Shay Rojansky</Authors>
-    <Description>NetTopologySuite PostGIS spatial support plugin for PostgreSQL/Npgsql Entity Framework Core provider.</Description>
-    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql;spatial;postgis;nts</PackageTags>
+    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFramework>
 
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite</RootNamespace>
+
+    <Authors>Shay Rojansky</Authors>
+    <Description>NetTopologySuite PostGIS spatial support plugin for PostgreSQL/Npgsql Entity Framework Core provider.</Description>
+    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql;spatial;postgis;nts</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.PG.NodaTime/EFCore.PG.NodaTime.csproj
+++ b/src/EFCore.PG.NodaTime/EFCore.PG.NodaTime.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Authors>Shay Rojansky</Authors>
-    <Description>NodaTime support plugin for PostgreSQL/Npgsql Entity Framework Core provider.</Description>
-    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql;nodatime</PackageTags>
+    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFramework>
 
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime</RootNamespace>
+
+    <Authors>Shay Rojansky</Authors>
+    <Description>NodaTime support plugin for PostgreSQL/Npgsql Entity Framework Core provider.</Description>
+    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql;nodatime</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.PG/EFCore.PG.csproj
+++ b/src/EFCore.PG/EFCore.PG.csproj
@@ -1,12 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Authors>Shay Rojansky;Austin Drenski;Yoh Deadfall;</Authors>
-    <Description>PostgreSQL/Npgsql provider for Entity Framework Core.</Description>
-    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql</PackageTags>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net6.0</TargetFrameworks>
 
     <AssemblyName>Npgsql.EntityFrameworkCore.PostgreSQL</AssemblyName>
     <RootNamespace>Npgsql.EntityFrameworkCore.PostgreSQL</RootNamespace>
+
+    <Authors>Shay Rojansky;Austin Drenski;Yoh Deadfall;</Authors>
+    <Description>PostgreSQL/Npgsql provider for Entity Framework Core.</Description>
+    <PackageTags>npgsql;postgresql;postgres;Entity Framework Core;entity-framework-core;ef;efcore;orm;sql</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMemberTranslator.cs
@@ -30,7 +30,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             var type = member.DeclaringType;
-            if (type != typeof(DateTime) && type != typeof(NpgsqlDateTime) && type != typeof(NpgsqlDate))
+            if (type != typeof(DateTime) && type != typeof(NpgsqlDateTime) && type != typeof(NpgsqlDate)
+#if NET6_0_OR_GREATER
+                && type != typeof(DateOnly) && type != typeof(TimeOnly)
+#endif
+            )
                 return null;
 
             return member.Name switch
@@ -88,19 +92,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     returnType);
         }
 
-        /// <summary>
-        /// Constructs the DATE_PART expression.
-        /// </summary>
-        /// <param name="instance">The member expression.</param>
-        /// <param name="partName">The name of the DATE_PART to construct.</param>
-        /// <param name="floor">True if the result should be wrapped with FLOOR(...); otherwise, false.</param>
-        /// <returns>
-        /// The DATE_PART expression.
-        /// </returns>
-        /// <remarks>
-        /// DATE_PART returns doubles, which we floor and cast into ints
-        /// This also gets rid of sub-second components when retrieving seconds.
-        /// </remarks>
         private SqlExpression GetDatePartExpression(
             SqlExpression instance,
             string partName,

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMemberTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMemberTranslatorProvider.cs
@@ -29,7 +29,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Inte
                     JsonPocoTranslator,
                     new NpgsqlRangeTranslator(typeMappingSource, sqlExpressionFactory),
                     new NpgsqlStringMemberTranslator(sqlExpressionFactory),
-                    new NpgsqlTimeSpanMemberTranslator(sqlExpressionFactory)
+                    new NpgsqlTimeSpanMemberTranslator(sqlExpressionFactory),
                 });
         }
     }

--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
@@ -26,6 +26,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
         private static readonly ConstructorInfo DateTimeCtor2 =
             typeof(DateTime).GetConstructor(new[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) })!;
 
+#if NET6_0_OR_GREATER
+        private static readonly ConstructorInfo DateOnlyCtor =
+            typeof(DateOnly).GetConstructor(new[] { typeof(int), typeof(int), typeof(int) })!;
+#endif
+
         private static readonly MethodInfo Like2MethodInfo =
             typeof(DbFunctionsExtensions).GetRuntimeMethod(
                 nameof(DbFunctionsExtensions.Like), new[] { typeof(DbFunctions), typeof(string), typeof(string) })!;
@@ -431,6 +436,16 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal
                 return _sqlExpressionFactory.Function(
                     "make_timestamp", sqlArguments, nullable: true, TrueArrays[6], typeof(DateTime));
             }
+
+#if NET6_0_OR_GREATER
+            if (newExpression.Constructor == DateOnlyCtor)
+            {
+                return TryTranslateArguments(out var sqlArguments)
+                    ? _sqlExpressionFactory.Function(
+                        "make_date", sqlArguments, nullable: true, TrueArrays[3], typeof(DateOnly))
+                    : QueryCompilationContext.NotTranslatedExpression;
+            }
+#endif
 
             return QueryCompilationContext.NotTranslatedExpression;
 

--- a/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
@@ -294,16 +294,24 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
 
                 // DateTime + TimeSpan => DateTime
                 // DateTimeOffset + TimeSpan => DateTimeOffset
-                if (rightType == typeof(TimeSpan) && (
-                        leftType == typeof(DateTime) ||
-                        leftType == typeof(DateTimeOffset)) ||
-                    rightType.FullName == "NodaTime.Period" && (
-                        leftType.FullName == "NodaTime.LocalDateTime" ||
-                        leftType.FullName == "NodaTime.LocalDate" ||
-                        leftType.FullName == "NodaTime.LocalTime") ||
-                    rightType.FullName == "NodaTime.Duration" && (
-                        leftType.FullName == "NodaTime.Instant" ||
-                        leftType.FullName == "NodaTime.ZonedDateTime"))
+                // TimeOnly + TimeSpan => TimeOnly
+                if (rightType == typeof(TimeSpan)
+                    && (
+                        leftType == typeof(DateTime)
+                        || leftType == typeof(DateTimeOffset)
+#if NET6_0_OR_GREATER
+                        || leftType == typeof(TimeOnly)
+#endif
+                    )
+                    || rightType.FullName == "NodaTime.Period"
+                    && (
+                        leftType.FullName == "NodaTime.LocalDateTime"
+                        || leftType.FullName == "NodaTime.LocalDate"
+                        || leftType.FullName == "NodaTime.LocalTime")
+                    || rightType.FullName == "NodaTime.Duration"
+                    && (
+                        leftType.FullName == "NodaTime.Instant"
+                        || leftType.FullName == "NodaTime.ZonedDateTime"))
                 {
                     var newLeft = ApplyTypeMapping(left, typeMapping);
                     var newRight = ApplyDefaultTypeMapping(right);
@@ -314,15 +322,21 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                 {
                     // DateTime - DateTime => TimeSpan
                     // DateTimeOffset - DateTimeOffset => TimeSpan
+                    // DateOnly - DateOnly => TimeSpan
+                    // TimeOnly - TimeOnly => TimeSpan
                     // Instant - Instant => Duration
                     // LocalDateTime - LocalDateTime => Period
-                    if (leftType == typeof(DateTime) && rightType == typeof(DateTime) ||
-                        leftType == typeof(DateTimeOffset) && rightType == typeof(DateTimeOffset) ||
-                        leftType.FullName == "NodaTime.Instant" && rightType.FullName == "NodaTime.Instant" ||
-                        leftType.FullName == "NodaTime.LocalDateTime" && rightType.FullName == "NodaTime.LocalDateTime" ||
-                        leftType.FullName == "NodaTime.ZonedDateTime" && rightType.FullName == "NodaTime.ZonedDateTime" ||
-                        leftType.FullName == "NodaTime.LocalDate" && rightType.FullName == "NodaTime.LocalDate" ||
-                        leftType.FullName == "NodaTime.LocalTime" && rightType.FullName == "NodaTime.LocalTime")
+                    if (leftType == typeof(DateTime) && rightType == typeof(DateTime)
+                        || leftType == typeof(DateTimeOffset) && rightType == typeof(DateTimeOffset)
+#if NET6_0_OR_GREATER
+                        || leftType == typeof(DateOnly) && rightType == typeof(DateOnly)
+                        || leftType == typeof(TimeOnly) && rightType == typeof(TimeOnly)
+#endif
+                        || leftType.FullName == "NodaTime.Instant" && rightType.FullName == "NodaTime.Instant"
+                        || leftType.FullName == "NodaTime.LocalDateTime" && rightType.FullName == "NodaTime.LocalDateTime"
+                        || leftType.FullName == "NodaTime.ZonedDateTime" && rightType.FullName == "NodaTime.ZonedDateTime"
+                        || leftType.FullName == "NodaTime.LocalDate" && rightType.FullName == "NodaTime.LocalDate"
+                        || leftType.FullName == "NodaTime.LocalTime" && rightType.FullName == "NodaTime.LocalTime")
                     {
                         var inferredTypeMapping = typeMapping ?? ExpressionExtensions.InferTypeMapping(left, right);
 
@@ -331,7 +345,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query
                             ApplyTypeMapping(left, inferredTypeMapping),
                             ApplyTypeMapping(right, inferredTypeMapping),
                             binary.Type,
-                            typeMapping ?? _typeMappingSource.FindMapping(binary.Type));
+                            typeMapping ?? _typeMappingSource.FindMapping(binary.Type, "interval"));
                     }
                 }
             }

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -64,13 +64,18 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
         private readonly NpgsqlJsonTypeMapping         _jsonElement        = new("json", typeof(JsonElement));
 
         // Date/Time types
-        private readonly NpgsqlDateTypeMapping         _date               = new();
+        private readonly NpgsqlDateTypeMapping         _dateDateTime       = new(typeof(DateTime));
         private readonly NpgsqlTimestampTypeMapping    _timestamp          = new();
         private readonly NpgsqlTimestampTzTypeMapping  _timestamptz        = new(typeof(DateTime));
         private readonly NpgsqlTimestampTzTypeMapping  _timestamptzDto     = new(typeof(DateTimeOffset));
         private readonly NpgsqlIntervalTypeMapping     _interval           = new();
-        private readonly NpgsqlTimeTypeMapping         _time               = new();
+        private readonly NpgsqlTimeTypeMapping         _timeTimeSpan       = new(typeof(TimeSpan));
         private readonly NpgsqlTimeTzTypeMapping       _timetz             = new();
+
+#if NET6_0_OR_GREATER
+        private readonly NpgsqlDateTypeMapping         _dateDateOnly       = new(typeof(DateOnly));
+        private readonly NpgsqlTimeTypeMapping         _timeTimeOnly       = new(typeof(TimeOnly));
+#endif
 
         // Network address types
         private readonly NpgsqlMacaddrTypeMapping      _macaddr            = new();
@@ -181,14 +186,36 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { "char",                        new[] { _char                         } },
                 { "char(1)",                     new RelationalTypeMapping[] { _singleChar, _stringAsSingleChar } },
                 { "character(1)",                new RelationalTypeMapping[] { _singleChar, _stringAsSingleChar } },
-                { "date",                        new[] { _date                         } },
                 { "timestamp without time zone", new[] { _timestamp                    } },
                 { "timestamp",                   new[] { _timestamp                    } },
                 { "timestamp with time zone",    new[] { _timestamptz, _timestamptzDto } },
                 { "timestamptz",                 new[] { _timestamptz, _timestamptzDto } },
                 { "interval",                    new[] { _interval                     } },
-                { "time without time zone",      new[] { _time                         } },
-                { "time",                        new[] { _time                         } },
+
+                { "date", new RelationalTypeMapping[]
+#if NET6_0_OR_GREATER
+                    { _dateDateOnly, _dateDateTime }
+#else
+                    { _dateDateTime }
+#endif
+                },
+
+                { "time without time zone", new RelationalTypeMapping[]
+#if NET6_0_OR_GREATER
+                    { _timeTimeOnly, _timeTimeSpan }
+#else
+                    { _timeTimeSpan }
+#endif
+                },
+
+                { "time", new RelationalTypeMapping[]
+#if NET6_0_OR_GREATER
+                    { _timeTimeOnly, _timeTimeSpan }
+#else
+                    { _timeTimeSpan }
+#endif
+                },
+
                 { "time with time zone",         new[] { _timetz                       } },
                 { "timetz",                      new[] { _timetz                       } },
                 { "macaddr",                     new[] { _macaddr                      } },
@@ -258,6 +285,11 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
                 { typeof(ImmutableDictionary<string, string>), _immutableHstore      },
                 { typeof(Dictionary<string, string>),          _hstore               },
                 { typeof(NpgsqlTid),                           _tid                  },
+
+#if NET6_0_OR_GREATER
+                { typeof(DateOnly),                            _dateDateOnly         },
+                { typeof(TimeOnly),                            _timeTimeOnly         },
+#endif
 
                 { typeof(NpgsqlPoint),                         _point                },
                 { typeof(NpgsqlBox),                           _box                  },

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -98,6 +98,11 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                         DateTimeOffsetAsTimetz = new DateTimeOffset(1, 1, 1, 12, 0, 0, TimeSpan.FromHours(2)),
                         TimeSpanAsInterval = new TimeSpan(11, 15, 12),
 
+#if NET6_0_OR_GREATER
+                        DateOnlyAsDate = new DateOnly(2015, 1, 2),
+                        TimeOnlyAsTime = new TimeOnly(11, 15, 12),
+#endif
+
                         StringAsText = "Gumball Rules!",
                         StringAsVarchar = "Gumball Rules OK",
                         // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
@@ -200,89 +205,97 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 TimeSpan? param19 = new TimeSpan(11, 15, 12);
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.TimeSpanAsInterval == param19));
 
-                // ReSharper disable once ConvertToConstant.Local
-                var param20 = "Gumball Rules!";
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsText == param20));
+#if NET6_0_OR_GREATER
+                DateOnly? param20 = new DateOnly(2015, 1, 2);
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.DateOnlyAsDate == param20));
+
+                TimeOnly? param21 = new TimeOnly(11, 15, 12);
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.TimeOnlyAsTime == param21));
+#endif
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param21 = "Gumball Rules OK";
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsVarchar == param21));
+                var param22 = "Gumball Rules!";
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsText == param22));
+
+                // ReSharper disable once ConvertToConstant.Local
+                var param23 = "Gumball Rules OK";
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsVarchar == param23));
 
                 // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
-                // var param21a = 'f';
-                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsChar1 == param21a));
+                // var param23a = 'f';
+                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsChar1 == param23a));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param21b = 'g';
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsText == param21b));
+                var param23b = 'g';
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsText == param23b));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param21c = 'h';
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsVarchar == param21c));
+                var param23c = 'h';
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.CharAsVarchar == param23c));
 
-                var param22 = new byte[] { 86 };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.BytesAsBytea == param22));
+                var param24 = new byte[] { 86 };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.BytesAsBytea == param24));
 
-                Guid? param23 = new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.GuidAsUuid == param23));
+                Guid? param25 = new Guid("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.GuidAsUuid == param25));
 
-                StringEnum16? param24 = StringEnum16.Value4;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsText == param24));
+                StringEnum16? param26 = StringEnum16.Value4;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsText == param26));
 
-                StringEnumU16? param25 = StringEnumU16.Value4;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsVarchar == param25));
+                StringEnumU16? param27 = StringEnumU16.Value4;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.EnumAsVarchar == param27));
 
-                var param26 = PhysicalAddress.Parse("08-00-2B-01-02-03");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressAsMacaddr.Equals(param26)));
+                var param28 = PhysicalAddress.Parse("08-00-2B-01-02-03");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressAsMacaddr.Equals(param28)));
 
                 // PostgreSQL doesn't support equality comparison on point
-                // NpgsqlPoint? param27 = new NpgsqlPoint(5.2, 3.3);
-                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Point == param27));
+                // NpgsqlPoint? param29 = new NpgsqlPoint(5.2, 3.3);
+                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Point == param29));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param28 = @"{""a"": ""b""}";
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsJsonb == param28));
+                var param30 = @"{""a"": ""b""}";
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsJsonb == param30));
 
                 // operator does not exist: json = json (https://stackoverflow.com/questions/32843213/operator-does-not-exist-json-json)
-                // var param29 = @"{""a"": ""b""}";
-                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsJson == param29));
+                // var param31 = @"{""a"": ""b""}";
+                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.StringAsJson == param31));
 
-                var param30 = new Dictionary<string, string> { { "a", "b" } };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.DictionaryAsHstore == param30));
+                var param32 = new Dictionary<string, string> { { "a", "b" } };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.DictionaryAsHstore == param32));
 
-                var param31 = ImmutableDictionary<string, string>.Empty.Add("c", "d");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.ImmutableDictionaryAsHstore == param31));
+                var param33 = ImmutableDictionary<string, string>.Empty.Add("c", "d");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.ImmutableDictionaryAsHstore == param33));
 
-                var param32 = new NpgsqlRange<int>(4, true, 8, false);
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.NpgsqlRangeAsRange == param32));
+                var param34 = new NpgsqlRange<int>(4, true, 8, false);
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.NpgsqlRangeAsRange == param34));
 
-                var param33 = new[] { 2, 3 };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntArrayAsIntArray == param33));
+                var param35 = new[] { 2, 3 };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.IntArrayAsIntArray == param35));
 
-                var param34 = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") };
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressArrayAsMacaddrArray == param34));
-
-                // ReSharper disable once ConvertToConstant.Local
-                var param35 = (uint)int.MaxValue + 1;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsXid == param35));
-
-                var param36 = NpgsqlTsQuery.Parse("a & b");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchQuery == param36));
-
-                var param37 = NpgsqlTsVector.Parse("a b");
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchVector == param37));
+                var param36 = new[] { PhysicalAddress.Parse("08-00-2B-01-02-03"), PhysicalAddress.Parse("08-00-2B-01-02-04") };
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.PhysicalAddressArrayAsMacaddrArray == param36));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param38 = NpgsqlTsRankingNormalization.DivideByLength;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.RankingNormalization == param38));
+                var param37 = (uint)int.MaxValue + 1;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.UintAsXid == param37));
+
+                var param38 = NpgsqlTsQuery.Parse("a & b");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchQuery == param38));
+
+                var param39 = NpgsqlTsVector.Parse("a b");
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.SearchVector == param39));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param39 = 12724u;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Regconfig == param39));
+                var param40 = NpgsqlTsRankingNormalization.DivideByLength;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.RankingNormalization == param40));
 
                 // ReSharper disable once ConvertToConstant.Local
-                var param40 = Mood.Sad;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Mood == param40));
+                var param41 = 12724u;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Regconfig == param41));
+
+                // ReSharper disable once ConvertToConstant.Local
+                var param42 = Mood.Sad;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Mood == param42));
             }
         }
 
@@ -367,81 +380,89 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
                 TimeSpan? param19 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.TimeSpanAsInterval == param19));
 
-                string param20 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsText == param20));
+#if NET6_0_OR_GREATER
+                DateOnly? param20 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.DateOnlyAsDate == param20));
 
-                string param21 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsVarchar == param21));
+                TimeOnly? param21 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.TimeOnlyAsTime == param21));
+#endif
+
+                string param22 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsText == param22));
+
+                string param23 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsVarchar == param23));
 
                 // TODO: enable here (and above) after https://github.com/aspnet/EntityFrameworkCore/issues/14159 is fixed
-                // char? param21a = null;
-                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsChar1 == param21a));
+                // char? param23a = null;
+                // Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsChar1 == param23a));
 
-                char? param21b = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsText == param21b));
+                char? param23b = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsText == param23b));
 
-                char? param21c = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsVarchar == param21c));
+                char? param23c = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.CharAsVarchar == param23c));
 
-                byte[] param22 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsBytea == param22));
+                byte[] param24 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.BytesAsBytea == param24));
 
-                Guid? param23 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.GuidAsUuid == param23));
+                Guid? param25 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.GuidAsUuid == param25));
 
-                StringEnum16? param24 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.EnumAsText == param24));
+                StringEnum16? param26 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.EnumAsText == param26));
 
-                StringEnumU16? param25 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.EnumAsVarchar == param25));
+                StringEnumU16? param27 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.EnumAsVarchar == param27));
 
-                PhysicalAddress param26 = null;
+                PhysicalAddress param28 = null;
                 // ReSharper disable once PossibleUnintendedReferenceComparison
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressAsMacaddr == param26));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressAsMacaddr == param28));
 
                 // PostgreSQL does not support equality comparison on geometry types, see https://www.postgresql.org/docs/current/functions-geometry.html
-                //NpgsqlPoint? param27 = null;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlPointAsPoint == param27));
+                //NpgsqlPoint? param29 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlPointAsPoint == param29));
 
-                string param28 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsJsonb == param28));
+                string param30 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsJsonb == param30));
 
                 // PostgreSQL does not support equality comparison on json
-                //string param29 = null;
-                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsJson == param29));
+                //string param31 = null;
+                //Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.StringAsJson == param31));
 
-                Dictionary<string, string> param30 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.DictionaryAsHstore == param30));
+                Dictionary<string, string> param32 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.DictionaryAsHstore == param32));
 
-                ImmutableDictionary<string, string> param31 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.ImmutableDictionaryAsHstore == param31));
+                ImmutableDictionary<string, string> param33 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.ImmutableDictionaryAsHstore == param33));
 
-                NpgsqlRange<int>? param32 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlRangeAsRange == param32));
+                NpgsqlRange<int>? param34 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.NpgsqlRangeAsRange == param34));
 
-                int[] param33 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param33));
+                int[] param35 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.IntArrayAsIntArray == param35));
 
-                PhysicalAddress[] param34 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param34));
+                PhysicalAddress[] param36 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.PhysicalAddressArrayAsMacaddrArray== param36));
 
-                uint? param35 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param35));
+                uint? param37 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.UintAsXid == param37));
 
-                NpgsqlTsQuery param36 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchQuery == param36));
+                NpgsqlTsQuery param38 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchQuery == param38));
 
-                NpgsqlTsVector param37 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchVector == param37));
+                NpgsqlTsVector param39 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SearchVector == param39));
 
-                NpgsqlTsRankingNormalization? param38 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.RankingNormalization == param38));
+                NpgsqlTsRankingNormalization? param40 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.RankingNormalization == param40));
 
-                uint? param39 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Regconfig == param39));
+                uint? param41 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Regconfig == param41));
 
-                Mood? param40 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Mood == param40));
+                Mood? param42 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Mood == param42));
             }
         }
 
@@ -673,6 +694,11 @@ WHERE m.""TimeSpanAsTime"" = @__timeSpan_0");
             Assert.Null(entity.TimeSpanAsTime);
             Assert.Null(entity.DateTimeOffsetAsTimetz);
             Assert.Null(entity.TimeSpanAsInterval);
+
+            #if NET6_0_OR_GREATER
+            Assert.Null(entity.DateOnlyAsDate);
+            Assert.Null(entity.TimeOnlyAsTime);
+            #endif
 
             Assert.Null(entity.StringAsText);
             Assert.Null(entity.StringAsVarchar);
@@ -1280,6 +1306,14 @@ FROM ""MappedDataTypes"" AS m");
 
             [Column(TypeName = "time")]
             public TimeSpan? TimeSpanAsTime { get; set; }
+
+#if NET6_0_OR_GREATER
+            [Column(TypeName = "date")]
+            public DateOnly? DateOnlyAsDate { get; set; }
+
+            [Column(TypeName = "time")]
+            public TimeOnly? TimeOnlyAsTime { get; set; }
+#endif
 
             [Column(TypeName = "timetz")]
             public DateTimeOffset? DateTimeOffsetAsTimetz { get; set; }

--- a/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Xunit;
@@ -200,6 +201,284 @@ WHERE (floor(date_part('millisecond', m.""Duration""))::INT % 1000) = 1");
 
         #endregion TimeSpan
 
+#if DATEONLY_TIMEONLY_TESTS_IMPLEMENTED_UPSTREAM
+#if NET6_0_OR_GREATER
+        #region DateOnly
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_ctor(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m =>
+                    new DateOnly(EF.Property<DateOnly>(m, "Date").Year, EF.Property<DateOnly>(m, "Date").Month, 1) == new DateOnly(1996, 9, 11)));
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE make_date(date_part('year', m.""Date"")::INT, date_part('month', m.""Date"")::INT, 1) = DATE '1996-09-11'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_Year(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.Year == 1990).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('year', m.""Date"")::INT = 1990");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_Month(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.Month == 11).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('month', m.""Date"")::INT = 11");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_Day(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.Day == 10).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('day', m.""Date"")::INT = 10");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_DayOfYear(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.DayOfYear == 314).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('doy', m.""Date"")::INT = 314");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_DayOfWeek(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.DayOfWeek == DayOfWeek.Saturday).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE floor(date_part('dow', m.""Date""))::INT = 6");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_AddYears(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.AddYears(3) == new DateOnly(1993, 11, 10)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Date"" + INTERVAL '3 years') = DATE '1993-11-10'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_AddMonths(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.AddMonths(3) == new DateOnly(1991, 2, 10)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Date"" + INTERVAL '3 months') = DATE '1991-02-10'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_DateOnly_AddDays(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Date.AddDays(3) == new DateOnly(1990, 11, 13)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Date"" + INTERVAL '3 days') = DATE '1990-11-13'");
+        }
+
+        #endregion DateOnly
+
+        #region TimeOnly
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_Hour(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Hour == 10).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('hour', m.""Time"")::INT = 10");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_Minute(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Minute == 15).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('minute', m.""Time"")::INT = 15");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_Second(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Second == 50).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE date_part('second', m.""Time"")::INT = 50");
+        }
+
+        // [ConditionalTheory]
+        // [MemberData(nameof(IsAsyncData))]
+        // public virtual Task Where_TimeOnly_Millisecond(bool async)
+        // {
+        //     return Task.CompletedTask;
+        //     // SQL translation not implemented, too annoying
+        //     // await AssertQuery(
+        //     //     async,
+        //     //     ss => ss.Set<Mission>().Where(m => m.Time.Millisecond == 500).AsTracking(),
+        //     //     entryCount: 1);
+        // }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_AddHours(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.AddHours(3) == new TimeOnly(13, 15, 50, 500)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Time"" + INTERVAL '3 hours') = TIME '13:15:50.5'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_AddMinutes(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.AddMinutes(3) == new TimeOnly(10, 18, 50, 500)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Time"" + INTERVAL '3 mins') = TIME '10:18:50.5'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_Add_TimeSpan(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.Add(new TimeSpan(3, 0, 0)) == new TimeOnly(13, 15, 50, 500)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Time"" + INTERVAL '03:00:00') = TIME '13:15:50.5'");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_IsBetween(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time.IsBetween(new TimeOnly(10, 0, 0), new TimeOnly(11, 0, 0))).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Time"" >= TIME '10:00:00') AND (m.""Time"" < TIME '11:00:00')");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Where_TimeOnly_subtract_TimeOnly(bool async)
+        {
+            await AssertQuery(
+                async,
+                ss => ss.Set<Mission>().Where(m => m.Time - new TimeOnly(10, 0, 0) == new TimeSpan(0, 0, 15, 50, 500)).AsTracking(),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT m.""Id"", m.""CodeName"", m.""Date"", m.""Duration"", m.""Rating"", m.""Time"", m.""Timeline""
+FROM ""Missions"" AS m
+WHERE (m.""Time"" - TIME '10:00:00') = INTERVAL '00:15:50.5'");
+        }
+
+        #endregion TimeOnly
+#endif
+#endif
         private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -24,8 +24,17 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
 
         [Fact]
         public void GenerateSqlLiteral_returns_date_literal()
-            => Assert.Equal("DATE '2015-03-12'",
+        {
+            Assert.Equal(
+                "DATE '2015-03-12'",
                 GetMapping("date").GenerateSqlLiteral(new DateTime(2015, 3, 12)));
+
+#if NET6_0_OR_GREATER
+            Assert.Equal(
+                "DATE '2015-03-12'",
+                GetMapping("date").GenerateSqlLiteral(new DateOnly(2015, 3, 12)));
+#endif
+        }
 
         [Fact]
         public void GenerateSqlLiteral_returns_timestamp_literal()
@@ -75,12 +84,23 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage
         public void GenerateSqlLiteral_returns_time_literal()
         {
             var mapping = GetMapping("time");
+
             Assert.Equal("TIME '04:05:06.123456'",
                 mapping.GenerateSqlLiteral(new TimeSpan(0, 4, 5, 6, 123).Add(TimeSpan.FromTicks(4560))));
             Assert.Equal("TIME '04:05:06.000123'",
                 mapping.GenerateSqlLiteral(new TimeSpan(0, 4, 5, 6).Add(TimeSpan.FromTicks(1230))));
             Assert.Equal("TIME '04:05:06.123'", mapping.GenerateSqlLiteral(new TimeSpan(0, 4, 5, 6, 123)));
             Assert.Equal("TIME '04:05:06'", mapping.GenerateSqlLiteral(new TimeSpan(4, 5, 6)));
+
+#if NET6_0_OR_GREATER
+            Assert.Equal("TIME '04:05:06.123456'",
+                mapping.GenerateSqlLiteral(new TimeOnly(4, 5, 6, 123).Add(TimeSpan.FromTicks(4560))));
+            Assert.Equal("TIME '04:05:06.000123'",
+                mapping.GenerateSqlLiteral(new TimeOnly(4, 5, 6).Add(TimeSpan.FromTicks(1230))));
+            Assert.Equal("TIME '04:05:06.123'", mapping.GenerateSqlLiteral(new TimeOnly(4, 5, 6, 123)));
+            Assert.Equal("TIME '04:05:06'", mapping.GenerateSqlLiteral(new TimeOnly(4, 5, 6)));
+            Assert.Equal("TIME '13:05:06'", mapping.GenerateSqlLiteral(new TimeOnly(13, 5, 6)));
+#endif
         }
 
         [Fact]


### PR DESCRIPTION
Multitarget to net6.0

Closes #1781
Fixes #1865

Note that the translation tests are commented out, since they depend on upstream test support in EF Core, which doesn't have them yet (I'll work on this). I've verified locally that all the commented-out tests work.