### PR TITLE
Add support for TotaHours and Duration

### DIFF
--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -209,18 +209,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
             return _sqlExpressionFactory.Convert(result, typeof(int));
         }
         
-        /// <summary>
-        /// Constructs the DATE_PART expression.
-        /// </summary>
-        /// <param name="e">The member expression.</param>
-        /// <param name="partName">The name of the DATE_PART to construct.</param>
-        /// <param name="floor">True if the result should be wrapped with FLOOR(...); otherwise, false.</param>
-        /// <returns>
-        /// The DATE_PART expression.
-        /// </returns>
-        /// <remarks>
-        /// DATE_PART returns doubles
-        /// </remarks>
         private SqlExpression GetDatePartExpressionDouble(
             SqlExpression instance,
             string partName,

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -86,7 +86,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
             return null;
         }
 
-        private SqlExpression TranslateDurationTotalMember(SqlExpression instance, double divisor) =>  _sqlExpressionFactory.Divide(GetDatePartExpressionDouble(instance, "epoch"), _sqlExpressionFactory.Constant(divisor));
+        private SqlExpression TranslateDurationTotalMember(SqlExpression instance, double divisor)
+            =>  _sqlExpressionFactory.Divide(GetDatePartExpressionDouble(instance, "epoch"), _sqlExpressionFactory.Constant(divisor));
         
         private SqlExpression? TranslateDuration(SqlExpression instance, MemberInfo member)
             => member.Name switch

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -67,18 +67,20 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
                 return _sqlExpressionFactory.Constant(SystemClock.Instance);
 
             var declaringType = member.DeclaringType;
-            if (instance is not null
-                && (declaringType == typeof(LocalDateTime)
+            if (instance is not null)
+            {
+                if (declaringType == typeof(LocalDateTime)
                     || declaringType == typeof(LocalDate)
                     || declaringType == typeof(LocalTime)
-                    || declaringType == typeof(Period)))
-            {
-                return TranslateDateTime(instance, member, returnType);
-            }
+                    || declaringType == typeof(Period))
+                {
+                    return TranslateDateTime(instance, member, returnType);
+                }
 
-            if (instance is not null && declaringType == typeof(Duration))
-            {
-                return TranslateDuration(instance, member);
+                if (declaringType == typeof(Duration))
+                {
+                    return TranslateDuration(instance, member);
+                }
             }
 
             return null;

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -104,7 +104,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
                 nameof(Duration.Minutes) => GetDatePartExpression(instance, "minute"),
                 nameof(Duration.Seconds) => GetDatePartExpression(instance, "second", true),
                 nameof(Duration.Milliseconds) => null, // Too annoying, floating point and sub-millisecond handling
-                _ => null
+                _ => null,
             };
         }
 

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -71,7 +71,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
                 && (declaringType == typeof(LocalDateTime)
                     || declaringType == typeof(LocalDate)
                     || declaringType == typeof(LocalTime)
-                    || declaringType == typeof(Period)))
+                    || declaringType == typeof(Period))
+                    || declaringType == typeof(Duration)))
             {
                 return TranslateDateTime(instance, member, returnType);
             }
@@ -152,6 +153,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
                 // are default-mapped from CLR types (timespan maps to interval,
                 // which timestamp cannot be cast into)
                 return null;
+
+            case "TotalHours":
+                return sqlExpressionFactory.Divide(GetDatePartExpression(instance, "epoch"), sqlExpressionFactory.Constant(3600));
 
             default:
                 return null;

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -126,7 +126,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
                         _sqlExpressionFactory.Constant(1000)
                     ), typeof(int));
                         
-                default: return null;
+                default: 
+                    return null;
             }
         }
 

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -88,12 +88,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
 
         private SqlExpression TranslateDurationTotalMember(SqlExpression instance, double divisor) =>  _sqlExpressionFactory.Divide(GetDatePartExpressionDouble(instance, "epoch"), _sqlExpressionFactory.Constant(divisor));
         
