### PR TITLE
Translate PostgreSQL custom aggregates

### DIFF
--- a/src/EFCore.PG.NTS/Query/ExpressionTranslators/Internal/NpgsqlNetTopologySuiteAggregateMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.PG.NTS/Query/ExpressionTranslators/Internal/NpgsqlNetTopologySuiteAggregateMethodCallTranslatorPlugin.cs
@@ -64,9 +64,9 @@ public class NpgsqlNetTopologySuiteAggregateMethodTranslator : IAggregateMethodC
             return _sqlExpressionFactory.AggregateFunction(
                 method == GeometryCombineMethod ? "ST_Collect" : "ST_Union",
                 new[] { sqlExpression },
+                source,
                 nullable: true,
                 argumentsPropagateNullability: new[] { false },
-                source,
                 typeof(Geometry),
                 resultTypeMapping);
         }
@@ -80,9 +80,9 @@ public class NpgsqlNetTopologySuiteAggregateMethodTranslator : IAggregateMethodC
                 _sqlExpressionFactory.AggregateFunction(
                     "ST_Collect",
                     new[] { sqlExpression },
+                    source,
                     nullable: true,
                     argumentsPropagateNullability: new[] { false },
-                    source,
                     typeof(Geometry),
                     resultTypeMapping)
             },

