### PR TITLE
Don't block querying over DateOnly/TimeOnly in JSON

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonPocoTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonPocoTranslator.cs
@@ -123,7 +123,10 @@ public class NpgsqlJsonPocoTranslator : IMemberTranslator
                 return _sqlExpressionFactory.Convert(expression, returnType, _typeMappingSource.FindMapping(returnType, _model));
         }
 
-        if (unwrappedReturnType == typeof(Guid) || unwrappedReturnType == typeof(DateTimeOffset))
+        if (unwrappedReturnType == typeof(Guid)
+            || unwrappedReturnType == typeof(DateTimeOffset)
+            || unwrappedReturnType == typeof(DateOnly)
+            || unwrappedReturnType == typeof(TimeOnly))
         {
             return _sqlExpressionFactory.Convert(expression, returnType, _typeMappingSource.FindMapping(returnType, _model));
         }


### PR DESCRIPTION
Though until System.Text.Json supports DateOnly/TimeOnly, converters must be used.

Fixes #2148