-        /// <summary>
-        /// Translates Duration members
-        /// </summary>
-        /// <param name="instance"></param>
-        /// <param name="member"></param>
-        /// <returns>The translated expression or null</returns>
         private SqlExpression? TranslateDuration(SqlExpression instance, MemberInfo member)
             => member.Name switch
             {

--- a/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/ExpressionTranslators/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -85,13 +85,13 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime
 
             return null;
         }
-        
-        
+
         private SqlExpression? TranslateDuration(SqlExpression instance, MemberInfo member)
         {
-            var translateDurationTotalMember = new Func<SqlExpression, double, SqlBinaryExpression>((inst, divisor) =>  
-                _sqlExpressionFactory.Divide(GetDatePartExpressionDouble(inst, "epoch"), _sqlExpressionFactory.Constant(divisor)));
-            
+            var translateDurationTotalMember = new Func<SqlExpression, double, SqlBinaryExpression>(
+                (inst, divisor) =>
+                    _sqlExpressionFactory.Divide(GetDatePartExpressionDouble(inst, "epoch"), _sqlExpressionFactory.Constant(divisor)));
+
             return member.Name switch
             {
                 nameof(Duration.TotalDays) => translateDurationTotalMember(instance, 86400),

--- a/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -432,6 +432,7 @@ LIMIT 2");
         #endregion Period
 
         #region Duration
+
         [Fact]
         public void Duration_TotalDays()
         {

--- a/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -514,15 +514,6 @@ LIMIT 2");
             Assert.Contains(@"FLOOR(DATE_PART('second', n.""Duration""))::INT", Sql);
         }
 
-        [Fact]
-        public void Duration_Milliseconds()
-        {
-            using var ctx = CreateContext();
-            var d = ctx.NodaTimeTypes.Select(t => t.Duration.Milliseconds).ToList();
-            Assert.Equal(20, d.First());
-            Assert.Contains(@"CAST(((DATE_PART('second', n.""Duration"") - FLOOR(DATE_PART('second', n.""Duration""))) * 1000.0) AS integer)", Sql);
-        }
-
         #endregion
 
         #region Range

--- a/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -519,7 +519,7 @@ LIMIT 2");
             using var ctx = CreateContext();
             var d = ctx.NodaTimeTypes.Select(t => t.Duration.Milliseconds).ToList();
             Assert.Equal(20, d.First());
-            Assert.Contains(@"((DATE_PART('second', n.""Duration"") - FLOOR(DATE_PART('second', n.""Duration""))) * 1000.0)::int", Sql);
+            Assert.Contains(@"CAST(((DATE_PART('second', n.""Duration"") - FLOOR(DATE_PART('second', n.""Duration""))) * 1000.0) AS integer)", Sql);
         }
 
         #endregion

--- a/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -430,6 +431,99 @@ LIMIT 2");
 
         #endregion Period
 
+        #region Duration
+        [Fact]
+        public void Duration_TotalDays()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.TotalDays).ToList();
+            Assert.Equal(27.3779, Math.Round(d.First(), 4));
+            Assert.Contains(@"DATE_PART('epoch', n.""Duration"") / 86400", Sql);
+        }
+
+        [Fact]
+        public void Duration_TotalHours()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.TotalHours).ToList();
+            Assert.Equal(657.0689, Math.Round(d.First(), 4));
+            Assert.Contains(@"DATE_PART('epoch', n.""Duration"") / 3600", Sql);
+        }
+
+        [Fact]
+        public void Duration_TotalMinutes()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.TotalMinutes).ToList();
+            Assert.Equal(39424.1337, Math.Round(d.First(), 4));
+            Assert.Contains(@"DATE_PART('epoch', n.""Duration"") / 60", Sql);
+        }
+
+        [Fact]
+        public void Duration_TotalSeconds()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.TotalSeconds).ToList();
+            Assert.Equal(2365448.02, d.First());
+            Assert.Contains(@"DATE_PART('epoch', n.""Duration"") / 1", Sql);
+        }
+
+        [Fact]
+        public void Duration_TotalMilliseconds()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.TotalMilliseconds).ToList();
+            Assert.Equal(2365448020, d.First());
+            Assert.Contains(@"DATE_PART('epoch', n.""Duration"") / 0.001", Sql);
+        }
+
+        [Fact]
+        public void Duration_Days()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.Days).ToList();
+            Assert.Equal(27, d.First());
+            Assert.Contains(@"DATE_PART('day', n.""Duration"")::INT", Sql);
+        }
+
+        [Fact]
+        public void Duration_Hours()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.Hours).ToList();
+            Assert.Equal(9, d.First());
+            Assert.Contains(@"DATE_PART('hour', n.""Duration"")::INT", Sql);
+        }
+
+        [Fact]
+        public void Duration_Minutes()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.Minutes).ToList();
+            Assert.Equal(4, d.First());
+            Assert.Contains(@"DATE_PART('minute', n.""Duration"")::INT", Sql);
+        }
+
+        [Fact]
+        public void Duration_Seconds()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.Seconds).ToList();
+            Assert.Equal(8, d.First());
+            Assert.Contains(@"FLOOR(DATE_PART('second', n.""Duration""))::INT", Sql);
+        }
+
+        [Fact]
+        public void Duration_Milliseconds()
+        {
+            using var ctx = CreateContext();
+            var d = ctx.NodaTimeTypes.Select(t => t.Duration.Milliseconds).ToList();
+            Assert.Equal(20, d.First());
+            Assert.Contains(@"((DATE_PART('second', n.""Duration"") - FLOOR(DATE_PART('second', n.""Duration""))) * 1000.0)::int", Sql);
+        }
+
+        #endregion
+
         #region Range
 
         [Fact]