--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlAggregateDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlAggregateDbFunctionsExtensions.cs
@@ -1,0 +1,514 @@
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Provides extension methods supporting aggregate function translation for PostgreSQL.
+/// </summary>
+public static class NpgsqlAggregateDbFunctionsExtensions
+{
+    /// <summary>
+    /// Collects all the input values, including nulls, into a PostgreSQL array.
+    /// Corresponds to the PostgreSQL <c>array_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input values to be aggregated into an array.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static T[] ArrayAgg<T>(this DbFunctions _, IEnumerable<T> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ArrayAgg)));
+
+    /// <summary>
+    /// Collects all the input values, including nulls, into a json array. Values are converted to JSON as per <c>to_json</c> or
+    /// <c>to_jsonb</c>. Corresponds to the PostgreSQL <c>json_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input values to be aggregated into a JSON array.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static T[] JsonAgg<T>(this DbFunctions _, IEnumerable<T> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonAgg)));
+
+    /// <summary>
+    /// Collects all the input values, including nulls, into a jsonb array. Values are converted to JSON as per <c>to_json</c> or
+    /// <c>to_jsonb</c>. Corresponds to the PostgreSQL <c>jsonb_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input values to be aggregated into a JSON array.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static T[] JsonbAgg<T>(this DbFunctions _, IEnumerable<T> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonbAgg)));
+
+    #region Range
+
+    /// <summary>
+    /// Computes the union of the non-null input ranges. Corresponds to the PostgreSQL <c>range_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The ranges to be aggregated via union into a multirange.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static NpgsqlRange<T>[] RangeAgg<T>(this DbFunctions _, IEnumerable<NpgsqlRange<T>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RangeAgg)));
+
+    /// <summary>
+    /// Computes the intersection of the non-null input ranges. Corresponds to the PostgreSQL <c>range_intersect_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The ranges to be aggregated via intersection into a multirange.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static NpgsqlRange<T> RangeIntersectAgg<T>(this DbFunctions _, IEnumerable<NpgsqlRange<T>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RangeAgg)));
+
+    /// <summary>
+    /// Computes the intersection of the non-null input multiranges.
+    /// Corresponds to the PostgreSQL <c>range_intersect_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The ranges to be aggregated via intersection into a multirange.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static NpgsqlRange<T>[] RangeIntersectAgg<T>(this DbFunctions _, IEnumerable<NpgsqlRange<T>[]> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RangeAgg)));
+
+    #endregion Range
+
+    #region JsonObjectAgg
+
+    /// <summary>
+    /// Collects all the key/value pairs into a JSON object. Key arguments are coerced to text; value arguments are converted as per
+    /// <c>to_json</c>. Values can be <see langword="null" />, but not keys.
+    /// Corresponds to the PostgreSQL <c>json_object_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="keyValuePairs">An enumerable of key-value pairs to be aggregated into a JSON object.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static string JsonObjectAgg<T1, T2>(this DbFunctions _, IEnumerable<(T1, T2)> keyValuePairs)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonObjectAgg)));
+
+    /// <summary>
+    /// Collects all the key/value pairs into a JSON object. Key arguments are coerced to text; value arguments are converted as per
+    /// <c>to_json</c>. Values can be <see langword="null" />, but not keys.
+    /// Corresponds to the PostgreSQL <c>json_object_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="keyValuePairs">An enumerable of key-value pairs to be aggregated into a JSON object.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static TReturn JsonObjectAgg<T1, T2, TReturn>(this DbFunctions _, IEnumerable<(T1, T2)> keyValuePairs)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonObjectAgg)));
+
+    /// <summary>
+    /// Collects all the key/value pairs into a JSON object. Key arguments are coerced to text; value arguments are converted as per
+    /// <c>to_jsonb</c>. Values can be <see langword="null" />, but not keys.
+    /// Corresponds to the PostgreSQL <c>jsonb_object_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="keyValuePairs">An enumerable of key-value pairs to be aggregated into a JSON object.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static string JsonbObjectAgg<T1, T2>(this DbFunctions _, IEnumerable<(T1, T2)> keyValuePairs)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonbObjectAgg)));
+
+    /// <summary>
+    /// Collects all the key/value pairs into a JSON object. Key arguments are coerced to text; value arguments are converted as per
+    /// <c>to_jsonb</c>. Values can be <see langword="null" />, but not keys.
+    /// Corresponds to the PostgreSQL <c>jsonb_object_agg</c> aggregate function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="keyValuePairs">An enumerable of key-value pairs to be aggregated into a JSON object.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/functions-aggregate.html">PostgreSQL documentation for aggregate functions.</seealso>
+    public static TReturn JsonbObjectAgg<T1, T2, TReturn>(this DbFunctions _, IEnumerable<(T1, T2)> keyValuePairs)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonbObjectAgg)));
+
+    #endregion JsonObjectAgg
+
+    #region Sample standard deviation
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<byte> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<short> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<int> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<long> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<float> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<double> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    /// <summary>
+    ///     Returns the sample standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample standard deviation.</returns>
+    public static double? StandardDeviationSample(this DbFunctions _, IEnumerable<decimal> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationSample)));
+
+    #endregion Sample standard deviation
+
+    #region Population standard deviation
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<byte> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<short> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<int> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<long> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<float> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<double> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    /// <summary>
+    ///     Returns the population standard deviation of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>stddev_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population standard deviation.</returns>
+    public static double? StandardDeviationPopulation(this DbFunctions _, IEnumerable<decimal> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(StandardDeviationPopulation)));
+
+    #endregion Population standard deviation
+
+    #region Sample variance
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<byte> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<short> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<int> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<long> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<float> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<double> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    /// <summary>
+    ///     Returns the sample variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed sample variance.</returns>
+    public static double? VarianceSample(this DbFunctions _, IEnumerable<decimal> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VarianceSample)));
+
+    #endregion Sample variance
+
+    #region Population variance
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<byte> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<short> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<int> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<long> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<float> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<double> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    /// <summary>
+    ///     Returns the population variance of all values in the specified expression.
+    ///     Corresponds to the PostgreSQL <c>var_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    /// <returns>The computed population variance.</returns>
+    public static double? VariancePopulation(this DbFunctions _, IEnumerable<decimal> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(VariancePopulation)));
+
+    #endregion Population variance
+
+    #region Other statistics functions
+
+    /// <summary>
+    ///     Computes the correlation coefficient. Corresponds to the PostgreSQL <c>corr</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? Correlation(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Correlation)));
+
+    /// <summary>
+    ///     Computes the population covariance. Corresponds to the PostgreSQL <c>covar_pop</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? CovariancePopulation(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CovariancePopulation)));
+
+    /// <summary>
+    ///     Computes the sample covariance. Corresponds to the PostgreSQL <c>covar_samp</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? CovarianceSample(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(CovarianceSample)));
+
+    /// <summary>
+    ///     Computes the average of the independent variable, <c>sum(X)/N</c>.
+    ///     Corresponds to the PostgreSQL <c>regr_avgx</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrAverageX(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrAverageX)));
+
+    /// <summary>
+    ///     Computes the average of the dependent variable, <c>sum(Y)/N</c>.
+    ///     Corresponds to the PostgreSQL <c>regr_avgy</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrAverageY(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrAverageY)));
+
+    /// <summary>
+    ///     Computes the number of rows in which both inputs are non-null.
+    ///     Corresponds to the PostgreSQL <c>regr_count</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static long? RegrCount(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrCount)));
+
+    /// <summary>
+    ///     Computes the y-intercept of the least-squares-fit linear equation determined by the (X, Y) pairs.
+    ///     Corresponds to the PostgreSQL <c>regr_intercept</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrIntercept(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrIntercept)));
+
+    /// <summary>
+    ///     Computes the square of the correlation coefficient.
+    ///     Corresponds to the PostgreSQL <c>regr_r2</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrR2(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrR2)));
+
+    /// <summary>
+    ///     Computes the slope of the least-squares-fit linear equation determined by the (X, Y) pairs.
+    ///     Corresponds to the PostgreSQL <c>regr_slope</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrSlope(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrSlope)));
+
+    /// <summary>
+    ///     Computes the “sum of squares” of the independent variable, <c>sum(X^2) - sum(X)^2/N</c>.
+    ///     Corresponds to the PostgreSQL <c>regr_sxx</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrSXX(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrSXX)));
+
+    /// <summary>
+    ///     Computes the “sum of products” of independent times dependent variables, <c>sum(X*Y) - sum(X) * sum(Y)/N</c>.
+    ///     Corresponds to the PostgreSQL <c>regr_sxy</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="values">The values.</param>
+    public static double? RegrSXY(this DbFunctions _, IEnumerable<(double, double)> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(RegrSXY)));
+
+    #endregion Other statistics functions
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlAggregateMethodCallTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlAggregateMethodCallTranslatorProvider.cs
@@ -11,7 +11,9 @@ public class NpgsqlAggregateMethodCallTranslatorProvider : RelationalAggregateMe
         AddTranslators(
             new IAggregateMethodCallTranslator[]
             {
-                new NpgsqlQueryableAggregateMethodTranslator(sqlExpressionFactory, typeMappingSource)
+                new NpgsqlQueryableAggregateMethodTranslator(sqlExpressionFactory, typeMappingSource),
+                new NpgsqlStatisticsAggregateMethodTranslator(sqlExpressionFactory, typeMappingSource),
+                new NpgsqlMiscAggregateMethodTranslator(sqlExpressionFactory, typeMappingSource)
             });
     }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMiscAggregateMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMiscAggregateMethodTranslator.cs
