### PR TITLE
Don't scaffold database collation when it's the default

### DIFF
--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -174,11 +174,15 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Scaffolding.Internal
             if (connection.Settings.ServerCompatibilityMode == ServerCompatibilityMode.Redshift)
                 return;
 
-            var commandText = @"SELECT datcollate FROM pg_database WHERE datname=current_database()";
+            var commandText = @"
+SELECT datcollate FROM pg_database WHERE datname=current_database() AND
+        datcollate <> (SELECT datcollate FROM pg_database WHERE datname='template1')";
             using var command = new NpgsqlCommand(commandText, connection);
             using var reader = command.ExecuteReader();
             if (reader.Read())
+            {
                 databaseModel.Collation = reader.GetString(0);
+            }
         }
 
         /// <summary>

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -1601,6 +1601,17 @@ CREATE TABLE columns_with_collation (
                 },
                 @"DROP TABLE columns_with_collation");
 
+        [ConditionalFact]
+        public void Default_database_collation_is_not_scaffolded()
+        {
+            Test(
+                @"-- Empty database",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel => Assert.Null(dbModel.Collation),
+                @"");
+        }
+
         [Fact]
         public void Index_method()
             => Test(@"


### PR DESCRIPTION
Note: the "default collation" is considered to be the collation of the `template1` database, which is what's used when a simple CREATE DATABASE is executed.

Fixes #1981
