### PR TITLE
Fix Date translations

### DIFF
--- a/test/EFCore.PG.FunctionalTests/Query/TimestampQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/TimestampQueryTest.cs
@@ -336,6 +336,41 @@ WHERE now() <> @__myDatetime_0");
 
     #endregion Now
 
+    #region Date member
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    [MinimumPostgresVersion(12, 0)]
+    public virtual async Task Where_datetime_date_on_timestamptz(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Entity>().Where(e => e.TimestamptzDateTime.Date == new DateTime(1998, 4, 12, 0, 0, 0, DateTimeKind.Utc)),
+            entryCount: 1);
+
+        AssertSql(
+            @"SELECT e.""Id"", e.""TimestampDateTime"", e.""TimestampDateTimeArray"", e.""TimestampDateTimeOffset"", e.""TimestampDateTimeOffsetArray"", e.""TimestampDateTimeRange"", e.""TimestamptzDateTime"", e.""TimestamptzDateTimeArray"", e.""TimestamptzDateTimeRange""
+FROM ""Entities"" AS e
+WHERE date_trunc('day', e.""TimestamptzDateTime"", 'UTC') = TIMESTAMPTZ '1998-04-12 00:00:00Z'");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public virtual async Task Where_datetime_date_on_timestamp(bool async)
+    {
+        await AssertQuery(
+            async,
+            ss => ss.Set<Entity>().Where(e => e.TimestampDateTime.Date == new DateTime(1998, 4, 12, 0, 0, 0, DateTimeKind.Local)),
+            entryCount: 1);
+
+        AssertSql(
+            @"SELECT e.""Id"", e.""TimestampDateTime"", e.""TimestampDateTimeArray"", e.""TimestampDateTimeOffset"", e.""TimestampDateTimeOffsetArray"", e.""TimestampDateTimeRange"", e.""TimestamptzDateTime"", e.""TimestamptzDateTimeArray"", e.""TimestamptzDateTimeRange""
+FROM ""Entities"" AS e
+WHERE date_trunc('day', e.""TimestampDateTime"") = TIMESTAMP '1998-04-12 00:00:00'");
+    }
+
+    #endregion
+
     #region DateTimeOffset
 
     [ConditionalTheory]

--- a/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -274,7 +274,7 @@ WHERE FLOOR(DATE_PART('second', n.""LocalDateTime""))::INT = 33");
         AssertSql(
             @"SELECT n.""Id"", n.""DateInterval"", n.""Duration"", n.""Instant"", n.""InstantRange"", n.""Interval"", n.""LocalDate"", n.""LocalDate2"", n.""LocalDateRange"", n.""LocalDateTime"", n.""LocalTime"", n.""Long"", n.""OffsetTime"", n.""Period"", n.""TimeZoneId"", n.""ZonedDateTime""
 FROM ""NodaTimeTypes"" AS n
-WHERE DATE_TRUNC('day', n.""LocalDateTime"") = DATE '2018-04-20'");
+WHERE n.""LocalDateTime""::date = DATE '2018-04-20'");
     }
 
     [ConditionalTheory]
@@ -1342,7 +1342,7 @@ WHERE FLOOR(DATE_PART('second', n.""ZonedDateTime"" AT TIME ZONE 'UTC'))::INT = 
         AssertSql(
             @"SELECT n.""Id"", n.""DateInterval"", n.""Duration"", n.""Instant"", n.""InstantRange"", n.""Interval"", n.""LocalDate"", n.""LocalDate2"", n.""LocalDateRange"", n.""LocalDateTime"", n.""LocalTime"", n.""Long"", n.""OffsetTime"", n.""Period"", n.""TimeZoneId"", n.""ZonedDateTime""
 FROM ""NodaTimeTypes"" AS n
-WHERE DATE_TRUNC('day', n.""ZonedDateTime"" AT TIME ZONE 'UTC') = DATE '2018-04-20'");
+WHERE CAST(n.""ZonedDateTime"" AT TIME ZONE 'UTC' AS date) = DATE '2018-04-20'");
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
* Avoid time zone conversion when translating DateTime.Date with timestamptz.
* Return PG date from NodaTime {Local,Zoned}DateTime.Date

Fixes #2333
Fixes #2335