@@ -1,0 +1,158 @@
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
+using static Npgsql.EntityFrameworkCore.PostgreSQL.Utilities.Statics;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+public class NpgsqlMiscAggregateMethodTranslator : IAggregateMethodCallTranslator
+{
+    private static readonly MethodInfo StringJoin
+        = typeof(string).GetRuntimeMethod(nameof(string.Join), new[] { typeof(string), typeof(IEnumerable<string>) })!;
+
+    private static readonly MethodInfo StringConcat
+        = typeof(string).GetRuntimeMethod(nameof(string.Concat), new[] { typeof(IEnumerable<string>) })!;
+
+    private readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
+
+    public NpgsqlMiscAggregateMethodTranslator(
+        NpgsqlSqlExpressionFactory sqlExpressionFactory,
+        IRelationalTypeMappingSource typeMappingSource)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+        _typeMappingSource = typeMappingSource;
+    }
+
+    public virtual SqlExpression? Translate(
+        MethodInfo method,
+        EnumerableExpression source,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        // Docs: https://www.postgresql.org/docs/current/functions-aggregate.html
+
+        if (source.Selector is not SqlExpression sqlExpression)
+        {
+            return null;
+        }
+
+        if (method == StringJoin || method == StringConcat)
+        {
+            // string_agg filters out nulls, but string.Join treats them as empty strings; coalesce unless we know we're aggregating over
+            // a non-nullable column.
+            if (sqlExpression is not ColumnExpression { IsNullable: false })
+            {
+                sqlExpression = _sqlExpressionFactory.Coalesce(
+                    sqlExpression,
+                    _sqlExpressionFactory.Constant(string.Empty, typeof(string)));
+            }
+
+            // string_agg returns null when there are no rows (or non-null values), but string.Join returns an empty string.
+            return _sqlExpressionFactory.Coalesce(
+                _sqlExpressionFactory.AggregateFunction(
+                    "string_agg",
+                    new[]
+                    {
+                        sqlExpression,
+                        method == StringJoin ? arguments[0] : _sqlExpressionFactory.Constant(string.Empty, typeof(string))
+                    },
+                    source,
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { false, true },
+                    typeof(string),
+                    _typeMappingSource.FindMapping("text")), // Note that string_agg returns text even if its inputs are varchar(x)
+                _sqlExpressionFactory.Constant(string.Empty, typeof(string)));
+        }
+
+        if (method.DeclaringType == typeof(NpgsqlAggregateDbFunctionsExtensions))
+        {
+            switch (method.Name)
+            {
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.ArrayAgg):
+                    var arrayClrType = sqlExpression.Type.MakeArrayType();
+
+                    return _sqlExpressionFactory.AggregateFunction(
+                        "array_agg",
+                        new[] { sqlExpression },
+                        source,
+                        nullable: true,
+                        argumentsPropagateNullability: FalseArrays[1],
+                        returnType: arrayClrType,
+                        typeMapping: sqlExpression.TypeMapping is null
+                            ? null
+                            : new NpgsqlArrayArrayTypeMapping(arrayClrType, sqlExpression.TypeMapping));
+
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.JsonAgg):
+                    arrayClrType = sqlExpression.Type.MakeArrayType();
+
+                    return _sqlExpressionFactory.AggregateFunction(
+                        "json_agg",
+                        new[] { sqlExpression },
+                        source,
+                        nullable: true,
+                        argumentsPropagateNullability: FalseArrays[1],
+                        returnType: arrayClrType,
+                        _typeMappingSource.FindMapping(arrayClrType, "json"));
+
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.JsonbAgg):
+                    arrayClrType = sqlExpression.Type.MakeArrayType();
+
+                    return _sqlExpressionFactory.AggregateFunction(
+                        "jsonb_agg",
+                        new[] { sqlExpression },
+                        source,
+                        nullable: true,
+                        argumentsPropagateNullability: FalseArrays[1],
+                        returnType: arrayClrType,
+                        _typeMappingSource.FindMapping(arrayClrType, "jsonb"));
+
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.RangeAgg):
+                    arrayClrType = sqlExpression.Type.MakeArrayType();
+
+                    return _sqlExpressionFactory.AggregateFunction(
+                        "range_agg",
+                        new[] { sqlExpression },
+                        source,
+                        nullable: true,
+                        argumentsPropagateNullability: FalseArrays[1],
+                        returnType: arrayClrType,
+                        _typeMappingSource.FindMapping(arrayClrType));
+
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.RangeIntersectAgg):
+                    return _sqlExpressionFactory.AggregateFunction(
+                        "range_intersect_agg",
+                        new[] { sqlExpression },
+                        source,
+                        nullable: true,
+                        argumentsPropagateNullability: FalseArrays[1],
+                        returnType: sqlExpression.Type,
+                        sqlExpression.TypeMapping);
+
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.JsonbObjectAgg):
+                case nameof(NpgsqlAggregateDbFunctionsExtensions.JsonObjectAgg):
+                    var isJsonb = method.Name == nameof(NpgsqlAggregateDbFunctionsExtensions.JsonbObjectAgg);
+
+                    // These methods accept two enumerable (column) arguments; this is represented in LINQ as a projection from the grouping
+                    // to a tuple of the two columns. Since we generally translate tuples to PostgresRowValueExpression, we take it apart
+                    // here.
+                    if (source.Selector is not PostgresRowValueExpression rowValueExpression)
+                    {
+                        return null;
+                    }
+
+                    var (keys, values) = (rowValueExpression.Values[0], rowValueExpression.Values[1]);
+
+                    return _sqlExpressionFactory.AggregateFunction(
+                        isJsonb ? "jsonb_object_agg" : "json_object_agg",
+                        new[] { keys, values },
+                        source,
+                        nullable: true,
+                        argumentsPropagateNullability: FalseArrays[2],
+                        returnType: method.ReturnType,
+                        _typeMappingSource.FindMapping(method.ReturnType, isJsonb ? "jsonb" : "json"));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlQueryableAggregateMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlQueryableAggregateMethodTranslator.cs
@@ -45,18 +45,18 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                             _sqlExpressionFactory.AggregateFunction(
                                 "avg",
                                 new[] { averageSqlExpression },
-                                nullable: true,
-                                argumentsPropagateNullability: FalseArrays[1],
                                 source,
-                                typeof(double)),
+                                nullable: true,
+                                 argumentsPropagateNullability: FalseArrays[1],
+                                returnType: typeof(double)),
                             averageSqlExpression.Type,
                             averageSqlExpression.TypeMapping)
                         : _sqlExpressionFactory.AggregateFunction(
                             "avg",
                             new[] { averageSqlExpression },
+                            source,
                             nullable: true,
                             argumentsPropagateNullability: FalseArrays[1],
-                            source,
                             averageSqlExpression.Type,
                             averageSqlExpression.TypeMapping);
 
