### PR TITLE
Add overload `EnableRetryOnFailure`.

### DIFF
--- a/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
+++ b/src/EFCore.PG/Infrastructure/NpgsqlDbContextOptionsBuilder.cs
@@ -154,6 +154,16 @@ public class NpgsqlDbContextOptionsBuilder
     /// <summary>
     /// Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
     /// </summary>
+    /// <param name="errorCodesToAdd">Additional error codes that should be considered transient.</param>
+    /// <returns>
+    /// An instance of <see cref="NpgsqlDbContextOptionsBuilder"/> with the specified parameters.
+    /// </returns>
+    public virtual NpgsqlDbContextOptionsBuilder EnableRetryOnFailure(ICollection<string>? errorCodesToAdd)
+        => ExecutionStrategy(c => new NpgsqlRetryingExecutionStrategy(c, errorCodesToAdd));
+
+    /// <summary>
+    /// Configures the context to use the default retrying <see cref="IExecutionStrategy" />.
+    /// </summary>
     /// <param name="maxRetryCount">The maximum number of retry attempts.</param>
     /// <param name="maxRetryDelay">The maximum delay between retries.</param>
     /// <param name="errorCodesToAdd">Additional error codes that should be considered transient.</param>

--- a/src/EFCore.PG/NpgsqlRetryingExecutionStrategy.cs
+++ b/src/EFCore.PG/NpgsqlRetryingExecutionStrategy.cs
@@ -56,6 +56,18 @@ public class NpgsqlRetryingExecutionStrategy : ExecutionStrategy
     /// <summary>
     ///     Creates a new instance of <see cref="NpgsqlRetryingExecutionStrategy" />.
     /// </summary>
+    /// <param name="dependencies"> Parameter object containing service dependencies. </param>
+    /// <param name="errorCodesToAdd"> Additional error codes that should be considered transient. </param>
+    public NpgsqlRetryingExecutionStrategy(
+        ExecutionStrategyDependencies dependencies,
+        ICollection<string>? errorCodesToAdd)
+        : this(dependencies, DefaultMaxRetryCount, DefaultMaxDelay, errorCodesToAdd)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a new instance of <see cref="NpgsqlRetryingExecutionStrategy" />.
+    /// </summary>
     /// <param name="context"> The context on which the operations will be invoked. </param>
     /// <param name="maxRetryCount"> The maximum number of retry attempts. </param>
     /// <param name="maxRetryDelay"> The maximum delay between retries. </param>


### PR DESCRIPTION
Allow specifying `errorCodesToAdd` without count or delay.

Fixes #2048.