### PR TITLE
Introduce `JsonPathExists` function

### DIFF
--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
@@ -110,14 +110,14 @@ public static class NpgsqlJsonDbFunctionsExtensions
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonTypeof)));
 
     /// <summary>
-    /// Returns true if the JSON value matches the JSON Path expression
+    /// Checks whether the JSON path returns any item for the specified JSON value.
     /// </summary>
     /// <param name="_">DbFunctions instance</param>
     /// <param name="json">
     /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
     /// </param>
     /// <param name="jsonPath">
-    /// JSON Path query, if the test is true then the function will return true for the given JSON value
+    /// A JSON path to search within <paramref="json" />..
     /// </param>
     /// <remarks>
     /// This operation is only supported with PostgreSQL <c>jsonb</c>, not <c>json</c>.

--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
@@ -117,7 +117,7 @@ public static class NpgsqlJsonDbFunctionsExtensions
     /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
     /// </param>
     /// <param name="jsonPath">
-    /// A JSON path to search within <paramref="json" />..
+    /// A JSON path to search within <paramref name="json" />
     /// </param>
     /// <remarks>
     /// This operation is only supported with PostgreSQL <c>jsonb</c>, not <c>json</c>.

--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
@@ -126,4 +126,21 @@ public static class NpgsqlJsonDbFunctionsExtensions
     /// </remarks>
     public static bool JsonPathExists(this DbFunctions _, object json, string jsonPath)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonPathExists)));
+
+    /// <inheritdoc cref="JsonPathExists(Microsoft.EntityFrameworkCore.DbFunctions,object,string)"/>
+    /// <param name="vars">
+    /// must be a JSON object. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+    /// Its fields provide named values to be substituted into the jsonpath expression, field names are referenced with a `$`.
+    /// </param>
+#pragma warning disable CS1573
+    public static bool JsonPathExists(this DbFunctions _, object json, string jsonPath, object vars)
+#pragma warning restore CS1573
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonPathExists)));
+
+    /// <inheritdoc cref="JsonPathExists(Microsoft.EntityFrameworkCore.DbFunctions,object,string,object)"/>
+    /// <param name="silent">suppress the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors.</param>
+#pragma warning disable CS1573
+    public static bool JsonPathExists(this DbFunctions _, object json, string jsonPath, object vars, bool silent)
+#pragma warning restore CS1573
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonPathExists)));
 }

--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlJsonDbFunctionsExtensions.cs
@@ -108,4 +108,22 @@ public static class NpgsqlJsonDbFunctionsExtensions
     /// </remarks>
     public static string JsonTypeof(this DbFunctions _, object json)
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonTypeof)));
+
+    /// <summary>
+    /// Returns true if the JSON value matches the JSON Path expression
+    /// </summary>
+    /// <param name="_">DbFunctions instance</param>
+    /// <param name="json">
+    /// A JSON column or value. Can be a <see cref="JsonDocument"/>, a string, or a user POCO mapped to JSON.
+    /// </param>
+    /// <param name="jsonPath">
+    /// JSON Path query, if the test is true then the function will return true for the given JSON value
+    /// </param>
+    /// <remarks>
+    /// This operation is only supported with PostgreSQL <c>jsonb</c>, not <c>json</c>.
+    /// 
+    /// See https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-SQLJSON-PATH
+    /// </remarks>
+    public static bool JsonPathExists(this DbFunctions _, object json, string jsonPath)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(JsonPathExists)));
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDbFunctionsTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDbFunctionsTranslator.cs
@@ -99,9 +99,10 @@ public class NpgsqlJsonDbFunctionsTranslator : IMethodCallTranslator
             nameof(NpgsqlJsonDbFunctionsExtensions.JsonPathExists)
                 => _sqlExpressionFactory.Function(
                     "jsonb_path_exists",
-                    new[] { args[0], args[1] },
+                    //args could be anywhere between 2 and 4, arg 2 is user variables and needs to be converted to jsonb if it's passed in.
+                    args.Select((arg, i) => i == 2 ? Jsonb(arg) : arg),
                     nullable: false,
-                    argumentsPropagateNullability: FalseArrays[2],
+                    argumentsPropagateNullability: TrueArrays[4],
                     returnType: typeof(bool)),
             _ => null
         };

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDbFunctionsTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlJsonDbFunctionsTranslator.cs
@@ -96,7 +96,13 @@ public class NpgsqlJsonDbFunctionsTranslator : IMethodCallTranslator
                 => _sqlExpressionFactory.MakePostgresBinary(PostgresExpressionType.JsonExistsAny, Jsonb(args[0]), args[1]),
             nameof(NpgsqlJsonDbFunctionsExtensions.JsonExistAll)
                 => _sqlExpressionFactory.MakePostgresBinary(PostgresExpressionType.JsonExistsAll, Jsonb(args[0]), args[1]),