@@ -69,11 +69,12 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                         _sqlExpressionFactory.AggregateFunction(
                             "count",
                             new[] { countSqlExpression },
+                            source,
                             nullable: false,
                             argumentsPropagateNullability: FalseArrays[1],
-                            source,
                             typeof(long)),
-                        typeof(int), _typeMappingSource.FindMapping(typeof(int)));
+                        typeof(int),
+                        _typeMappingSource.FindMapping(typeof(int)));
 
                 case nameof(Queryable.LongCount)
                 when methodInfo == QueryableMethods.LongCountWithoutPredicate
@@ -82,9 +83,9 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                     return _sqlExpressionFactory.AggregateFunction(
                             "count",
                             new[] { longCountSqlExpression },
+                            source,
                             nullable: false,
                             argumentsPropagateNullability: FalseArrays[1],
-                            source,
                             typeof(long));
 
                 case nameof(Queryable.Max)
@@ -94,9 +95,9 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                     return _sqlExpressionFactory.AggregateFunction(
                             "max",
                             new[] { maxSqlExpression },
+                            source,
                             nullable: true,
                             argumentsPropagateNullability: FalseArrays[1],
-                            source,
                             maxSqlExpression.Type,
                             maxSqlExpression.TypeMapping);
 
@@ -107,9 +108,9 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                     return _sqlExpressionFactory.AggregateFunction(
                             "min",
                             new[] { minSqlExpression },
+                            source,
                             nullable: true,
                             argumentsPropagateNullability: FalseArrays[1],
-                            source,
                             minSqlExpression.Type,
                             minSqlExpression.TypeMapping);
 
