### PR TITLE
Allow mapping inet as (IPAddress, int).

### DIFF
--- a/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
@@ -460,13 +460,11 @@ public class NpgsqlQuerySqlGenerator : QuerySqlGenerator
             .Append(binaryExpression.OperatorType switch
             {
                 PostgresExpressionType.Contains
-                    when binaryExpression.Left.TypeMapping is NpgsqlInetTypeMapping ||
-                    binaryExpression.Left.TypeMapping is NpgsqlCidrTypeMapping
+                    when binaryExpression.Left.TypeMapping is NpgsqlInetTypeMapping
                     => ">>",
 
                 PostgresExpressionType.ContainedBy
-                    when binaryExpression.Left.TypeMapping is NpgsqlInetTypeMapping ||
-                    binaryExpression.Left.TypeMapping is NpgsqlCidrTypeMapping
+                    when binaryExpression.Left.TypeMapping is NpgsqlInetTypeMapping
                     => "<<",
 
                 PostgresExpressionType.Contains    => "@>",

--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -117,8 +117,9 @@ public class NpgsqlTypeMappingSource : RelationalTypeMappingSource
     // Network address types
     private readonly NpgsqlMacaddrTypeMapping      _macaddr            = new();
     private readonly NpgsqlMacaddr8TypeMapping     _macaddr8           = new();
-    private readonly NpgsqlInetTypeMapping         _inet               = new();
-    private readonly NpgsqlCidrTypeMapping         _cidr               = new();
+    private readonly NpgsqlInetTypeMapping         _inet               = new("inet", typeof(IPAddress),        NpgsqlDbType.Inet);
+    private readonly NpgsqlInetTypeMapping         _inetMask           = new("inet", typeof((IPAddress, int)), NpgsqlDbType.Inet);
+    private readonly NpgsqlInetTypeMapping         _cidr               = new("cidr", typeof((IPAddress, int)), NpgsqlDbType.Cidr);
 
     // Built-in geometric types
     private readonly NpgsqlPointTypeMapping        _point              = new();
@@ -316,7 +317,7 @@ public class NpgsqlTypeMappingSource : RelationalTypeMappingSource
 
             { "macaddr",                     new[] { _macaddr                      } },
             { "macaddr8",                    new[] { _macaddr8                     } },
-            { "inet",                        new[] { _inet                         } },
+            { "inet",                        new[] { _inet, _inetMask              } },
             { "cidr",                        new[] { _cidr                         } },
 
             { "point",                       new[] { _point                        } },

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -254,6 +254,14 @@ public class NpgsqlTypeMappingTest
         => Assert.Equal(@"System.Net.IPAddress.Parse(""192.168.1.1"")", CodeLiteral(IPAddress.Parse("192.168.1.1")));
 
     [Fact]
+    public void GenerateSqlLiteral_returns_inet_masked_literal()
+        => Assert.Equal("INET '192.168.1.1/24'", GetMapping(typeof((IPAddress, int)), "inet").GenerateSqlLiteral((IPAddress.Parse("192.168.1.1"), 24)));
+
+    [Fact]
+    public void GenerateCodeLiteral_returns_inet_masked_literal()
+        => Assert.Equal(@"(System.Net.IPAddress.Parse(""192.168.1.1""), 24)", CodeLiteral((IPAddress.Parse("192.168.1.1"), 24)));
+
+    [Fact]
     public void GenerateSqlLiteral_returns_cidr_literal()
         => Assert.Equal("CIDR '192.168.1.0/24'", GetMapping("cidr").GenerateSqlLiteral((IPAddress.Parse("192.168.1.0"), 24)));
 


### PR DESCRIPTION
Fixes #1158

Unified `cidr` and `inet` handling code since they're similar.

I have no idea what I'm doing and barely understand how this code works, so please review carefully.