### PR TITLE
Fix array member nullability check

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -652,9 +652,10 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal
             // We decode NRT annotations here to return the correct type mapping.
             if (mapping is NpgsqlArrayTypeMapping arrayMapping
                 && !arrayMapping.ElementMapping.ClrType.IsValueType
-                && !property.IsShadowProperty())
+                && !property.IsShadowProperty()
+                && property.GetMemberInfo(forMaterialization: false, forSet: false) is MemberInfo memberInfo
+                && memberInfo.GetMemberType().IsArrayOrGenericList())
             {
-                var memberInfo = property.GetMemberInfo(forMaterialization: false, forSet: false);
                 if (_referenceNullabilityDecoder.IsArrayOrListElementNonNullable(memberInfo))
                 {
                     return arrayMapping.MakeNonNullable();

--- a/src/EFCore.PG/Utilities/ReferenceNullabilityDecoder.cs
+++ b/src/EFCore.PG/Utilities/ReferenceNullabilityDecoder.cs
@@ -60,7 +60,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Utilities
         {
             if (!memberInfo.GetMemberType().TryGetElementType(out var elementType))
             {
-                throw new ArgumentException("Argument isn't an array or generic List", nameof(memberInfo));
+                throw new ArgumentException($"Member {memberInfo.DeclaringType?.Name}.{memberInfo.Name} isn't an array or generic List", nameof(memberInfo));
             }
 
             if (elementType.IsValueType)


### PR DESCRIPTION
Only check cases when the CLR type is actually an array or generic list.

Fixes #1839