@@ -129,9 +130,9 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                             _sqlExpressionFactory.AggregateFunction(
                                 "sum",
                                 new[] { sumSqlExpression },
+                                source,
                                 nullable: true,
                                 argumentsPropagateNullability: FalseArrays[1],
-                                source,
                                 typeof(long)),
                             sumInputType,
                             sumSqlExpression.TypeMapping);
@@ -143,9 +144,9 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                             _sqlExpressionFactory.AggregateFunction(
                                 "sum",
                                 new[] { sumSqlExpression },
+                                source,
                                 nullable: true,
                                 argumentsPropagateNullability: FalseArrays[1],
-                                source,
                                 typeof(decimal)),
                             sumInputType,
                             sumSqlExpression.TypeMapping);
@@ -154,9 +155,9 @@ public class NpgsqlQueryableAggregateMethodTranslator : IAggregateMethodCallTran
                     return _sqlExpressionFactory.AggregateFunction(
                         "sum",
                         new[] { sumSqlExpression },
+                        source,
                         nullable: true,
                         argumentsPropagateNullability: FalseArrays[1],
-                        source,
                         sumInputType,
                         sumSqlExpression.TypeMapping);
             }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStatisticsAggregateMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStatisticsAggregateMethodTranslator.cs
@@ -1,0 +1,104 @@
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+using static Npgsql.EntityFrameworkCore.PostgreSQL.Utilities.Statics;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+public class NpgsqlStatisticsAggregateMethodTranslator : IAggregateMethodCallTranslator
+{
+    private readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+    private readonly RelationalTypeMapping _doubleTypeMapping, _longTypeMapping;
+
+    public NpgsqlStatisticsAggregateMethodTranslator(
+        NpgsqlSqlExpressionFactory sqlExpressionFactory,
+        IRelationalTypeMappingSource typeMappingSource)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+        _doubleTypeMapping = typeMappingSource.FindMapping(typeof(double))!;
+        _longTypeMapping = typeMappingSource.FindMapping(typeof(long))!;
+    }
+
+    public virtual SqlExpression? Translate(
+        MethodInfo method,
+        EnumerableExpression source,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        // Docs: https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-AGGREGATE-STATISTICS-TABLE
+
+        if (method.DeclaringType != typeof(NpgsqlAggregateDbFunctionsExtensions)
+            || source.Selector is not SqlExpression sqlExpression)
+        {
+            return null;
+        }
+
+        // These four functions are simple and take a single enumerable argument
+        var functionName = method.Name switch
+        {
+            nameof(NpgsqlAggregateDbFunctionsExtensions.StandardDeviationSample) => "stddev_samp",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.StandardDeviationPopulation) => "stddev_pop",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.VarianceSample) => "var_samp",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.VariancePopulation) => "var_pop",
+            _ => null
+        };
+
+        if (functionName is not null)
+        {
+            return _sqlExpressionFactory.AggregateFunction(
+                functionName,
+                new[] { sqlExpression },
+                source,
+                nullable: true,
+                argumentsPropagateNullability: FalseArrays[1],
+                typeof(double),
+                _doubleTypeMapping);
+        }
+
+        functionName = method.Name switch
+        {
+            nameof(NpgsqlAggregateDbFunctionsExtensions.Correlation) => "corr",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.CovariancePopulation) => "covar_pop",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.CovarianceSample) => "covar_samp",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrAverageX) => "regr_avgx",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrAverageY) => "regr_avgy",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrCount) => "regr_count",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrIntercept) => "regr_intercept",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrR2) => "regr_r2",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrSlope) => "regr_slope",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrSXX) => "regr_sxx",
+            nameof(NpgsqlAggregateDbFunctionsExtensions.RegrSXY) => "regr_sxy",
+            _ => null
+        };
+
+        if (functionName is not null)
+        {
+            // These methods accept two enumerable (column) arguments; this is represented in LINQ as a projection from the grouping
+            // to a tuple of the two columns. Since we generally translate tuples to PostgresRowValueExpression, we take it apart here.
+            if (source.Selector is not PostgresRowValueExpression rowValueExpression)
+            {
+                return null;
+            }
+
+            var (y, x) = (rowValueExpression.Values[0], rowValueExpression.Values[1]);
+
+            return method.Name == nameof(NpgsqlAggregateDbFunctionsExtensions.RegrCount)
+                ? _sqlExpressionFactory.AggregateFunction(
+                    functionName,
+                    new[] { y, x },
+                    source,
+                    nullable: true,
+                    argumentsPropagateNullability: FalseArrays[2],
+                    typeof(long),
+                    _longTypeMapping)
+                : _sqlExpressionFactory.AggregateFunction(
+                    functionName,
+                    new[] { y, x },
+                    source,
+                    nullable: true,
+                    argumentsPropagateNullability: FalseArrays[2],
+                    typeof(double),
+                    _doubleTypeMapping);
+        }
+
+        return null;
+    }
+}

