### PR TITLE
Provide a better exception message for invalid data source config.

### DIFF
--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -247,7 +247,7 @@ public class NpgsqlOptionsExtension : RelationalOptionsExtension
                 || RemoteCertificateValidationCallback is not null
                 || ProvidePasswordCallback is not null))
         {
-            throw new InvalidOperationException();
+            throw new InvalidOperationException($"Use {nameof(dataSource)} to configure certificate callbacks.");
         }
 
         if (UseRedshift && _postgresVersion is not null)

--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -248,22 +248,19 @@ public class NpgsqlOptionsExtension : RelationalOptionsExtension
             if (ProvideClientCertificatesCallback is not null)
             {
                 throw new InvalidOperationException(
-                    NpgsqlStrings.CannotConfigureWhenDataSourceIsInUse(
-                        "When passing an NpgsqlDataSource to UseNpgsql(), call 'ProvideClientCertificatesCallback' on NpgsqlDataSourceBuilder rather than in UseNpgsql()."));
+                    "When passing an NpgsqlDataSource to UseNpgsql(), call 'ProvideClientCertificatesCallback' on NpgsqlDataSourceBuilder rather than in UseNpgsql().");
             }
 
             if (RemoteCertificateValidationCallback is not null)
             {
                 throw new InvalidOperationException(
-                    NpgsqlStrings.CannotConfigureWhenDataSourceIsInUse(
-                        "When passing an NpgsqlDataSource to UseNpgsql(), call 'RemoteCertificateValidationCallback' on NpgsqlDataSourceBuilder rather than in UseNpgsql()."));
+                    "When passing an NpgsqlDataSource to UseNpgsql(), call 'RemoteCertificateValidationCallback' on NpgsqlDataSourceBuilder rather than in UseNpgsql().");
             }
 
             if (ProvidePasswordCallback is not null)
             {
                 throw new InvalidOperationException(
-                    NpgsqlStrings.CannotConfigureWhenDataSourceIsInUse(
-                        "When passing an NpgsqlDataSource to UseNpgsql(), 'ProviderPasswordCallback' cannot be used in UseNpgsql(). See https://www.npgsql.org/doc/security.html for configuring passwords and token rotation on NpgsqlDataSourceBuilder."));
+                    "When passing an NpgsqlDataSource to UseNpgsql(), 'ProviderPasswordCallback' cannot be used in UseNpgsql(). See https://www.npgsql.org/doc/security.html for configuring passwords and token rotation on NpgsqlDataSourceBuilder.");
             }
         }
 


### PR DESCRIPTION
Ran into this config problem a couple days ago. 
Using the npgsql data source builder to configure a enum mapping and providing a certificate callback not using this very same data source builder throws an exception with a default message. Which may be confusing.  
