### PR TITLE
Fix Redshift Compatibility for Insert Operation

### DIFF
--- a/src/EFCore.PG/Update/Internal/NpgsqlUpdateSqlGenerator.cs
+++ b/src/EFCore.PG/Update/Internal/NpgsqlUpdateSqlGenerator.cs
@@ -1,12 +1,16 @@
 using System.Text;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Update.Internal;
 
 public class NpgsqlUpdateSqlGenerator : UpdateSqlGenerator
 {
-    public NpgsqlUpdateSqlGenerator(UpdateSqlGeneratorDependencies dependencies)
+    private readonly INpgsqlOptions _npgsqlOptions;
+
+    public NpgsqlUpdateSqlGenerator(UpdateSqlGeneratorDependencies dependencies, INpgsqlOptions npgsqlOptions)
         : base(dependencies)
     {
+        _npgsqlOptions = npgsqlOptions;
     }
 
     public override ResultSetMapping AppendInsertOperation(
@@ -24,8 +28,8 @@ public class NpgsqlUpdateSqlGenerator : UpdateSqlGenerator
         Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
         Check.NotNull(command, nameof(command));
 
-        var name = command.TableName;
-        var schema = command.Schema;
+        var tableName = command.TableName;
+        var schemaName = command.Schema;
         var operations = command.ColumnModifications;
 
         var writeOperations = operations.Where(o => o.IsWrite).ToArray();
@@ -38,10 +42,10 @@ public class NpgsqlUpdateSqlGenerator : UpdateSqlGenerator
         }
 
         AppendValuesHeader(commandStringBuilder, writeOperations);
-        AppendValues(commandStringBuilder, name, schema, writeOperations);
+        AppendValues(commandStringBuilder, tableName, schemaName, writeOperations);
         if (readOperations.Length > 0)
         {
-            AppendReturningClause(commandStringBuilder, readOperations);
+            AppendReturningClause(commandStringBuilder, readOperations, writeOperations, tableName, schemaName);
         }
 
         commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator).AppendLine();
@@ -69,7 +73,7 @@ public class NpgsqlUpdateSqlGenerator : UpdateSqlGenerator
         AppendWhereClause(commandStringBuilder, conditionOperations);
         if (readOperations.Length > 0)
         {
-            AppendReturningClause(commandStringBuilder, readOperations);
+            AppendReturningClause(commandStringBuilder, readOperations, writeOperations, tableName, schemaName);
         }
         commandStringBuilder.Append(SqlGenerationHelper.StatementTerminator).AppendLine();
         return ResultSetMapping.NoResultSet;
@@ -78,12 +82,34 @@ public class NpgsqlUpdateSqlGenerator : UpdateSqlGenerator
     // ReSharper disable once ParameterTypeCanBeEnumerable.Local
     private void AppendReturningClause(
         StringBuilder commandStringBuilder,
-        IReadOnlyList<IColumnModification> operations)
+        IReadOnlyList<IColumnModification> readOperations,
+        IReadOnlyList<IColumnModification> writeOperations,
+        string tableName,
+        string? schemaName)
     {
+        if (_npgsqlOptions.UseRedshift)
+        {
+            var targetTableName = schemaName != null ? $"{schemaName}.{tableName}" : tableName;
+
+            commandStringBuilder
+                .Append(SqlGenerationHelper.StatementTerminator)
+                .AppendLine()
+                .Append("SELECT ")
+                .AppendJoin(readOperations.Select(c => SqlGenerationHelper.DelimitIdentifier(c.ColumnName)))
+                .AppendLine()
+                .Append("FROM ")
+                .Append(targetTableName)
+                .AppendLine()
+                .Append("WHERE ")
+                .AppendJoin(writeOperations.Select(w => $"{w.ColumnName} = @{w.ParameterName}"), " AND ");
+
+            return;
+        }
+
         commandStringBuilder
             .AppendLine()
             .Append("RETURNING ")
-            .AppendJoin(operations.Select(c => SqlGenerationHelper.DelimitIdentifier(c.ColumnName)));
+            .AppendJoin(readOperations.Select(c => SqlGenerationHelper.DelimitIdentifier(c.ColumnName)));
     }
 
     public override void AppendNextSequenceValueOperation(StringBuilder commandStringBuilder, string name, string? schema)

--- a/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchFactoryTest.cs
@@ -34,7 +34,8 @@ public class NpgsqlModificationCommandBatchFactoryTest
                     new UpdateSqlGeneratorDependencies(
                         new NpgsqlSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
-                        typeMapper)),
+                        typeMapper),
+                    new NpgsqlOptions()),
                 new TypedRelationalValueBufferFactoryFactory(
                     new RelationalValueBufferFactoryDependencies(
                         typeMapper, new CoreSingletonOptions())),
@@ -73,7 +74,8 @@ public class NpgsqlModificationCommandBatchFactoryTest
                     new UpdateSqlGeneratorDependencies(
                         new NpgsqlSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
-                        typeMapper)),
+                        typeMapper),
+                    new NpgsqlOptions()),
                 new TypedRelationalValueBufferFactoryFactory(
                     new RelationalValueBufferFactoryDependencies(
                         typeMapper, new CoreSingletonOptions())),

--- a/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchTest.cs
+++ b/test/EFCore.PG.Tests/Update/NpgsqlModificationCommandBatchTest.cs
@@ -32,7 +32,8 @@ public class NpgsqlModificationCommandBatchTest
                     new UpdateSqlGeneratorDependencies(
                         new NpgsqlSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
-                        typeMapper)),
+                        typeMapper),
+                    new NpgsqlOptions()),
                 new TypedRelationalValueBufferFactoryFactory(
                     new RelationalValueBufferFactoryDependencies(
                         typeMapper, new CoreSingletonOptions())),


### PR DESCRIPTION
This is trying to fix the compatibility issue for Redshift during the Insert Operation. Redshift does not support the RETURNING keyword. Hence, will throw error upon executing an insert operation.

I am not entirely sure if I am modifying correctly for the test files. Also if there are any existing util functions that I should have used for the changes in NpgsqlUpdateSqlGenerator.cs file, please kindly point me to the right direction. Will be more than happy to fix it up.

Cheers!

**Existing Sample SQL Generated**
```
INSERT INTO schema.table (f0, f1, f2, f3)
VALUES (@p0, @p1, @p2, @p3)
RETURNING tbl_key
```

**SQL Generated with This PR:**
```
INSERT INTO schema.table (f0, f1, f2, f3)
VALUES (@p0, @p1, @p2, @p3);
SELECT tbl_key
FROM schema.table
WHERE f0 = @p0 AND f1 = @p1 AND f2 = @p2 AND f3= @p3
```

**Usage during the DI required would then be** 
```
services.AddDbContext<YourContext>((provider, options) =>
{
    options.UseNpgsql(connectionString, o =>
    {
        o.UseRedshift(true);
    });
});
```
