### PR TITLE
Cast NodaTime DateInterval.End to date

### DIFF
--- a/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -251,10 +251,13 @@ public class NpgsqlNodaTimeMemberTranslator : IMemberTranslator
 
         if (member == DateInterval_End)
         {
-            return
-                _sqlExpressionFactory.Subtract(
+            var upperBound = _sqlExpressionFactory.Subtract(
                     Upper(),
                     _sqlExpressionFactory.Constant(Period.FromDays(1), _periodTypeMapping));
+
+            // PostgreSQL creates a result of type 'timestamp without time zone' when subtracting periods from dates.
+            // So we need to cast it to date explicitly.
+            return _sqlExpressionFactory.Convert(upperBound, typeof(LocalDate), _typeMappingSource.FindMapping(typeof(LocalDate)));
         }
 
         if (member == DateInterval_Length)

--- a/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.NodaTime.FunctionalTests/NodaTimeQueryNpgsqlTest.cs
@@ -1300,7 +1300,7 @@ WHERE lower(n."DateInterval") = DATE '2018-04-20'
             """
 SELECT n."Id", n."DateInterval", n."Duration", n."Instant", n."InstantRange", n."Interval", n."LocalDate", n."LocalDate2", n."LocalDateRange", n."LocalDateTime", n."LocalTime", n."Long", n."OffsetTime", n."Period", n."TimeZoneId", n."ZonedDateTime"
 FROM "NodaTimeTypes" AS n
-WHERE upper(n."DateInterval") - INTERVAL 'P1D' = DATE '2018-04-24'
+WHERE CAST(upper(n."DateInterval") - INTERVAL 'P1D' AS date) = DATE '2018-04-24'
 """);
     }
 


### PR DESCRIPTION
PostgreSQL creates a result of type 'timestamp without time zone' when subtracting periods from dates. This PR adds an explicit cast to date.

Fixes #3015