### PR TITLE
Support for row value comparisons

### DIFF
--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDbFunctionsExtensions.cs
@@ -1,6 +1,9 @@
 ﻿
 
 // ReSharper disable once CheckNamespace
+
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.EntityFrameworkCore;
 
 /// <summary>
@@ -42,4 +45,16 @@ public static class NpgsqlDbFunctionsExtensions
     /// <returns>The reversed string.</returns>
     public static string Reverse(this DbFunctions _, string value)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Reverse)));
+
+    public static bool GreaterThan(this DbFunctions _, ITuple a, ITuple b)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThan)));
+
+    public static bool LessThan(this DbFunctions _, ITuple a, ITuple b)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(LessThan)));
+
+    public static bool GreaterThanOrEqual(this DbFunctions _, ITuple a, ITuple b)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(GreaterThanOrEqual)));
+
+    public static bool LessThanOrEqual(this DbFunctions _, ITuple a, ITuple b)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(LessThanOrEqual)));
 }

--- a/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
@@ -122,6 +122,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
                 property, entityType);
 
         /// <summary>
+        ///     '{method}' requires two array parameters of the same length.
+        /// </summary>
+        public static string RowValueMethodRequiresTwoArraysOfSameLength(object? method)
+            => string.Format(
+                GetString("RowValueMethodRequiresTwoArraysOfSameLength", nameof(method)),
+                method);
+
+        /// <summary>
         ///     PostgreSQL sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.
         /// </summary>
         public static string SequenceBadType(object? property, object? entityType, object? propertyType)

--- a/src/EFCore.PG/Properties/NpgsqlStrings.resx
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.resx
@@ -226,4 +226,7 @@
   <data name="IdentityBadType" xml:space="preserve">
     <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.</value>
   </data>
+  <data name="RowValueMethodRequiresTwoArraysOfSameLength" xml:space="preserve">
+    <value>'{method}' requires two array parameters of the same length.</value>
+  </data>
 </root>

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
@@ -37,6 +37,7 @@ public class NpgsqlMethodCallTranslatorProvider : RelationalMethodCallTranslator
             new NpgsqlRandomTranslator(sqlExpressionFactory),
             new NpgsqlRangeTranslator(typeMappingSource, sqlExpressionFactory, model),
             new NpgsqlRegexIsMatchTranslator(sqlExpressionFactory),
+            new NpgsqlRowValueComparisonTranslator(sqlExpressionFactory),
             new NpgsqlStringMethodTranslator(typeMappingSource, sqlExpressionFactory, model),
             new NpgsqlTrigramsMethodTranslator(typeMappingSource, sqlExpressionFactory, model),
         });

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlRowValueComparisonTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlRowValueComparisonTranslator.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+public class NpgsqlRowValueComparisonTranslator : IMethodCallTranslator
+{
+    private readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+
+    private static readonly MethodInfo GreaterThan =
+        typeof(NpgsqlDbFunctionsExtensions).GetRuntimeMethod(
+            nameof(NpgsqlDbFunctionsExtensions.GreaterThan),
+            new[] { typeof(DbFunctions), typeof(ITuple), typeof(ITuple) })!;
+
+    private static readonly MethodInfo LessThan =
+        typeof(NpgsqlDbFunctionsExtensions).GetMethods()
+            .Single(m => m.Name == nameof(NpgsqlDbFunctionsExtensions.LessThan));
+
+    private static readonly MethodInfo GreaterThanOrEqual =
+        typeof(NpgsqlDbFunctionsExtensions).GetMethods()
+            .Single(m => m.Name == nameof(NpgsqlDbFunctionsExtensions.GreaterThanOrEqual));
+
+    private static readonly MethodInfo LessThanOrEqual =
+        typeof(NpgsqlDbFunctionsExtensions).GetMethods()
+            .Single(m => m.Name == nameof(NpgsqlDbFunctionsExtensions.LessThanOrEqual));
+
+    private static readonly Dictionary<MethodInfo, ExpressionType> Methods = new()
+    {
+        { GreaterThan, ExpressionType.GreaterThan },
+        { LessThan, ExpressionType.LessThan },
+        { GreaterThanOrEqual, ExpressionType.GreaterThanOrEqual },
+        { LessThanOrEqual, ExpressionType.LessThanOrEqual }
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NpgsqlRowValueComparisonTranslator"/> class.
+    /// </summary>
+    public NpgsqlRowValueComparisonTranslator(NpgsqlSqlExpressionFactory sqlExpressionFactory)
+        => _sqlExpressionFactory = sqlExpressionFactory;
+
+    /// <inheritdoc />
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType != typeof(NpgsqlDbFunctionsExtensions)
+            || !Methods.TryGetValue(method, out var expressionType)
+            || arguments[1] is not PostgresRowValueExpression rowValue1
+            || arguments[2] is not PostgresRowValueExpression rowValue2)
+        {
+            return null;
+        }
+
+        if (rowValue1.Values.Count != rowValue2.Values.Count)
+        {
+            throw new ArgumentException(NpgsqlStrings.RowValueMethodRequiresTwoArraysOfSameLength(method.Name));
+        }
+
+        return _sqlExpressionFactory.MakeBinary(expressionType, rowValue1, rowValue2, typeMapping: null);
+    }
+}

