### PR TITLE
Add translator for hstore type

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlHstoreTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlHstoreTranslator.cs
@@ -1,0 +1,59 @@
+﻿using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class NpgsqlHstoreTranslator : IMethodCallTranslator
+{
+    private readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+    private readonly RelationalTypeMapping? _stringTypeMapping;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public NpgsqlHstoreTranslator(
+        IRelationalTypeMappingSource typeMappingSource,
+        NpgsqlSqlExpressionFactory sqlExpressionFactory,
+        IModel model)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+        _stringTypeMapping = typeMappingSource.FindMapping(typeof(string), model)!;
+    }
+
+    private static readonly MethodInfo _methodInfo = typeof(Dictionary<string, string>).GetRuntimeMethod(
+        "get_Item",
+        [
+            typeof(string),
+        ]
+    )!;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method != _methodInfo
+            || method.DeclaringType != typeof(Dictionary<string, string>)
+            || instance?.TypeMapping is not NpgsqlHstoreTypeMapping)
+        {
+            return null;
+        }
+
+        return _sqlExpressionFactory.JsonTraversal(instance, arguments, false, typeof(string), _stringTypeMapping);
+    }
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
@@ -51,6 +51,7 @@ public class NpgsqlMethodCallTranslatorProvider : RelationalMethodCallTranslator
                 new NpgsqlJsonDomTranslator(typeMappingSource, sqlExpressionFactory, model),
                 new NpgsqlJsonDbFunctionsTranslator(typeMappingSource, sqlExpressionFactory, model),
                 new NpgsqlJsonPocoTranslator(typeMappingSource, sqlExpressionFactory, model),
+                new NpgsqlHstoreTranslator(typeMappingSource, sqlExpressionFactory, model),
                 new NpgsqlLikeTranslator(sqlExpressionFactory),
                 LTreeTranslator,
                 new NpgsqlMathTranslator(typeMappingSource, sqlExpressionFactory, model),


### PR DESCRIPTION
for example: 
`a["b"]` will translate to `"a" -> 'b'`

If there is no translator, using the values of fields with the hstore type as a WHERE condition would be very cumbersome, and can only be achieved using `FromSqlRaw`.`