@@ -500,6 +594,11 @@ LIMIT 2");
                 var localDateTime = new LocalDateTime(2018, 4, 20, 10, 31, 33, 666);
                 var zonedDateTime = localDateTime.InUtc();
                 var instant = zonedDateTime.ToInstant();
+                var duration = Duration.FromMilliseconds(20)
+                    .Plus(Duration.FromSeconds(8))
+                    .Plus(Duration.FromMinutes(4))
+                    .Plus(Duration.FromHours(9))
+                    .Plus(Duration.FromDays(27));
 
                 _defaultPeriod = Period.FromYears(2018) + Period.FromMonths(4) + Period.FromDays(20) +
                                 Period.FromHours(10) + Period.FromMinutes(31) + Period.FromSeconds(23) +
@@ -515,7 +614,8 @@ LIMIT 2");
                     LocalTime = localDateTime.TimeOfDay,
                     OffsetTime = new OffsetTime(new LocalTime(10, 31, 33, 666), Offset.Zero),
                     Period = _defaultPeriod,
-                    DateRange = new NpgsqlRange<LocalDate>(localDateTime.Date, localDateTime.Date.PlusDays(5))
+                    DateRange = new NpgsqlRange<LocalDate>(localDateTime.Date, localDateTime.Date.PlusDays(5)),
+                    Duration = duration,
                 });
                 context.SaveChanges();
             }
@@ -533,6 +633,7 @@ LIMIT 2");
             public LocalTime LocalTime { get; set; }
             public OffsetTime OffsetTime { get; set; }
             public Period Period { get; set; }
+            public Duration Duration { get; set; }
             public NpgsqlRange<LocalDate> DateRange { get; set; }
             // ReSharper restore UnusedAutoPropertyAccessor.Global
         }


### PR DESCRIPTION
This adds a Translation for `TotalHours` of the `Duration` Type.

Maybe we should refactor this class and use `nameof` for all string constants.

Fixes #1933