--- a/src/EFCore.PG/Query/Expressions/Internal/PostgresFunctionExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/PostgresFunctionExpression.cs
@@ -58,9 +58,8 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
 
         return new PostgresFunctionExpression(
             name, arguments, argumentNames, argumentSeparators: null,
-            nullable, argumentsPropagateNullability,
             aggregateDistinct: false, aggregatePredicate: null, aggregateOrderings: Array.Empty<OrderingExpression>(),
-            type, typeMapping);
+            nullable: nullable, argumentsPropagateNullability: argumentsPropagateNullability, type: type, typeMapping: typeMapping);
     }
 
     public static PostgresFunctionExpression CreateWithArgumentSeparators(
@@ -77,10 +76,9 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
         Check.NotNull(argumentSeparators, nameof(argumentSeparators));
 
         return new PostgresFunctionExpression(
-            name, arguments, argumentNames: null, argumentSeparators,
-            nullable, argumentsPropagateNullability,
+            name, arguments, argumentNames: null, argumentSeparators: argumentSeparators,
             aggregateDistinct: false, aggregatePredicate: null, aggregateOrderings: Array.Empty<OrderingExpression>(),
-            type, typeMapping);
+            nullable: nullable, argumentsPropagateNullability: argumentsPropagateNullability, type: type, typeMapping: typeMapping);
     }
 
     public PostgresFunctionExpression(
@@ -88,11 +86,11 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
         IEnumerable<SqlExpression> arguments,
         IEnumerable<string?>? argumentNames,
         IEnumerable<string?>? argumentSeparators,
-        bool nullable,
-        IEnumerable<bool> argumentsPropagateNullability,
         bool aggregateDistinct,
         SqlExpression? aggregatePredicate,
         IReadOnlyList<OrderingExpression> aggregateOrderings,
+        bool nullable,
+        IEnumerable<bool> argumentsPropagateNullability,
         Type type,
         RelationalTypeMapping? typeMapping)
         : base(name, arguments, nullable, argumentsPropagateNullability, type, typeMapping)