-
+            nameof(NpgsqlJsonDbFunctionsExtensions.JsonPathExists)
+                => _sqlExpressionFactory.Function(
+                    "jsonb_path_exists",
+                    new[] { args[0], args[1] },
+                    nullable: false,
+                    argumentsPropagateNullability: FalseArrays[2],
+                    returnType: typeof(bool)),
             _ => null
         };
 

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
@@ -577,7 +577,7 @@ WHERE json_typeof(j."CustomerElement"#>'{Statistics,Visits}') = 'number'
 
         Assert.Equal(1, count);
         AssertSql(
-            """
+"""
 SELECT count(*)::int
 FROM "JsonbEntities" AS j
 WHERE jsonb_path_exists(j."CustomerElement", '$.Orders[*] ? (@.Price == 5)')

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
@@ -584,6 +584,46 @@ WHERE jsonb_path_exists(j."CustomerElement", '$.Orders[*] ? (@.Price == 5)')
 """);
     }
 
+    [Fact]
+    public void JsonPathExists_with_vars()
+    {
+        using var ctx = CreateContext();
+        var price = 5;
+        var count = ctx.JsonbEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.CustomerElement, """$.Orders[*] ? (@.Price == $price)""", new {price}));
+
+        Assert.Equal(1, count);
+        AssertSql(
+"""
+@__p_1='{ price = 5 }' (DbType = Object)
+
+SELECT count(*)::int
+FROM "JsonbEntities" AS j
+WHERE jsonb_path_exists(j."CustomerElement", '$.Orders[*] ? (@.Price == $price)', @__p_1)
+""");
+    }
+
+    [Fact]
+    public void JsonPathExists_with_silent()
+    {
+        using var ctx = CreateContext();
+        var price = 5;
+        var count = ctx.JsonbEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.CustomerElement, """$.Orders[*] ? (@.Price == $price)""", new {price}, true));
+
+        Assert.Equal(1, count);
+        AssertSql(
+"""
+@__p_1='{ price = 5 }' (DbType = Object)
+
+SELECT count(*)::int
+FROM "JsonbEntities" AS j
+WHERE jsonb_path_exists(j."CustomerElement", '$.Orders[*] ? (@.Price == $price)', @__p_1, TRUE)
+""");
+    }
+
     #endregion Functions
 
     #region Support

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomQueryTest.cs
@@ -567,6 +567,23 @@ WHERE json_typeof(j."CustomerElement"#>'{Statistics,Visits}') = 'number'
 """);
     }
 
+    [Fact]
+    public void JsonPathExists()
+    {
+        using var ctx = CreateContext();
+        var count = ctx.JsonbEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.CustomerElement, """$.Orders[*] ? (@.Price == 5)"""));
+
+        Assert.Equal(1, count);
+        AssertSql(
+            """
+SELECT count(*)::int
+FROM "JsonbEntities" AS j
+WHERE jsonb_path_exists(j."CustomerElement", '$.Orders[*] ? (@.Price == 5)')
+""");
+    }
+
     #endregion Functions
 
     #region Support

--- a/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
@@ -682,6 +682,23 @@ WHERE json_typeof(j."Customer"#>'{Statistics,Visits}') = 'number'
 """);
     }
 
+    [Fact]
+    public void JsonPathExists()
+    {
+        using var ctx = CreateContext();
+        var count = ctx.JsonbEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.Customer, """$.Orders[*] ? (@.Price == 5)"""));
+
+        Assert.Equal(1, count);
+        AssertSql(
+            """
+SELECT count(*)::int
+FROM "JsonbEntities" AS j
+WHERE jsonb_path_exists(j."Customer", '$.Orders[*] ? (@.Price == 5)')
+""");
+    }
+
     #endregion Functions
 
     #region Support

--- a/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
@@ -692,7 +692,7 @@ WHERE json_typeof(j."Customer"#>'{Statistics,Visits}') = 'number'
 
         Assert.Equal(1, count);
         AssertSql(
-            """
+"""
 SELECT count(*)::int
 FROM "JsonbEntities" AS j
 WHERE jsonb_path_exists(j."Customer", '$.Orders[*] ? (@.Price == 5)')

--- a/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonPocoQueryTest.cs
@@ -699,6 +699,46 @@ WHERE jsonb_path_exists(j."Customer", '$.Orders[*] ? (@.Price == 5)')
 """);
     }
 