--- a/src/EFCore.PG/Query/Expressions/Internal/PostgresRowValueExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/PostgresRowValueExpression.cs
@@ -1,0 +1,143 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+
+/// <summary>
+/// An expression that represents a PostgreSQL-specific row value expression in a SQL tree.
+/// </summary>
+/// <remarks>
+/// See the <see href="https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-ROW-CONSTRUCTORS">PostgreSQL docs</see>
+/// for more information.
+/// </remarks>
+public class PostgresRowValueExpression : SqlExpression, IEquatable<PostgresRowValueExpression>
+{
+    /// <summary>
+    /// The values of this PostgreSQL row value expression.
+    /// </summary>
+    public virtual IReadOnlyList<SqlExpression> Values { get; }
+
+    public static RelationalTypeMapping TypeMappingInstance => RowValueTypeMapping.Instance;
+
+    /// <inheritdoc />
+    public PostgresRowValueExpression(IReadOnlyList<SqlExpression> values, RelationalTypeMapping? typeMapping = null)
+        : base(typeof(ITuple), typeMapping)
+    {
+        Check.NotNull(values, nameof(values));
+
+        Values = values;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        Check.NotNull(visitor, nameof(visitor));
+
+        SqlExpression[]? newRowValues = null;
+
+        for (var i = 0; i < Values.Count; i++)
+        {
+            var rowValue = Values[i];
+            var visited = (SqlExpression)visitor.Visit(rowValue);
+            if (visited != rowValue && newRowValues is null)
+            {
+                newRowValues = new SqlExpression[Values.Count];
+                for (var j = 0; j < i; i++)
+                {
+                    newRowValues[j] = Values[j];
+                }
+            }
+
+            if (newRowValues is not null)
+            {
+                newRowValues[i] = visited;
+            }
+        }
+
+        return newRowValues is null ? this : new PostgresRowValueExpression(newRowValues);
+    }
+
+    public virtual PostgresRowValueExpression Update(IReadOnlyList<SqlExpression> values)
+        => values.Count == Values.Count && values.Zip(Values, (x, y) => (x, y)).All(tup => tup.x == tup.y)
+            ? this
+            : new PostgresRowValueExpression(values);
+
+    /// <inheritdoc />
+    protected override void Print(ExpressionPrinter expressionPrinter)
+    {
+        expressionPrinter.Append("(");
+
+        var count = Values.Count;
+        for (var i = 0; i < count; i++)
+        {
+            expressionPrinter.Visit(Values[i]);
+
+            if (i < count - 1)
+            {
+                expressionPrinter.Append(", ");
+            }
+        }
+
+        expressionPrinter.Append(")");
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => obj is PostgresRowValueExpression other && Equals(other);
+
+    /// <inheritdoc />
+    public virtual bool Equals(PostgresRowValueExpression? other)
+    {
+        if (other is null || !base.Equals(other) || other.Values.Count != Values.Count)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        for (var i = 0; i < Values.Count; i++)
+        {
+            if (!other.Values[i].Equals(Values[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hashCode = new HashCode();
+
+        foreach (var rowValue in Values)
+        {
+            hashCode.Add(rowValue);
+        }
+
+        return hashCode.ToHashCode();
+    }
+
+    /// <summary>
+    /// Every node in the SQL tree must have a type mapping, but row values aren't actual values (in the sense that they can be sent as
+    /// parameters, or have a literal representation). So we have a dummy type mapping for that.
+    /// </summary>
+    private sealed class RowValueTypeMapping : RelationalTypeMapping
+    {
+        internal static RowValueTypeMapping Instance { get; } = new();
+
+        private RowValueTypeMapping()
+            : base(new(new(), storeType: "rowvalue"))
+        {
+        }
+
+        protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+            => this;
+    }
+}

--- a/src/EFCore.PG/Query/Internal/NpgsqlEvaluatableExpressionFilter.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlEvaluatableExpressionFilter.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
 
 public class NpgsqlEvaluatableExpressionFilter : RelationalEvaluatableExpressionFilter
@@ -35,6 +37,14 @@ public class NpgsqlEvaluatableExpressionFilter : RelationalEvaluatableExpression
                 }
 
                 break;
+
+            case NewExpression newExpression when newExpression.Type.IsAssignableTo(typeof(ITuple)):
+                // We translate new ValueTuple<T1, T2...>(x, y...) to a SQL row value expression: (x, y)
+                // (see NpgsqlSqlTranslatingExpressionVisitor.VisitNew).
+                // We must prevent evaluation when the tuple contains only constants/parameters, since SQL row values cannot be
+                // parameterized; we need to render them as "literals" instead:
+                // WHERE (x, y) > (3, $1)
+                return false;
         }
 
         return base.IsEvaluatableExpression(expression, model);

--- a/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
@@ -49,6 +49,7 @@ public class NpgsqlQuerySqlGenerator : QuerySqlGenerator
             PostgresJsonTraversalExpression jsonTraversalExpression => VisitJsonPathTraversal(jsonTraversalExpression),
             PostgresNewArrayExpression newArrayExpression           => VisitPostgresNewArray(newArrayExpression),
             PostgresRegexMatchExpression regexMatchExpression       => VisitRegexMatch(regexMatchExpression),
+            PostgresRowValueExpression rowValueExpression           => VisitRowValue(rowValueExpression),
             PostgresUnknownBinaryExpression unknownBinaryExpression => VisitUnknownBinary(unknownBinaryExpression),
             _                                                       => base.VisitExtension(extensionExpression)
         };
@@ -545,6 +546,27 @@ public class NpgsqlQuerySqlGenerator : QuerySqlGenerator
         Sql.Append(")");
 
         return expression;
+    }
+
+    public virtual Expression VisitRowValue(PostgresRowValueExpression rowValueExpression)
+    {
+        Sql.Append("(");
+
+        var values = rowValueExpression.Values;
+        var count = values.Count;
+        for (var i = 0; i < count; i++)
+        {
+            Visit(values[i]);
+
+            if (i < count - 1)
+            {
+                Sql.Append(", ");
+            }
+        }
+
+        Sql.Append(")");
+
+        return rowValueExpression;
     }
 
     /// <summary>

--- a/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
@@ -13,6 +13,13 @@ public class GearsOfWarQueryNpgsqlTest : GearsOfWarQueryRelationalTestBase<Gears
         // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
+    // This test attempts to project a Tuple<,> out of the database. In Npgsql specifically, we map Tuple and ValueTuple to row values,
+    // e.g. for row value comparisons ((a, b) > (3, 4)). However, we do not yet support reading row values from the database.
+    // At the ADO level, we do support reading them (records), but currently return them as object[]; we could change the ADO mapping
+    // to be a ValueTuple/Tuple instead, at which point we could map Tuple/ValueTuple in EF Core as a supported primitive type.
+    public override Task Select_null_propagation_negative4(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_null_propagation_negative4(async));
+
     #region Byte array
 
     public override async Task Byte_array_contains_literal(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindAggregateOperatorsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindAggregateOperatorsQueryNpgsqlTest.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query;
 
@@ -67,7 +66,7 @@ WHERE e.""EmployeeID"" = ANY (@__ids_0)");
         => await AssertTranslationFailed(() => base.Contains_with_local_anonymous_type_array_closure(async));
 
     public override async Task Contains_with_local_tuple_array_closure(bool async)
-        => await AssertTranslationFailed(() => base.Contains_with_local_tuple_array_closure(async));
+        => await Assert.ThrowsAsync<InvalidOperationException>(() => base.Contains_with_local_tuple_array_closure(async: true));
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindMiscellaneousQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindMiscellaneousQueryNpgsqlTest.cs
@@ -17,6 +17,7 @@ public class NorthwindMiscellaneousQueryNpgsqlTest : NorthwindMiscellaneousQuery
     public override async Task Query_expression_with_to_string_and_contains(bool async)
     {
         await base.Query_expression_with_to_string_and_contains(async);
+
         AssertContainsSqlFragment(@"strpos(o.""EmployeeID""::text, '10') > 0");
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/TPTGearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/TPTGearsOfWarQueryNpgsqlTest.cs
@@ -15,6 +15,10 @@ public class TPTGearsOfWarQueryNpgsqlTest : TPTGearsOfWarQueryRelationalTestBase
     // TODO: #1232
     // protected override bool CanExecuteQueryString => true;
 
+    // See GearsOfWarQueryNpgsqlTest.Select_null_propagation_negative4
+    public override Task Select_null_propagation_negative4(bool async)
+        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_null_propagation_negative4(async));
+
     [ConditionalTheory(Skip = "https://github.com/npgsql/efcore.pg/issues/2039")]
     public override Task Where_DateOnly_Year(bool async)
         => base.Where_DateOnly_Year(async);


### PR DESCRIPTION
This implements https://github.com/dotnet/efcore/issues/26822 for PostgreSQL only; things are easier here because there's already full support for arrays. I don't think this blocks us if we introduce something in relational, we can always obsolete the specific methods here.

Note: the methods have the long names (e.g. RowValueGreaterThan) since PG also supports array comparison in SQL.

/cc @smitpatel @ajcvickers @mrahhal

Closes #2349
