### PR TITLE
feat: add support for Contains on HashSets (apart from arrays and Lists)

### DIFF
--- a/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlSqlTranslatingExpressionVisitor.cs
@@ -169,6 +169,20 @@ public class NpgsqlSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
                             (SqlExpression)Visit(arguments[0]),
                             (SqlExpression)Visit(wherePredicateMethodCall.Object!));
                     }
+                    
+                    // As above, but for Contains on HashSet<T>
+                    if (predicateMethod.DeclaringType?.IsGenericType == true &&
+                        predicateMethod.DeclaringType.GetGenericTypeDefinition() == typeof(HashSet<>) &&
+                        predicateMethod.Name == nameof(HashSet<int>.Contains) &&
+                        predicateMethod.GetParameters().Length == 1 &&
+                        predicateArguments[0] is ParameterExpression parameterExpression3 &&
+                        parameterExpression3 == wherePredicate.Parameters[0])
+                    {
+                        return _sqlExpressionFactory.Overlaps(
+                            (SqlExpression)Visit(arguments[0]),
+                            (SqlExpression)Visit(wherePredicateMethodCall.Object!));
+                    }
+
                 }
 
                 // Pattern match for: array.Any(e => e == x) (and other equality patterns)
@@ -264,6 +278,20 @@ public class NpgsqlSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
                         (SqlExpression)Visit(arguments[0]),
                         (SqlExpression)Visit(wherePredicateMethodCall.Object!));
                 }
+                
+                // As above, but for Contains on HashSet<T>
+                if (predicateMethod.DeclaringType?.IsGenericType == true &&
+                    predicateMethod.DeclaringType.GetGenericTypeDefinition() == typeof(HashSet<>) &&
+                    predicateMethod.Name == nameof(HashSet<int>.Contains) &&
+                    predicateMethod.GetParameters().Length == 1 &&
+                    predicateArguments[0] is ParameterExpression parameterExpression3 &&
+                    parameterExpression3 == wherePredicate.Parameters[0])
+                {
+                    return _sqlExpressionFactory.ContainedBy(
+                        (SqlExpression)Visit(arguments[0]),
+                        (SqlExpression)Visit(wherePredicateMethodCall.Object!));
+                }
+
             }
         }
 


### PR DESCRIPTION
I stumbled upon a translation error when trying to use an All together with a Contains statement, like this:

```c#
var assignableRoles = claimsPrincipal.GetAssignableRoles().ToHashSet();
return query.Where(user => user.Roles.All(role => assignableRoles.Contains(role)));
```
The same code did work when using `ToArray()` instead of `ToHashSet()`.

I have extended the code in `NpgsqlSqlTranslatingExpressionVisitor` to also allow HashSets.

(BTW, I hope I'm doing this the right way, this is only my second PR on GitHub, and I couldn't find rules about contributing to the project)