+    [Fact]
+    public void JsonPathExists_with_vars()
+    {
+        using var ctx = CreateContext();
+        var price = 5;
+        var count = ctx.JsonbEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.Customer, """$.Orders[*] ? (@.Price == $price)""", new {price}));
+
+        Assert.Equal(1, count);
+        AssertSql(
+"""
+@__p_1='{ price = 5 }' (DbType = Object)
+
+SELECT count(*)::int
+FROM "JsonbEntities" AS j
+WHERE jsonb_path_exists(j."Customer", '$.Orders[*] ? (@.Price == $price)', @__p_1)
+""");
+    }
+
+    [Fact]
+    public void JsonPathExists_with_silent()
+    {
+        using var ctx = CreateContext();
+        var price = 5;
+        var count = ctx.JsonbEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.Customer, """$.Orders[*] ? (@.Price == $price)""", new {price}, true));
+
+        Assert.Equal(1, count);
+        AssertSql(
+"""
+@__p_1='{ price = 5 }' (DbType = Object)
+
+SELECT count(*)::int
+FROM "JsonbEntities" AS j
+WHERE jsonb_path_exists(j."Customer", '$.Orders[*] ? (@.Price == $price)', @__p_1, TRUE)
+""");
+    }
+
     #endregion Functions
 
     #region Support

--- a/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
@@ -246,7 +246,7 @@ WHERE j."CustomerJsonb" ?& ARRAY['foo','Age']::text[]
 
         Assert.Equal(1, count);
         AssertSql(
-            """
+"""
 SELECT count(*)::int
 FROM "JsonEntities" AS j
 WHERE jsonb_path_exists(j."CustomerJsonb", '$.Orders[*] ? (@.Price == 5)')

--- a/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
@@ -235,6 +235,24 @@ WHERE j."CustomerJsonb" ?& ARRAY['foo','Age']::text[]
 """);
     }
 
+
+    [Fact]
+    public void JsonPathExists()
+    {
+        using var ctx = CreateContext();
+        var count = ctx.JsonEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.CustomerJsonb, """$.Orders[*] ? (@.Price == 5)"""));
+
+        Assert.Equal(1, count);
+        AssertSql(
+            """
+SELECT count(*)::int
+FROM "JsonEntities" AS j
+WHERE jsonb_path_exists(j."CustomerJsonb", '$.Orders[*] ? (@.Price == 5)')
+""");
+    }
+
     #endregion Functions
 
     #region Support

--- a/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonStringQueryTest.cs
@@ -235,7 +235,6 @@ WHERE j."CustomerJsonb" ?& ARRAY['foo','Age']::text[]
 """);
     }
 
-
     [Fact]
     public void JsonPathExists()
     {
@@ -250,6 +249,46 @@ WHERE j."CustomerJsonb" ?& ARRAY['foo','Age']::text[]
 SELECT count(*)::int
 FROM "JsonEntities" AS j
 WHERE jsonb_path_exists(j."CustomerJsonb", '$.Orders[*] ? (@.Price == 5)')
+""");
+    }
+
+    [Fact]
+    public void JsonPathExists_with_vars()
+    {
+        using var ctx = CreateContext();
+        var price = 5;
+        var count = ctx.JsonEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.CustomerJsonb, """$.Orders[*] ? (@.Price == $price)""", new {price}));
+
+        Assert.Equal(1, count);
+        AssertSql(
+"""
+@__p_1='{ price = 5 }' (DbType = Object)
+
+SELECT count(*)::int
+FROM "JsonEntities" AS j
+WHERE jsonb_path_exists(j."CustomerJsonb", '$.Orders[*] ? (@.Price == $price)', @__p_1)
+""");
+    }
+
+    [Fact]
+    public void JsonPathExists_with_silent()
+    {
+        using var ctx = CreateContext();
+        var price = 5;
+        var count = ctx.JsonEntities.Count(
+            e =>
+                EF.Functions.JsonPathExists(e.CustomerJsonb, """$.Orders[*] ? (@.Price == $price)""", new {price}, true));
+
+        Assert.Equal(1, count);
+        AssertSql(
+"""
+@__p_1='{ price = 5 }' (DbType = Object)
+
+SELECT count(*)::int
+FROM "JsonEntities" AS j
+WHERE jsonb_path_exists(j."CustomerJsonb", '$.Orders[*] ? (@.Price == $price)', @__p_1, TRUE)
 """);
     }
 


### PR DESCRIPTION
Implements `json_path_exists` support via an extension function for #2668. Currently this version does not support the `vars` or `silent` parameter that the database function does.

I would love to implement the `vars` support especially otherwise there's some possibility for JSON path injection if a user defined variable is used to build the path expression, which seems very likely. I suppose the `vars` could be either a json string or a `JsonElement` like what was done with `JsonContains` but is there a risk of some kind of injection there too? Also it's quite difficult to work with either element or a json string in code.

As for implementing other json path methods this seems like the simplest to start with as it just returns a boolean, others that actually return json would be a lot harder to work with.