@@ -175,11 +173,10 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
         return changed
             ? new PostgresFunctionExpression(
                 Name, visitedArguments ?? Arguments, ArgumentNames, ArgumentSeparators,
-                IsNullable, ArgumentsPropagateNullability!,
                 IsAggregateDistinct,
                 visitedAggregatePredicate ?? AggregatePredicate,
                 visitedAggregateOrderings ?? AggregateOrderings,
-                Type, TypeMapping)
+                IsNullable, ArgumentsPropagateNullability!, Type, TypeMapping)
             : this;
     }
 
@@ -189,13 +186,11 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
             Arguments,
             ArgumentNames,
             ArgumentSeparators,
-            IsNullable,
-            ArgumentsPropagateNullability,
             IsAggregateDistinct,
             AggregatePredicate,
             AggregateOrderings,
-            Type,
-            typeMapping ?? TypeMapping);
+            IsNullable,
+            ArgumentsPropagateNullability, Type, typeMapping ?? TypeMapping);
 
     public override SqlFunctionExpression Update(SqlExpression? instance, IReadOnlyList<SqlExpression>? arguments)
     {
@@ -209,11 +204,10 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
         return !arguments.SequenceEqual(Arguments)
             ? new PostgresFunctionExpression(
                 Name, arguments, ArgumentNames, ArgumentSeparators,
-                IsNullable, ArgumentsPropagateNullability,
                 IsAggregateDistinct,
                 AggregatePredicate,
                 AggregateOrderings,
-                Type, TypeMapping)
+                IsNullable, ArgumentsPropagateNullability, Type, TypeMapping)
             : this;
     }
 
@@ -224,11 +218,10 @@ public class PostgresFunctionExpression : SqlFunctionExpression, IEquatable<Post
         return predicate != AggregatePredicate || orderings != AggregateOrderings
             ? new PostgresFunctionExpression(
                 Name, Arguments, ArgumentNames, ArgumentSeparators,
-                IsNullable, ArgumentsPropagateNullability,
                 IsAggregateDistinct,
                 predicate,
                 orderings,
-                Type, TypeMapping)
+                IsNullable, ArgumentsPropagateNullability, Type, TypeMapping)
             : this;
     }
 

--- a/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
@@ -283,9 +283,9 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
     public virtual PostgresFunctionExpression AggregateFunction(
         string name,
         IEnumerable<SqlExpression> arguments,
+        EnumerableExpression aggregateEnumerableExpression,
         bool nullable,
         IEnumerable<bool> argumentsPropagateNullability,
-        EnumerableExpression aggregateEnumerableExpression,
         Type returnType,
         RelationalTypeMapping? typeMapping = null)
     {
@@ -301,13 +301,11 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
             typeMappedArguments,
             argumentNames: null,
             argumentSeparators: null,
-            nullable,
-            argumentsPropagateNullability,
             aggregateEnumerableExpression.IsDistinct,
             aggregateEnumerableExpression.Predicate,
             aggregateEnumerableExpression.Orderings,
-            returnType,
-            typeMapping);
+            nullable: nullable,
+            argumentsPropagateNullability: argumentsPropagateNullability, type: returnType, typeMapping: typeMapping);
     }
 
     #endregion Expression factory methods


### PR DESCRIPTION
Here's some nice WIP based off of @smitpatel's great work in https://github.com/dotnet/efcore/pull/28092.

This implements the PG-specific aggregate operators ([FILTER](https://github.com/npgsql/efcore.pg/pull/2383/files#diff-93dee472cc58de12f790841bc6d992751b2af17d1fa3d7be5a3165bdbbb1aaa7R2465) and [ORDER BY](https://github.com/npgsql/efcore.pg/pull/2383/files#diff-93dee472cc58de12f790841bc6d992751b2af17d1fa3d7be5a3165bdbbb1aaa7R3158)), and provides a first implementation of [string_agg](https://github.com/npgsql/efcore.pg/pull/2383/files#diff-93dee472cc58de12f790841bc6d992751b2af17d1fa3d7be5a3165bdbbb1aaa7R3177) and [array_agg](https://github.com/npgsql/efcore.pg/pull/2383/files#diff-93dee472cc58de12f790841bc6d992751b2af17d1fa3d7be5a3165bdbbb1aaa7R3188). Really impressive we can do this!

/cc @dotnet/efteam

Closes #2384