### PR TITLE
Rename NpgsqlUuid7ValueGenerator to NpgsqlSequentialGuidValueGenerator and make it public

### DIFF
--- a/src/EFCore.PG/ValueGeneration/Internal/NpgsqlValueGeneratorSelector.cs
+++ b/src/EFCore.PG/ValueGeneration/Internal/NpgsqlValueGeneratorSelector.cs
@@ -104,6 +104,6 @@ public class NpgsqlValueGeneratorSelector : RelationalValueGeneratorSelector
         => property.ClrType.UnwrapNullableType() == typeof(Guid)
             ? property.ValueGenerated == ValueGenerated.Never || property.GetDefaultValueSql() is not null
                 ? new TemporaryGuidValueGenerator()
-                : new NpgsqlUuid7ValueGenerator()
+                : new NpgsqlSequentialGuidValueGenerator()
             : base.FindForType(property, typeBase, clrType);
 }

--- a/src/EFCore.PG/ValueGeneration/NpgsqlSequentialGuidValueGenerator.cs
+++ b/src/EFCore.PG/ValueGeneration/NpgsqlSequentialGuidValueGenerator.cs
@@ -1,13 +1,13 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal;
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration;
 
 /// <summary>
 ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
 ///     directly from your code. This API may change or be removed in future releases.
 /// </summary>
-public class NpgsqlUuid7ValueGenerator : ValueGenerator<Guid>
+public class NpgsqlSequentialGuidValueGenerator : ValueGenerator<Guid>
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.PG.Tests/NpgsqlValueGeneratorSelectorTest.cs
+++ b/test/EFCore.PG.Tests/NpgsqlValueGeneratorSelectorTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.TestUtilities;
+using Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration;
 using Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL;
@@ -21,7 +22,7 @@ public class NpgsqlValueGeneratorSelectorTest
         AssertGenerator<TemporaryByteValueGenerator>("NullableByte");
         AssertGenerator<TemporaryDecimalValueGenerator>("Decimal");
         AssertGenerator<StringValueGenerator>("String");
-        AssertGenerator<NpgsqlUuid7ValueGenerator>("Guid");
+        AssertGenerator<NpgsqlSequentialGuidValueGenerator>("Guid");
         AssertGenerator<BinaryValueGenerator>("Binary");
     }
 
@@ -128,7 +129,7 @@ public class NpgsqlValueGeneratorSelectorTest
         AssertGenerator<NpgsqlSequenceHiLoValueGenerator<long>>("NullableLong", setSequences: true);
         AssertGenerator<NpgsqlSequenceHiLoValueGenerator<short>>("NullableShort", setSequences: true);
         AssertGenerator<StringValueGenerator>("String", setSequences: true);
-        AssertGenerator<NpgsqlUuid7ValueGenerator>("Guid", setSequences: true);
+        AssertGenerator<NpgsqlSequentialGuidValueGenerator>("Guid", setSequences: true);
         AssertGenerator<BinaryValueGenerator>("Binary", setSequences: true);
     }
 
@@ -216,7 +217,7 @@ public class NpgsqlValueGeneratorSelectorTest
     {
         var dtoNow = DateTimeOffset.UtcNow;
         var net9Internal = Guid.CreateVersion7(dtoNow);
-        var custom = NpgsqlUuid7ValueGenerator.BorrowedFromNet9.CreateVersion7(dtoNow);
+        var custom = NpgsqlSequentialGuidValueGenerator.BorrowedFromNet9.CreateVersion7(dtoNow);
         var bytenet9 = net9Internal.ToByteArray().AsSpan(0, 6);
         var bytecustom = custom.ToByteArray().AsSpan(0, 6);
         Assert.Equal(bytenet9, bytecustom);


### PR DESCRIPTION
EF only automatically configured client-side GUID generation for **key** GUID properties; other non-key GUID properties do not get configured by default. Since users may want to explicitly configure that behavior (see explicit call-out on this [in the docs](https://www.npgsql.org/efcore/modeling/generated-properties.html#guiduuid-generation)), the new UUID7 generator should be public and more properly named.

@ChrisJollyAU @Timovzl does this (and the new naming) make sense to you?

Follow-up to #3249