### PR TITLE
Fix parsing of store types precision and scale

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -986,7 +986,7 @@ public class NpgsqlTypeMappingSource : RelationalTypeMappingSource
                     return storeTypeName;
                 }
 
-                if (int.TryParse(s[(comma + 1)..].Trim(), out var parsedScale))
+                if (int.TryParse(s[(comma + 1)..closeParen].Trim(), out var parsedScale))
                 {
                     scale = parsedScale;
                 }

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -16,6 +16,7 @@ public class NpgsqlTypeMappingSourceTest
     [InlineData("int", typeof(int), null, null, null, false)]
     [InlineData("int[]", typeof(int[]), null, null, null, false)]
     [InlineData("numeric", typeof(decimal), null, null, null, false)]
+    [InlineData("numeric(10,2)", typeof(decimal), null, 10, 2, false)]
     [InlineData("text", typeof(string), null, null, null, false)]
     [InlineData("TEXT", typeof(string), null, null, null, false)]
     [InlineData("character(8)", typeof(string), 8, null, null, true)]
@@ -44,6 +45,7 @@ public class NpgsqlTypeMappingSourceTest
     {
         var mapping = CreateTypeMappingSource().FindMapping(typeName);
 
+        Assert.NotNull(mapping);
         Assert.Same(type, mapping.ClrType);
         Assert.Equal(size, mapping.Size);
         Assert.Equal(precision, mapping.Precision);

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -11,41 +11,43 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage;
 public class NpgsqlTypeMappingSourceTest
 {
     [Theory]
-    [InlineData("integer", typeof(int), null, false)]
-    [InlineData("integer[]", typeof(int[]), null, false)]
-    [InlineData("int", typeof(int), null, false)]
-    [InlineData("int[]", typeof(int[]), null, false)]
-    [InlineData("numeric", typeof(decimal), null, false)]
-    [InlineData("text", typeof(string), null, false)]
-    [InlineData("TEXT", typeof(string), null, false)]
-    [InlineData("character(8)", typeof(string), 8, true)]
-    [InlineData("char(8)", typeof(string), 8, true)]
-    [InlineData("character(1)", typeof(char), 1, true)]
-    [InlineData("char(1)", typeof(char), 1, true)]
-    [InlineData("character", typeof(char), null, true)]
-    [InlineData("character varying(8)", typeof(string), 8, false)]
-    [InlineData("varchar(8)", typeof(string), 8, false)]
-    [InlineData("varchar", typeof(string), null, false)]
-    [InlineData("timestamp with time zone", typeof(DateTime), null, false)]
-    [InlineData("dummy", typeof(DummyType), null, false)]
-    [InlineData("int4range", typeof(NpgsqlRange<int>), null, false)]
-    [InlineData("floatrange", typeof(NpgsqlRange<float>), null, false)]
-    [InlineData("dummyrange", typeof(NpgsqlRange<DummyType>), null, false)]
-    [InlineData("int4multirange", typeof(NpgsqlRange<int>[]), null, false)]
-    [InlineData("geometry", typeof(Geometry), null, false)]
-    [InlineData("geometry(Polygon)", typeof(Polygon), null, false)]
-    [InlineData("geography(Point, 4326)", typeof(Point), null, false)]
-    [InlineData("geometry(pointz, 4326)", typeof(Point), null, false)]
-    [InlineData("geography(LineStringZM)", typeof(LineString), null, false)]
-    [InlineData("geometry(POLYGONM)", typeof(Polygon), null, false)]
-    [InlineData("xid", typeof(uint), null, false)]
-    [InlineData("xid8", typeof(ulong), null, false)]
-    public void By_StoreType(string typeName, Type type, int? size, bool fixedLength)
+    [InlineData("integer", typeof(int), null, null, null, false)]
+    [InlineData("integer[]", typeof(int[]), null, null, null, false)]
+    [InlineData("int", typeof(int), null, null, null, false)]
+    [InlineData("int[]", typeof(int[]), null, null, null, false)]
+    [InlineData("numeric", typeof(decimal), null, null, null, false)]
+    [InlineData("text", typeof(string), null, null, null, false)]
+    [InlineData("TEXT", typeof(string), null, null, null, false)]
+    [InlineData("character(8)", typeof(string), 8, null, null, true)]
+    [InlineData("char(8)", typeof(string), 8, null, null, true)]
+    [InlineData("character(1)", typeof(char), 1, null, null, true)]
+    [InlineData("char(1)", typeof(char), 1, null, null, true)]
+    [InlineData("character", typeof(char), null, null, null, true)]
+    [InlineData("character varying(8)", typeof(string), 8, null, null, false)]
+    [InlineData("varchar(8)", typeof(string), 8, null, null, false)]
+    [InlineData("varchar", typeof(string), null, null, null, false)]
+    [InlineData("timestamp with time zone", typeof(DateTime), null, null, null, false)]
+    [InlineData("dummy", typeof(DummyType), null, null, null, false)]
+    [InlineData("int4range", typeof(NpgsqlRange<int>), null, null, null, false)]
+    [InlineData("floatrange", typeof(NpgsqlRange<float>), null, null, null, false)]
+    [InlineData("dummyrange", typeof(NpgsqlRange<DummyType>), null, null, null, false)]
+    [InlineData("int4multirange", typeof(NpgsqlRange<int>[]), null, null, null, false)]
+    [InlineData("geometry", typeof(Geometry), null, null, null, false)]
+    [InlineData("geometry(Polygon)", typeof(Polygon), null, null, null, false)]
+    [InlineData("geography(Point, 4326)", typeof(Point), null, null, null, false)]
+    [InlineData("geometry(pointz, 4326)", typeof(Point), null, null, null, false)]
+    [InlineData("geography(LineStringZM)", typeof(LineString), null, null, null, false)]
+    [InlineData("geometry(POLYGONM)", typeof(Polygon), null, null, null, false)]
+    [InlineData("xid", typeof(uint), null, null, null, false)]
+    [InlineData("xid8", typeof(ulong), null, null, null, false)]
+    public void By_StoreType(string typeName, Type type, int? size, int? precision, int? scale, bool fixedLength)
     {
         var mapping = CreateTypeMappingSource().FindMapping(typeName);
 
         Assert.Same(type, mapping.ClrType);
         Assert.Equal(size, mapping.Size);
+        Assert.Equal(precision, mapping.Precision);
+        Assert.Equal(scale, mapping.Scale);
         Assert.False(mapping.IsUnicode);
         Assert.Equal(fixedLength, mapping.IsFixedLength);
         Assert.Equal(typeName, mapping.StoreType);


### PR DESCRIPTION
This is a regression that was introduced in afe8200cb7cd1b6780928aa7cfd05cc2da16c0bd but no test was covering the parsing of precision and scale.

Note: I discovered this bug while scaffolding the Chinook database with my [new tool](https://github.com/0xced/EFCore.Scaffolding#sample-code). The columns defined with `numeric(10,2)` would not be scaffolded with these warnings:
> Could not find type mapping for column 'public.Track.UnitPrice' with data type 'numeric(10,2)'. Skipping column.
> Could not find type mapping for column 'public.Invoice.Total' with data type 'numeric(10,2)'. Skipping column.
> Could not find type mapping for column 'public.InvoiceLine.UnitPrice' with data type 'numeric(10,2)'. Skipping column.

I'm pretty happy it only took me only about one hour from noticing the missing columns to submitting this pull request. 😄