### PR TITLE
Fix test concurrency issue

### DIFF
--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindQueryNpgsqlFixture.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindQueryNpgsqlFixture.cs
@@ -11,15 +11,6 @@ public class NorthwindQueryNpgsqlFixture<TModelCustomizer> : NorthwindQueryRelat
     protected override ITestStoreFactory TestStoreFactory => NpgsqlNorthwindTestStoreFactory.Instance;
     protected override Type ContextType => typeof(NorthwindNpgsqlContext);
 
-    static NorthwindQueryNpgsqlFixture()
-    {
-        // TODO: Switch to using NpgsqlDataSource
-#pragma warning disable CS0618 // Type or member is obsolete
-        NpgsqlConnection.GlobalTypeMapper.EnableDynamicJsonMappings();
-        NpgsqlConnection.GlobalTypeMapper.EnableRecordsAsTuples();
-#pragma warning restore CS0618 // Type or member is obsolete
-    }
-
     public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
     {
         var optionsBuilder = base.AddOptions(builder);

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/NpgsqlNorthwindTestStoreFactory.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/NpgsqlNorthwindTestStoreFactory.cs
@@ -6,6 +6,15 @@ public class NpgsqlNorthwindTestStoreFactory : NpgsqlTestStoreFactory
     public static readonly string NorthwindConnectionString = NpgsqlTestStore.CreateConnectionString(Name);
     public new static NpgsqlNorthwindTestStoreFactory Instance { get; } = new();
 
+    static NpgsqlNorthwindTestStoreFactory()
+    {
+        // TODO: Switch to using NpgsqlDataSource
+#pragma warning disable CS0618 // Type or member is obsolete
+        NpgsqlConnection.GlobalTypeMapper.EnableDynamicJsonMappings();
+        NpgsqlConnection.GlobalTypeMapper.EnableRecordsAsTuples();
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
     protected NpgsqlNorthwindTestStoreFactory()
     {
     }


### PR DESCRIPTION
Make sure the (legacy) Northwind data source always gets created with support for dynamic JSON and records as tuples.