### PR TITLE
Implement ExecuteUpdate

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <EFCoreVersion>7.0.0-rc.1.22404.6</EFCoreVersion>
-    <MicrosoftExtensionsVersion>7.0.0-rc.1.22381.5</MicrosoftExtensionsVersion>
+    <EFCoreVersion>7.0.0-rc.1.22410.9</EFCoreVersion>
+    <MicrosoftExtensionsVersion>7.0.0-rc.1.22407.4</MicrosoftExtensionsVersion>
     <NpgsqlVersion>7.0.0-preview.7</NpgsqlVersion>
   </PropertyGroup>
 

--- a/src/EFCore.PG/Query/Internal/NpgsqlDeleteConvertingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlDeleteConvertingExpressionVisitor.cs
@@ -6,7 +6,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
 ///     Converts the relational <see cref="NonQueryExpression" /> into a PG-specific <see cref="PostgresDeleteExpression" />, which
 ///     precisely models a DELETE statement in PostgreSQL. This is done to handle the PG-specific USING syntax for table joining.
 /// </summary>
-public class NonQueryConvertingExpressionVisitor : ExpressionVisitor
+public class NpgsqlDeleteConvertingExpressionVisitor : ExpressionVisitor
 {
     public virtual Expression Process(Expression node)
         => node switch

--- a/src/EFCore.PG/Query/Internal/NpgsqlParameterBasedSqlProcessor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlParameterBasedSqlProcessor.cs
@@ -16,7 +16,7 @@ public class NpgsqlParameterBasedSqlProcessor : RelationalParameterBasedSqlProce
     {
         queryExpression = base.Optimize(queryExpression, parametersValues, out canCache);
 
-        queryExpression = new NonQueryConvertingExpressionVisitor().Process(queryExpression);
+        queryExpression = new NpgsqlDeleteConvertingExpressionVisitor().Process(queryExpression);
 
         return queryExpression;
     }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/FiltersInheritanceBulkUpdatesNpgsqlTest.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.BulkUpdates;
 
@@ -67,6 +66,66 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Update_where_hierarchy(bool async)
+    {
+        await base.Update_where_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Animals"" AS a
+    SET ""Name"" = 'Animal'
+WHERE a.""CountryId"" = 1 AND a.""Name"" = 'Great spotted kiwi'");
+    }
+
+    public override async Task Update_where_hierarchy_subquery(bool async)
+    {
+        await base.Update_where_hierarchy_subquery(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_derived(bool async)
+    {
+        await base.Update_where_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Animals"" AS a
+    SET ""Name"" = 'Kiwi'
+WHERE a.""Discriminator"" = 'Kiwi' AND a.""CountryId"" = 1 AND a.""Name"" = 'Great spotted kiwi'");
+    }
+
+    public override async Task Update_where_using_hierarchy(bool async)
+    {
+        await base.Update_where_using_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    WHERE a.""CountryId"" = 1 AND c.""Id"" = a.""CountryId"" AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_using_hierarchy_derived(bool async)
+    {
+        await base.Update_where_using_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    WHERE a.""CountryId"" = 1 AND c.""Id"" = a.""CountryId"" AND a.""Discriminator"" = 'Kiwi' AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+    {
+        await base.Update_where_keyless_entity_mapped_to_sql_query(async);
+
+        AssertExecuteUpdateSql();
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
@@ -75,4 +134,7 @@ WHERE (
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesNpgsqlFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesNpgsqlFixture.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.BulkUpdates;
@@ -7,4 +8,11 @@ public class InheritanceBulkUpdatesNpgsqlFixture : InheritanceBulkUpdatesRelatio
 {
     protected override ITestStoreFactory TestStoreFactory
         => NpgsqlTestStoreFactory.Instance;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        modelBuilder.Entity<AnimalQuery>().HasNoKey().ToSqlQuery(@"SELECT * FROM ""Animals""");
+    }
 }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/InheritanceBulkUpdatesNpgsqlTest.cs
@@ -66,6 +66,66 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Update_where_hierarchy(bool async)
+    {
+        await base.Update_where_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Animals"" AS a
+    SET ""Name"" = 'Animal'
+WHERE a.""Name"" = 'Great spotted kiwi'");
+    }
+
+    public override async Task Update_where_hierarchy_subquery(bool async)
+    {
+        await base.Update_where_hierarchy_subquery(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_derived(bool async)
+    {
+        await base.Update_where_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Animals"" AS a
+    SET ""Name"" = 'Kiwi'
+WHERE a.""Discriminator"" = 'Kiwi' AND a.""Name"" = 'Great spotted kiwi'");
+    }
+
+    public override async Task Update_where_using_hierarchy(bool async)
+    {
+        await base.Update_where_using_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    WHERE c.""Id"" = a.""CountryId"" AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_using_hierarchy_derived(bool async)
+    {
+        await base.Update_where_using_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    WHERE c.""Id"" = a.""CountryId"" AND a.""Discriminator"" = 'Kiwi' AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+    {
+        await base.Update_where_keyless_entity_mapped_to_sql_query(async);
+
+        AssertExecuteUpdateSql();
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());
@@ -74,4 +134,7 @@ WHERE (
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
@@ -13,10 +13,6 @@ public class NorthwindBulkUpdatesNpgsqlTest : NorthwindBulkUpdatesTestBase<North
         // Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalFact]
-    public virtual void Check_all_tests_overridden()
-        => TestHelpers.AssertAllMethodsOverridden(GetType());
-
     public override async Task Delete_Where(bool async)
     {
         await base.Delete_Where(async);
@@ -501,6 +497,135 @@ WHERE EXISTS (
     WHERE o0.""OrderID"" < 10276 AND o0.""OrderID"" = o.""OrderID"" AND o0.""ProductID"" = o.""ProductID"")");
     }
 
+    public override async Task Update_where_constant(bool async)
+    {
+        await base.Update_where_constant(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Customers"" AS c
+    SET ""ContactName"" = 'Updated'
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_where_parameter(bool async)
+    {
+        await base.Update_where_parameter(async);
+
+        AssertExecuteUpdateSql(
+            @"@__value_0='Abc'
+
+UPDATE ""Customers"" AS c
+    SET ""ContactName"" = @__value_0
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+        public override async Task Update_where_using_property_plus_constant(bool async)
+    {
+        await base.Update_where_using_property_plus_constant(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Customers"" AS c
+    SET ""ContactName"" = COALESCE(c.""ContactName"", '') || 'Abc'
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_where_using_property_plus_parameter(bool async)
+    {
+        await base.Update_where_using_property_plus_parameter(async);
+
+        AssertExecuteUpdateSql(
+            @"@__value_0='Abc'
+
+UPDATE ""Customers"" AS c
+    SET ""ContactName"" = COALESCE(c.""ContactName"", '') || @__value_0
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_where_using_property_plus_property(bool async)
+    {
+        await base.Update_where_using_property_plus_property(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Customers"" AS c
+    SET ""ContactName"" = COALESCE(c.""ContactName"", '') || c.""CustomerID""
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_where_constant_using_ef_property(bool async)
+    {
+        await base.Update_where_constant_using_ef_property(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Customers"" AS c
+    SET ""ContactName"" = 'Updated'
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_where_null(bool async)
+    {
+        await base.Update_where_null(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Customers"" AS c
+    SET ""ContactName"" = NULL
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_without_property_to_set_throws(bool async)
+    {
+        await base.Update_without_property_to_set_throws(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_with_invalid_lambda_throws(bool async)
+    {
+        await base.Update_with_invalid_lambda_throws(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_multi_property_update(bool async)
+    {
+        await base.Update_where_multi_property_update(async);
+
+        AssertExecuteUpdateSql(
+            @"@__value_0='Abc'
+
+UPDATE ""Customers"" AS c
+    SET ""City"" = 'Seattle',
+    ""ContactName"" = @__value_0
+WHERE c.""CustomerID"" LIKE 'F%'");
+    }
+
+    public override async Task Update_with_invalid_lambda_in_set_property_throws(bool async)
+    {
+        await base.Update_with_invalid_lambda_in_set_property_throws(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_multiple_entity_update(bool async)
+    {
+        await base.Update_multiple_entity_update(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_unmapped_property(bool async)
+    {
+        await base.Update_unmapped_property(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesNpgsqlTest.cs
@@ -1,6 +1,4 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
-using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.BulkUpdates;
 
@@ -12,10 +10,6 @@ public class TPCFiltersInheritanceBulkUpdatesNpgsqlTest
     {
         ClearLog();
     }
-
-    [ConditionalFact]
-    public virtual void Check_all_tests_overridden()
-        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override async Task Delete_where_hierarchy(bool async)
     {
@@ -80,8 +74,81 @@ WHERE (
         AssertSql();
     }
 
+        public override async Task Update_where_hierarchy(bool async)
+    {
+        await base.Update_where_hierarchy(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_subquery(bool async)
+    {
+        await base.Update_where_hierarchy_subquery(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_derived(bool async)
+    {
+        await base.Update_where_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Kiwi"" AS k
+    SET ""Name"" = 'Kiwi'
+WHERE k.""CountryId"" = 1 AND k.""Name"" = 'Great spotted kiwi'");
+    }
+
+    public override async Task Update_where_using_hierarchy(bool async)
+    {
+        await base.Update_where_using_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM (
+        SELECT e.""Id"", e.""CountryId"", e.""Name"", e.""Species"", e.""EagleId"", e.""IsFlightless"", e.""Group"", NULL AS ""FoundOn"", 'Eagle' AS ""Discriminator""
+        FROM ""Eagle"" AS e
+        UNION ALL
+        SELECT k.""Id"", k.""CountryId"", k.""Name"", k.""Species"", k.""EagleId"", k.""IsFlightless"", NULL AS ""Group"", k.""FoundOn"", 'Kiwi' AS ""Discriminator""
+        FROM ""Kiwi"" AS k
+    ) AS t
+    WHERE t.""CountryId"" = 1 AND c.""Id"" = t.""CountryId"" AND t.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_using_hierarchy_derived(bool async)
+    {
+        await base.Update_where_using_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM (
+        SELECT k.""Id"", k.""CountryId"", k.""Name"", k.""Species"", k.""EagleId"", k.""IsFlightless"", NULL AS ""Group"", k.""FoundOn"", 'Kiwi' AS ""Discriminator""
+        FROM ""Kiwi"" AS k
+    ) AS t
+    WHERE t.""CountryId"" = 1 AND c.""Id"" = t.""CountryId"" AND t.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+    {
+        await base.Update_where_keyless_entity_mapped_to_sql_query(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesNpgsqlTest.cs
@@ -1,6 +1,4 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
-using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.BulkUpdates;
 
@@ -12,10 +10,6 @@ public class TPCInheritanceBulkUpdatesNpgsqlTest
     {
         ClearLog();
     }
-
-    [ConditionalFact]
-    public virtual void Check_all_tests_overridden()
-        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override async Task Delete_where_hierarchy(bool async)
     {
@@ -80,9 +74,82 @@ WHERE (
         AssertSql();
     }
 
+        public override async Task Update_where_hierarchy(bool async)
+    {
+        await base.Update_where_hierarchy(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_subquery(bool async)
+    {
+        await base.Update_where_hierarchy_subquery(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_derived(bool async)
+    {
+        await base.Update_where_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Kiwi"" AS k
+    SET ""Name"" = 'Kiwi'
+WHERE k.""Name"" = 'Great spotted kiwi'");
+    }
+
+    public override async Task Update_where_using_hierarchy(bool async)
+    {
+        await base.Update_where_using_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM (
+        SELECT e.""Id"", e.""CountryId"", e.""Name"", e.""Species"", e.""EagleId"", e.""IsFlightless"", e.""Group"", NULL AS ""FoundOn"", 'Eagle' AS ""Discriminator""
+        FROM ""Eagle"" AS e
+        UNION ALL
+        SELECT k.""Id"", k.""CountryId"", k.""Name"", k.""Species"", k.""EagleId"", k.""IsFlightless"", NULL AS ""Group"", k.""FoundOn"", 'Kiwi' AS ""Discriminator""
+        FROM ""Kiwi"" AS k
+    ) AS t
+    WHERE c.""Id"" = t.""CountryId"" AND t.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_using_hierarchy_derived(bool async)
+    {
+        await base.Update_where_using_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM (
+        SELECT k.""Id"", k.""CountryId"", k.""Name"", k.""Species"", k.""EagleId"", k.""IsFlightless"", NULL AS ""Group"", k.""FoundOn"", 'Kiwi' AS ""Discriminator""
+        FROM ""Kiwi"" AS k
+    ) AS t
+    WHERE c.""Id"" = t.""CountryId"" AND t.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+    {
+        await base.Update_where_keyless_entity_mapped_to_sql_query(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }
 

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesNpgsqlTest.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.BulkUpdates;
 
@@ -11,10 +10,6 @@ public class TPTFiltersInheritanceBulkUpdatesSqlServerTest
     {
         ClearLog();
     }
-
-    [ConditionalFact]
-    public virtual void Check_all_tests_overridden()
-        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override async Task Delete_where_hierarchy(bool async)
     {
@@ -70,8 +65,75 @@ WHERE (
         AssertSql();
     }
 
+    public override async Task Update_where_hierarchy(bool async)
+    {
+        await base.Update_where_hierarchy(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_subquery(bool async)
+    {
+        await base.Update_where_hierarchy_subquery(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_derived(bool async)
+    {
+        await base.Update_where_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_using_hierarchy(bool async)
+    {
+        await base.Update_where_using_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    LEFT JOIN ""Birds"" AS b ON a.""Id"" = b.""Id""
+    LEFT JOIN ""Eagle"" AS e ON a.""Id"" = e.""Id""
+    LEFT JOIN ""Kiwi"" AS k ON a.""Id"" = k.""Id""
+    WHERE a.""CountryId"" = 1 AND c.""Id"" = a.""CountryId"" AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_using_hierarchy_derived(bool async)
+    {
+        await base.Update_where_using_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    LEFT JOIN ""Birds"" AS b ON a.""Id"" = b.""Id""
+    LEFT JOIN ""Eagle"" AS e ON a.""Id"" = e.""Id""
+    LEFT JOIN ""Kiwi"" AS k ON a.""Id"" = k.""Id""
+    WHERE a.""CountryId"" = 1 AND c.""Id"" = a.""CountryId"" AND (k.""Id"" IS NOT NULL) AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+    {
+        await base.Update_where_keyless_entity_mapped_to_sql_query(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesNpgsqlTest.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.BulkUpdates;
 
@@ -10,10 +9,6 @@ public class TPTInheritanceBulkUpdatesNpgsqlTest : TPTInheritanceBulkUpdatesTest
     {
         ClearLog();
     }
-
-    [ConditionalFact]
-    public virtual void Check_all_tests_overridden()
-        => TestHelpers.AssertAllMethodsOverridden(GetType());
 
     public override async Task Delete_where_hierarchy(bool async)
     {
@@ -57,8 +52,75 @@ public class TPTInheritanceBulkUpdatesNpgsqlTest : TPTInheritanceBulkUpdatesTest
         AssertSql();
     }
 
+    public override async Task Update_where_hierarchy(bool async)
+    {
+        await base.Update_where_hierarchy(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_subquery(bool async)
+    {
+        await base.Update_where_hierarchy_subquery(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_hierarchy_derived(bool async)
+    {
+        await base.Update_where_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    public override async Task Update_where_using_hierarchy(bool async)
+    {
+        await base.Update_where_using_hierarchy(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    LEFT JOIN ""Birds"" AS b ON a.""Id"" = b.""Id""
+    LEFT JOIN ""Eagle"" AS e ON a.""Id"" = e.""Id""
+    LEFT JOIN ""Kiwi"" AS k ON a.""Id"" = k.""Id""
+    WHERE c.""Id"" = a.""CountryId"" AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_using_hierarchy_derived(bool async)
+    {
+        await base.Update_where_using_hierarchy_derived(async);
+
+        AssertExecuteUpdateSql(
+            @"UPDATE ""Countries"" AS c
+    SET ""Name"" = 'Monovia'
+WHERE (
+    SELECT count(*)::int
+    FROM ""Animals"" AS a
+    LEFT JOIN ""Birds"" AS b ON a.""Id"" = b.""Id""
+    LEFT JOIN ""Eagle"" AS e ON a.""Id"" = e.""Id""
+    LEFT JOIN ""Kiwi"" AS k ON a.""Id"" = k.""Id""
+    WHERE c.""Id"" = a.""CountryId"" AND (k.""Id"" IS NOT NULL) AND a.""CountryId"" > 0) > 0");
+    }
+
+    public override async Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+    {
+        await base.Update_where_keyless_entity_mapped_to_sql_query(async);
+
+        AssertExecuteUpdateSql();
+    }
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
     protected override void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
 
     private void AssertSql(params string[] expected)
         => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertExecuteUpdateSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, forUpdate: true);
 }

--- a/test/EFCore.PG.FunctionalTests/TableSplittingNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/TableSplittingNpgsqlTest.cs
@@ -13,6 +13,20 @@ public class TableSplittingNpgsqlTest : TableSplittingTestBase
 
     protected override ITestStoreFactory TestStoreFactory => NpgsqlTestStoreFactory.Instance;
 
+    public override async Task ExecuteUpdate_works_for_table_sharing(bool async)
+    {
+        await base.ExecuteUpdate_works_for_table_sharing(async);
+
+        AssertSql(
+            @"UPDATE ""Vehicles"" AS v
+    SET ""SeatingCapacity"" = 1",
+            //
+            @"SELECT NOT EXISTS (
+    SELECT 1
+    FROM ""Vehicles"" AS v
+    WHERE v.""SeatingCapacity"" <> 1)");
+    }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);


### PR DESCRIPTION
Here's the PG-side PR, nothing much to see here. Unlike with delete I don't think I'll need a special PG expression since the relational thing works pretty well as-is (no special logic needed for USING in DELETE). Will sync this as you make progress in [#28626](https://github.com/dotnet/efcore/pull/28626/files#).

Closes #2450