### PR TITLE
Add missing LTree expression types in PostgresBinaryExpression

### DIFF
--- a/src/EFCore.PG/Query/Expressions/Internal/PostgresBinaryExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/PostgresBinaryExpression.cs
@@ -1,3 +1,5 @@
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
+
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
 
 /// <summary>
@@ -119,6 +121,7 @@ public class PostgresBinaryExpression : SqlExpression
                 PostgresExpressionType.JsonExists    => "?",
                 PostgresExpressionType.JsonExistsAny => "?|",
                 PostgresExpressionType.JsonExistsAll => "?&",
+
                 PostgresExpressionType.LTreeMatches
                     when Right.TypeMapping?.StoreType == "lquery" ||
                     Right.TypeMapping is NpgsqlArrayTypeMapping arrayMapping &&

--- a/src/EFCore.PG/Query/Expressions/Internal/PostgresBinaryExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/PostgresBinaryExpression.cs
@@ -119,6 +119,21 @@ public class PostgresBinaryExpression : SqlExpression
                 PostgresExpressionType.JsonExists    => "?",
                 PostgresExpressionType.JsonExistsAny => "?|",
                 PostgresExpressionType.JsonExistsAll => "?&",
+                PostgresExpressionType.LTreeMatches
+                    when Right.TypeMapping?.StoreType == "lquery" ||
+                    Right.TypeMapping is NpgsqlArrayTypeMapping arrayMapping &&
+                    arrayMapping.ElementMapping.StoreType == "lquery"
+                    => "~",
+                PostgresExpressionType.LTreeMatches
+                    when Right.TypeMapping?.StoreType == "ltxtquery"
+                    => "@",
+                PostgresExpressionType.LTreeMatchesAny      => "?",
+                PostgresExpressionType.LTreeFirstAncestor   => "?@>",
+                PostgresExpressionType.LTreeFirstDescendent => "?<@",
+                PostgresExpressionType.LTreeFirstMatches
+                    when Right.TypeMapping?.StoreType == "lquery" => "?~",
+                PostgresExpressionType.LTreeFirstMatches
+                    when Right.TypeMapping?.StoreType == "ltxtquery" => "?@",
 
                 PostgresExpressionType.PostgisDistanceKnn => "<->",
 


### PR DESCRIPTION
 fixes error Unhandled operator type combined with log in debug level