### PR TITLE
Add failing test that exposes DbDataSource related bug.

### DIFF
--- a/test/EFCore.PG.Tests/NpgsqlRelationalConnectionTest.cs
+++ b/test/EFCore.PG.Tests/NpgsqlRelationalConnectionTest.cs
@@ -82,6 +82,46 @@ public class NpgsqlRelationalConnectionTest
     }
 
     [Fact]
+    public void Uses_correct_DbDataSource_from_application_service_provider_with_cached_DbContextOptions_extension()
+    {
+        var serviceCollection1 = new ServiceCollection();
+
+        serviceCollection1
+            .AddNpgsqlDataSource("Host=FakeHost1")
+            .AddDbContext<FakeDbContext>(o => o.UseNpgsql());
+
+        using (var serviceProvider1 = serviceCollection1.BuildServiceProvider())
+        {
+            var dataSource1 = serviceProvider1.GetRequiredService<NpgsqlDataSource>();
+
+            Assert.Equal("Host=FakeHost1", dataSource1.ConnectionString);
+
+            var context1 = serviceProvider1.GetRequiredService<FakeDbContext>();
+            var relationalConnection1 = (NpgsqlRelationalConnection)context1.GetService<IRelationalConnection>()!;
+
+            Assert.Same(dataSource1, relationalConnection1.DbDataSource);
+        }
+
+        var serviceCollection2 = new ServiceCollection();
+
+        serviceCollection2
+            .AddNpgsqlDataSource("Host=FakeHost2")
+            .AddDbContext<FakeDbContext>(o => o.UseNpgsql());
+
+        using (var serviceProvider2 = serviceCollection2.BuildServiceProvider())
+        {
+            var dataSource2 = serviceProvider2.GetRequiredService<NpgsqlDataSource>();
+
+            Assert.Equal("Host=FakeHost2", dataSource2.ConnectionString);
+
+            var context2 = serviceProvider2.GetRequiredService<FakeDbContext>();
+            var relationalConnection2 = (NpgsqlRelationalConnection)context2.GetService<IRelationalConnection>()!;
+
+            Assert.Same(dataSource2, relationalConnection2.DbDataSource);
+        }
+    }
+
+    [Fact]
     public void Can_create_master_connection_with_connection_string()
     {
         using var connection = CreateConnection();


### PR DESCRIPTION
@roji I took your `DbDataSource` support implementation as a base for our [Pomelo implementation](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1819) and came across a subtle bug.

This PR adds a test that fails.

The issue is that an old `DbDataSource` instance might be used by a later `DbContext` instance, if both contexts (the previous and the later one) are supposed to use a `DbDataSource` instance that was added as a service to the application service provider.

The reason seems to be that `NpgsqlOptionsExtension` is cached by the service provider cache and later reused, because none of its properties have changed (`DataSource` is `null` in both cases (the previous and the later context), since the `DbDataSource` instances are added via DI).

Because `NpgsqlOptionsExtension` is cached, no new `NpgsqlSingletonOptions` instance is created. But because it is `NpgsqlSingletonOptions.Initialize()` where the application service provider is checked for a DI supplied `DbDataSource` instance, later calls then reuse the obsolete one from the time that `NpgsqlOptionsExtension` was cached.

We workaround this issue by checking for `DbDataSource` services at the time we would actually need to, which is in our `IRelationalConnection` implementation. This might not be a good enough workaround for you, because you are accessing your `INpgsqlSingletonOptions.DataSource` property also from `NpgsqlTypeMappingSource`.

(Using `INpgsqlSingletonOptions.ApplicationServiceProvider` would suffer from the same issue.)

(It might be possible to pass the `CoreOptionsExtension` instance or the `DbContextOptions` instance as an option (`With...`) to `NpgsqlOptionsExtension` and then check the service provider(s) it contains in the `GetServiceProviderHashCode()`/`ShouldUseSameServiceProvider()` methods so that the `NpgsqlOptionsExtension` instance doesn't get cached if the `NpgsqlDataSource` service (and/or the service provider?) changed. I did not analyze or test this in any way, however, since it seems that Pomelo works fine with our current implementation. So this might not work or might turn out to be unreliable (e.g. somebody might alter the immutable `CoreOptionsExtension` instance after it has been passed, resulting in a new/cloned final instance). Anyway, just throwing it out there.).