### PR TITLE
Dictionary (hstore, json, and jsonb) query support

### DIFF
--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDictionaryDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDictionaryDbFunctionsExtensions.cs
@@ -1,0 +1,126 @@
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Provides extension methods supporting `Dictionary&lt;TKey,TValue>` and `ImmutableDictionary&lt;TKey,TValue>` function translation for PostgreSQL for the `hstore`, `json` and `jsonb` store types.
+/// </summary>
+public static class NpgsqlDictionaryDbFunctionsExtensions
+{
+    /// <summary>
+    /// Deletes keys from input operand Dictionary. Returns the same store type as the provided input for `hstore` and `jsonb` columns.
+    ///
+    /// Works with `hstore`, `json` and `jsonb` type columns
+    /// <br/>
+    /// SQL translation: input - key
+    ///
+    /// Note: for `json` type columns, input will be cast to `jsonb` and will output `jsonb` which requires PostgreSQL 9.3
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input dictionary.</param>
+    /// <param name="key">The key to remove.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static T Remove<T, TValue>(this DbFunctions _, T input, string key)
+        where T : IEnumerable<KeyValuePair<string, TValue>>
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Remove)));
+
+    /// <summary>
+    /// Converts string dictionary to an array of alternating keys and values.
+    /// <br/>
+    /// HStore SQL translation: hstore_to_array(input)
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input hstore.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static List<string> ToKeyValueList(this DbFunctions _, IEnumerable<KeyValuePair<string, string>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ToKeyValueList)));
+
+    /// <summary>
+    /// Constructs an hstore `Dictionary&lt;string, string>` from a key/value pair string array
+    /// <br/>
+    /// SQL translation: hstore(input)
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input string array of key value pairs.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, string> DictionaryFromKeyValueList(this DbFunctions _, IList<string> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DictionaryFromKeyValueList)));
+
+    /// <summary>
+    /// Constructs an hstore `Dictionary&lt;string, string>` from a string array of keys and a string array of values
+    /// <br/>
+    /// SQL translation: hstore(keys, values)
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="keys">The input string array of keys.</param>
+    /// <param name="values">The input string array of values.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, string> DictionaryFromKeysAndValues(this DbFunctions _, IList<string> keys, IList<string> values)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DictionaryFromKeysAndValues)));
+
+    /// <summary>
+    /// Converts an `hstore` to a `json` value type `Dictionary&lt;string, object?>`, but attempts to distinguish numerical and boolean values so they are unquoted in the JSON.
+    /// <br/>
+    /// SQL translation: hstore_to_json_loose(input)
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input hstore.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, object?> ToJsonLoose(this DbFunctions _, IEnumerable<KeyValuePair<string, string>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ToJsonLoose)));
+
+    /// <summary>
+    /// Converts an `hstore` to a `jsonb` value type `Dictionary&lt;string, object?>`, but attempts to distinguish numerical and boolean values so they are unquoted in the JSON.
+    /// <br/>
+    /// SQL translation: hstore_to_jsonb_loose(input)
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input hstore.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, object?> ToJsonbLoose(this DbFunctions _, IEnumerable<KeyValuePair<string, string>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ToJsonbLoose)));
+
+    /// <summary>
+    /// Converts a `json` or `jsonb` type `IEnumerable&lt;KeyValuePair&lt;string, string>>` (i.e. Dictionary&lt;string, string>> or related type) to an hstore type `Dictionary&lt;string, string>>`
+    /// <br/>
+    /// Can be used during a migration of changing a column's StoreType from 'json' to 'hstore' with the `Using` clause
+    ///
+    /// HStore SQL translation: input
+    /// Json SQL translation: select hstore(array_agg(key), array_agg(value)) FROM json_each_text(input)
+    /// Json SQL translation: select hstore(array_agg(key), array_agg(value)) FROM jsonb_each_text(input)
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input hstore.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, string> ToHstore(this DbFunctions _, IEnumerable<KeyValuePair<string, string>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ToHstore)));
+
+    /// <summary>
+    /// Converts an `jsonb` or `hstore` type value to a `jsonb` type `Dictionary&lt;TKey, TKey>`
+    /// <br/>
+    ///
+    /// Hstore SQL translation: hstore_to_json(input)
+    /// Json SQL translation: input
+    /// Jsonb SQL translation: input::json
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input hstore.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, TValue> ToJson<TValue>(this DbFunctions _, IEnumerable<KeyValuePair<string, TValue>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ToJson)));
+
+    /// <summary>
+    /// Converts an `hstore` or `json` type value to a `jsonb` type `Dictionary&lt;TKey, TValue>`
+    ///
+    /// Can be used during a migration of changing a column's StoreType from 'hstore' to 'jsonb' with the `Using` clause
+    /// <br/>
+    /// HStore SQL translation: hstore_to_jsonb(input)
+    /// Json SQL translation: input::jsonb
+    /// Jsonb SQL translation: input
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="input">The input hstore.</param>
+    /// <seealso href="https://www.postgresql.org/docs/current/hstore.html#HSTORE-OPS-FUNCS">PostgreSQL documentation for 'hstore' functions.</seealso>
+    public static Dictionary<string, TValue> ToJsonb<TValue>(this DbFunctions _, IEnumerable<KeyValuePair<string, TValue>> input)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(ToJsonb)));
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDictionaryTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDictionaryTranslator.cs
@@ -1,0 +1,881 @@
+using System.Collections.Immutable;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
+using static Npgsql.EntityFrameworkCore.PostgreSQL.Utilities.Statics;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public class DictionaryTranslator : IMethodCallTranslator, IMemberTranslator
+{
+    #region Types
+
+    private static readonly Type StringDictionaryType = typeof(Dictionary<string, string>);
+    private static readonly Type ImmutableStringDictionaryType = typeof(ImmutableDictionary<string, string>);
+    private static readonly Type ExtensionsType = typeof(NpgsqlDictionaryDbFunctionsExtensions);
+    private static readonly Type GenericKvpType = typeof(KeyValuePair<,>).MakeGenericType(
+        Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(1));
+    private static readonly Type EnumerableType = typeof(IEnumerable<>).MakeGenericType(Type.MakeGenericMethodParameter(0));
+    private static readonly Type GenericListType = typeof(List<>);
+    private static readonly Type StringType = typeof(string);
+    private static readonly Type BoolType = typeof(string);
+    private static readonly Type StringListType = typeof(List<string>);
+
+    #endregion
+
+    #region MethodInfo(s)
+
+    private static readonly MethodInfo Enumerable_Any =
+        typeof(Enumerable).GetMethod(nameof(Enumerable.Any), BindingFlags.Public | BindingFlags.Static, [EnumerableType])!;
+
+    private static readonly MethodInfo Enumerable_Count =
+        typeof(Enumerable).GetMethod(nameof(Enumerable.Count), BindingFlags.Public | BindingFlags.Static, [EnumerableType])!;
+
+    private static readonly MethodInfo Enumerable_ToList =
+        typeof(Enumerable).GetMethod(nameof(Enumerable.ToList), BindingFlags.Public | BindingFlags.Static, [EnumerableType])!;
+
+    private static readonly MethodInfo Enumerable_ToDictionary =
+        typeof(Enumerable).GetMethod(
+            nameof(Enumerable.ToDictionary), BindingFlags.Public | BindingFlags.Static,
+            [typeof(IEnumerable<>).MakeGenericType(GenericKvpType)])!;
+
+    private static readonly MethodInfo GenericImmutableDictionary_ToImmutableDictionary =
+        typeof(ImmutableDictionary).GetMethod(
+            nameof(ImmutableDictionary.ToImmutableDictionary), BindingFlags.Public | BindingFlags.Static,
+            [typeof(IEnumerable<>).MakeGenericType(GenericKvpType)])!;
+
+    private static readonly MethodInfo Enumerable_Concat = typeof(Enumerable).GetMethod(
+        nameof(Enumerable.Concat), BindingFlags.Public | BindingFlags.Static,
+        [EnumerableType, EnumerableType])!;
+
+    private static readonly MethodInfo Enumerable_Except = typeof(Enumerable).GetMethod(
+        nameof(Enumerable.Except), BindingFlags.Public | BindingFlags.Static,
+        [EnumerableType, EnumerableType])!;
+
+    private static readonly MethodInfo Enumerable_SequenceEqual = typeof(Enumerable).GetMethod(
+        nameof(Enumerable.SequenceEqual), BindingFlags.Public | BindingFlags.Static,
+        [EnumerableType, EnumerableType])!;
+
+    #endregion
+
+    #region Extension MethodInfo(s)
+
+    private static readonly MethodInfo Extension_ToHstore =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.ToHstore))!;
+
+    private static readonly MethodInfo Extension_ToJson =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.ToJson))!;
+
+    private static readonly MethodInfo Extension_ToJsonb =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.ToJsonb))!;
+
+    private static readonly MethodInfo Extension_ToJsonLoose =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.ToJsonLoose))!;
+
+    private static readonly MethodInfo Extension_ToJsonbLoose =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.ToJsonbLoose))!;
+
+    private static readonly MethodInfo Extension_Remove =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.Remove))!;
+
+    private static readonly MethodInfo Extension_ToKeysAndValues =
+        ExtensionsType.GetMethod(nameof(NpgsqlDictionaryDbFunctionsExtensions.ToKeyValueList))!;
+
+    private static readonly MethodInfo Extension_FromKeysAndValues_List =
+        ExtensionsType.GetMethod(
+            nameof(NpgsqlDictionaryDbFunctionsExtensions.DictionaryFromKeyValueList), BindingFlags.Public | BindingFlags.Static,
+            null, [typeof(DbFunctions), typeof(IList<string>)], null)!;
+
+    private static readonly MethodInfo Extension_FromKeysAndValues_List_List =
+        ExtensionsType.GetMethod(
+            nameof(NpgsqlDictionaryDbFunctionsExtensions.DictionaryFromKeyValueList), BindingFlags.Public | BindingFlags.Static,
+            null, [typeof(DbFunctions), typeof(IList<string>), typeof(IList<string>)], null)!;
+
+    #endregion
+
+    #region Fields
+
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
+    private readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory;
+    private readonly IModel _model;
+
+    #endregion
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public DictionaryTranslator(
+        IRelationalTypeMappingSource typeMappingSource,
+        NpgsqlSqlExpressionFactory sqlExpressionFactory,
+        IModel model)
+    {
+        _typeMappingSource = typeMappingSource;
+        _sqlExpressionFactory = sqlExpressionFactory;
+        _model = model;
+    }
+
+    #region Interface Methods
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance is null)
+        {
+            if (arguments.Count is 3)
+            {
+                if (!IsDictionaryType(arguments[1].Type))
+                {
+                    return null;
+                }
+
+                if (method == Extension_FromKeysAndValues_List_List)
+                {
+                    return FromKeysAndValues(arguments[1], arguments[2]);
+                }
+
+                if (method.IsClosedFormOf(Extension_Remove))
+                {
+                    return Subtract(arguments[1], arguments[2]);
+                }
+
+                return null;
+            }
+
+            if (arguments.Count is 2)
+            {
+                if (!IsDictionaryType(arguments[1].Type) && !IsDictionaryType(arguments[0].Type))
+                {
+                    return null;
+                }
+
+                if (method == Extension_ToHstore)
+                {
+                    return ToHstore(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Extension_ToJson))
+                {
+                    return ToJson(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Extension_ToJsonb))
+                {
+                    return ToJsonb(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Extension_ToKeysAndValues))
+                {
+                    return ToKeysAndValues(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Extension_FromKeysAndValues_List))
+                {
+                    return FromKeysAndValues(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Extension_ToJsonLoose))
+                {
+                    return ToJsonLoose(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Extension_ToJsonbLoose))
+                {
+                    return ToJsonbLoose(arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Enumerable_SequenceEqual))
+                {
+                    return Equal(arguments[0], arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Enumerable_Concat))
+                {
+                    return Concat(arguments[0], arguments[1]);
+                }
+
+                if (method.IsClosedFormOf(Enumerable_Except))
+                {
+                    return Subtract(arguments[0], arguments[1], false);
+                }
+
+                return null;
+            }
+
+            if (arguments.Count is 1)
+            {
+                if (method.IsClosedFormOf(Enumerable_Count) || method.IsClosedFormOf(Enumerable_Any))
+                {
+                    var keyValueType = method.GetGenericArguments()[0];
+                    return !keyValueType.IsGenericType || keyValueType.GetGenericTypeDefinition() != typeof(KeyValuePair<,>)
+                        ? null
+                        : method.Name == nameof(Enumerable.Count)
+                        ? Count(arguments[0])
+                        : NotEmpty(arguments[0]);
+                }
+
+                if (method.IsClosedFormOf(Enumerable_ToDictionary))
+                {
+                    return arguments[0].Type == method.ReturnType
+                        ? arguments[0]
+                        : arguments[0].TypeMapping?.StoreType == "hstore"
+                            ? arguments[0] is SqlConstantExpression or SqlParameterExpression
+                                ? _sqlExpressionFactory.ApplyTypeMapping(
+                                    arguments[0], _typeMappingSource.FindMapping(StringDictionaryType, _model)!)
+                                : _sqlExpressionFactory.Convert(
+                                    arguments[0], StringDictionaryType, _typeMappingSource.FindMapping(StringDictionaryType, _model)!)
+                            : null;
+                }
+
+                if (method.IsClosedFormOf(GenericImmutableDictionary_ToImmutableDictionary))
+                {
+                    return arguments[0].Type == method.ReturnType
+                        ? arguments[0]
+                        : arguments[0].TypeMapping?.StoreType == "hstore"
+                            ? arguments[0] is SqlConstantExpression or SqlParameterExpression
+                                ? _sqlExpressionFactory.ApplyTypeMapping(
+                                    arguments[0], _typeMappingSource.FindMapping(ImmutableStringDictionaryType, _model)!)
+                                : _sqlExpressionFactory.Convert(
+                                    arguments[0], ImmutableStringDictionaryType,
+                                    _typeMappingSource.FindMapping(ImmutableStringDictionaryType, _model)!)
+                            : null;
+                }
+
+                // Hstore: store.Keys.ToList() => akeys(store)
+                //         store.Values.ToList() -> avals(store)
+                // Json: store.Keys.ToList() => array(select json_object_keys(instance))
+                //       store.Values.ToList() => select array_agg(value) from json_each_text(instance))
+                // Jsonb: store.Keys.ToList() => array(select jsonb_object_keys(instance))
+                //        store.Values.ToList() => select array_agg(value) from jsonb_each_text(instance))
+                if (method.IsClosedFormOf(Enumerable_ToList)
+                    && (arguments[0] is SqlFunctionExpression { Name: "akeys" or "avals", Arguments: [{ TypeMapping.StoreType: "hstore" }] }
+                        || arguments[0] is SqlFunctionExpression
+                        {
+                            Name: "array",
+                            Arguments:
+                            [
+                                ScalarSubqueryExpression
+                                {
+                                    Subquery.Projection:
+                                    [
+                                        {
+                                            Expression: SqlFunctionExpression
+                                            {
+                                                Name: "json_object_keys" or "jsonb_object_keys",
+                                                Arguments: [{ TypeMapping.StoreType: "json" or "jsonb" }]
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                        || arguments[0] is ScalarSubqueryExpression
+                        {
+                            Subquery.Tables:
+                            [
+                                TableValuedFunctionExpression
+                                {
+                                    Name: "json_each_text" or "jsonb_each_text" or "json_each" or "jsonb_each",
+                                    Arguments: [{ TypeMapping.StoreType: "json" or "jsonb" }]
+                                }
+                            ]
+                        }))
+                {
+                    return arguments[0];
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+
+        if (!IsDictionaryMethod(method))
+        {
+            return null;
+        }
+
+        if (method.Name == "get_Item")
+        {
+            return ValueForKey(instance, arguments[0]);
+        }
+
+        if (method.Name == nameof(ImmutableDictionary<string, string>.Remove))
+        {
+            return Subtract(instance, arguments[0]);
+        }
+
+        if (method.Name == nameof(Dictionary<string, string>.ContainsKey))
+        {
+            return ContainsKey(instance, arguments[0]);
+        }
+
+        if (method.Name == nameof(Dictionary<string, string>.ContainsValue))
+        {
+            return ContainsValue(instance, arguments[0]);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance is null || !IsDictionaryType(instance.Type))
+        {
+            return null;
+        }
+
+        return member.Name switch
+        {
+            nameof(Dictionary<string, string>.Keys) => Keys(instance),
+            nameof(Dictionary<string, string>.Count) => Count(instance, true),
+            nameof(ImmutableDictionary<string, string>.IsEmpty) => Empty(instance),
+            nameof(Dictionary<string, string>.Values) => Values(instance),
+            _ => null
+        };
+    }
+
+    #endregion Interface Methods
+
+    #region Translation Methods
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Keys(SqlExpression instance)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => JsonObjectKeys(instance, "json_object_keys"),
+            "jsonb" => JsonObjectKeys(instance, "jsonb_object_keys"),
+            "hstore" => _sqlExpressionFactory.Function(
+                "akeys", [instance], true, TrueArrays[1], StringListType, _typeMappingSource.FindMapping(StringListType, _model)!),
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Values(SqlExpression instance)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => JsonObjectValues(instance, false),
+            "jsonb" => JsonObjectValues(instance, true),
+            "hstore" => _sqlExpressionFactory.Function(
+                "avals", [instance], true, TrueArrays[1], StringListType, _typeMappingSource.FindMapping(StringListType, _model)!),
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Count(SqlExpression instance, bool nullable = false)
+        => IsDictionaryStore(instance)
+            ? _sqlExpressionFactory.Function("cardinality", [Keys(instance)!], nullable, TrueArrays[1], typeof(int))
+            : null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? NotEmpty(SqlExpression instance)
+    {
+        var valueType = GetDictionaryValueType(instance.Type);
+        var emptyDictionary = valueType == StringType
+            ? new Dictionary<string, string>()
+            : typeof(Dictionary<,>).MakeGenericType(StringType, valueType).GetConstructor([])!.Invoke([]);
+        return instance.TypeMapping?.StoreType switch
+        {
+            "json" => _sqlExpressionFactory.NotEqual(
+                ConvertToJsonb(instance),
+                _sqlExpressionFactory.Constant(emptyDictionary, _typeMappingSource.FindMapping(emptyDictionary.GetType(), "jsonb"))),
+            "jsonb" => _sqlExpressionFactory.NotEqual(
+                instance,
+                _sqlExpressionFactory.Constant(emptyDictionary, _typeMappingSource.FindMapping(emptyDictionary.GetType(), "jsonb"))),
+            "hstore" => _sqlExpressionFactory.NotEqual(Count(instance)!, _sqlExpressionFactory.Constant(0)),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Empty(SqlExpression instance)
+    {
+        var valueType = GetDictionaryValueType(instance.Type);
+        var emptyDictionary = valueType == StringType
+            ? new Dictionary<string, string>()
+            : typeof(Dictionary<,>).MakeGenericType(StringType, valueType).GetConstructor([])!.Invoke([]);
+        return instance.TypeMapping?.StoreType switch
+        {
+            "json" => _sqlExpressionFactory.Equal(
+                ConvertToJsonb(instance),
+                _sqlExpressionFactory.Constant(emptyDictionary, _typeMappingSource.FindMapping(emptyDictionary.GetType(), "jsonb"))),
+            "jsonb" => _sqlExpressionFactory.Equal(
+                instance,
+                _sqlExpressionFactory.Constant(emptyDictionary, _typeMappingSource.FindMapping(emptyDictionary.GetType(), "jsonb"))),
+            "hstore" => _sqlExpressionFactory.Equal(Count(instance)!, _sqlExpressionFactory.Constant(0)),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Subtract(SqlExpression left, SqlExpression right, bool leftType = true)
+    {
+        var leftCoerced = ToHstoreOrJsonb(left);
+        var rightCoerced = ToHstoreStringArrayStringOrJsonb(right);
+        if (leftCoerced is null || rightCoerced is null)
+        {
+            return null;
+        }
+
+        return _sqlExpressionFactory.MakePostgresBinary(
+            PgExpressionType.DictionarySubtract, left, right, (leftType ? left : right).TypeMapping);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Concat(SqlExpression left, SqlExpression right)
+    {
+        var coerced = CoerceToSameStoreType(left, right, false);
+        if (!coerced.HasValue)
+        {
+            return null;
+        }
+
+        return _sqlExpressionFactory.MakePostgresBinary(
+            PgExpressionType.DictionaryConcat, coerced.Value.Item1, coerced.Value.Item2, coerced.Value.Item2.TypeMapping);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Equal(SqlExpression left, SqlExpression right)
+    {
+        var coerced = CoerceToSameStoreType(left, right, true);
+        if (!coerced.HasValue)
+        {
+            return null;
+        }
+
+        return _sqlExpressionFactory.MakeBinary(
+            ExpressionType.Equal, coerced.Value.Item1, coerced.Value.Item1, null);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? Contains(SqlExpression left, SqlExpression right)
+    {
+        var coerced = CoerceToSameStoreType(left, right, false);
+        if (!coerced.HasValue)
+        {
+            return null;
+        }
+
+        return _sqlExpressionFactory.MakePostgresBinary(
+            PgExpressionType.Contains, coerced.Value.Item1, coerced.Value.Item1);
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression FromKeysAndValues(params SqlExpression[] arguments)
+        => _sqlExpressionFactory.Function(
+            "hstore", arguments, true, TrueArrays[arguments.Length], StringDictionaryType,
+            _typeMappingSource.FindMapping(StringDictionaryType, _model)!);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToKeysAndValues(SqlExpression instance)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "hstore" => _sqlExpressionFactory.Function(
+                "hstore_to_array", [instance], true, TrueArrays[1], StringListType,
+                _typeMappingSource.FindMapping(StringListType, _model)!),
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ValueForKey(SqlExpression instance, SqlExpression key)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => JsonObjectValueForKey(instance, key, false),
+            "jsonb" => JsonObjectValueForKey(instance, key, true),
+            "hstore" => _sqlExpressionFactory.MakePostgresBinary(
+                PgExpressionType.DictionaryValueForKey, instance, key, _typeMappingSource.FindMapping(StringType, _model)!),
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ContainsKey(SqlExpression instance, SqlExpression key)
+        => IsDictionaryStore(instance)
+            ? _sqlExpressionFactory.MakePostgresBinary(PgExpressionType.DictionaryContainsKey, ToHstoreOrJsonb(instance)!, key)
+            : null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ContainsValue(SqlExpression instance, SqlExpression value)
+        => IsDictionaryStore(instance)
+            ? _sqlExpressionFactory.Any(value, Values(instance)!, PgAnyOperatorType.Equal)
+            : null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToJsonb(SqlExpression instance)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => ConvertToJsonb(instance),
+            "jsonb" => instance,
+            "hstore" => _sqlExpressionFactory.Function(
+                "hstore_to_jsonb", [instance], true, TrueArrays[1], StringDictionaryType, _typeMappingSource.FindMapping(StringDictionaryType, "jsonb")),
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToJson(SqlExpression instance)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => instance,
+            "jsonb" => instance is SqlParameterExpression or SqlConstantExpression
+                ? _sqlExpressionFactory.ApplyTypeMapping(instance, _typeMappingSource.FindMapping(instance.Type, "json"))
+                : _sqlExpressionFactory.Convert(instance, instance.Type, _typeMappingSource.FindMapping(instance.Type, "json")),
+            "hstore" => _sqlExpressionFactory.Function(
+                "hstore_to_json", [instance], true, TrueArrays[1], StringDictionaryType, _typeMappingSource.FindMapping(StringDictionaryType, "json")),
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToJsonLoose(SqlExpression instance)
+        => instance.TypeMapping?.StoreType is "hstore"
+            ? _sqlExpressionFactory.Function(
+                "hstore_to_json_loose", [instance], true, TrueArrays[1], typeof(Dictionary<string, object?>),
+                _typeMappingSource.FindMapping(typeof(Dictionary<string, object?>), "json"))
+            : null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToJsonbLoose(SqlExpression instance)
+        => instance.TypeMapping?.StoreType is "hstore"
+            ? _sqlExpressionFactory.Function(
+                "hstore_to_jsonb_loose", [instance], true, TrueArrays[1], typeof(Dictionary<string, object?>),
+                _typeMappingSource.FindMapping(typeof(Dictionary<string, object?>), "jsonb"))
+            : null;
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToHstore(SqlExpression instance, bool immutable = false)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => ToHstore(instance, "json_each_text", immutable),
+            "jsonb" => ToHstore(instance, "jsonb_each_text", immutable),
+            "hstore" => instance,
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToHstoreOrJsonb(SqlExpression instance)
+        => instance.TypeMapping?.StoreType switch
+        {
+            "json" => ConvertToJsonb(instance),
+            "jsonb" => instance,
+            "hstore" => instance,
+            _ => null
+        };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public SqlExpression? ToHstoreStringArrayStringOrJsonb(SqlExpression instance)
+        => instance.Type == StringType
+            ? instance
+            : instance.TypeMapping?.StoreType switch
+            {
+                "json" => ConvertToJsonb(instance),
+                "jsonb" => instance,
+                "hstore" => instance,
+                "text[]" => instance,
+                _ => null
+            };
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public (SqlExpression, SqlExpression)? CoerceToSameStoreType(SqlExpression left, SqlExpression right, bool allowJson)
+    {
+        if (left.TypeMapping is null || right.TypeMapping is null)
+        {
+            return null;
+        }
+
+        if (left.TypeMapping.StoreType == right.TypeMapping.StoreType)
+        {
+            return !allowJson && left.TypeMapping.StoreType == "json" ? (ConvertToJsonb(left), ConvertToJsonb(right)) : (left, right);
+        }
+
+        if ((left.TypeMapping.StoreType == "hstore" && right.TypeMapping.StoreType is "json" or "jsonb")
+            || (right.TypeMapping.StoreType == "hstore" && left.TypeMapping.StoreType is "json" or "jsonb"))
+        {
+            return (ToHstore(left)!, ToHstore(right)!);
+        }
+
+        if ((left.TypeMapping.StoreType == "json" && right.TypeMapping.StoreType is "jsonb")
+            || (right.TypeMapping.StoreType == "json" && left.TypeMapping.StoreType is "jsonb"))
+        {
+            return (ToHstoreOrJsonb(left)!, ToHstoreOrJsonb(right)!);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool IsDictionaryStore(SqlExpression expr)
+        => expr.TypeMapping?.StoreType is "json" or "jsonb" or "hstore";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool IsDictionaryMethod(MethodInfo method)
+        => IsDictionaryType(method.DeclaringType!);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static bool IsDictionaryType(Type type)
+        => type.IsGenericType
+            && (type.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+                || type.GetGenericTypeDefinition() == typeof(ImmutableDictionary<,>));
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static Type GetDictionaryValueType(Type dictionaryType)
+        => dictionaryType.GetGenericArguments()[1];
+
+    private SqlExpression ConvertToJsonb(SqlExpression instance)
+        => instance is SqlConstantExpression or SqlParameterExpression
+            ? _sqlExpressionFactory.ApplyTypeMapping(instance, _typeMappingSource.FindMapping(instance.Type, "jsonb"))
+            : _sqlExpressionFactory.Convert(instance, instance.Type, _typeMappingSource.FindMapping(instance.Type, "jsonb"));
+
+#pragma warning disable EF1001 // SelectExpression constructors are currently internal
+
+    private SqlExpression JsonObjectKeys(SqlExpression instance, string jsonObjectKeysFn)
+        => _sqlExpressionFactory.Function(
+            "array", [
+                new ScalarSubqueryExpression(
+                    new(
+                        null,
+                        [],
+                        null, [], null,
+                        [
+                            new(
+                                _sqlExpressionFactory.Function(
+                                    jsonObjectKeysFn, [instance],
+                                    true, TrueArrays[1], StringType, _typeMappingSource.FindMapping(StringType, _model)!),
+                                string.Empty)
+                        ], false, [], null, null, null!))
+            ], true, TrueArrays[1], StringListType, _typeMappingSource.FindMapping(StringListType, _model)!);
+
+    private ScalarSubqueryExpression JsonObjectValues(SqlExpression instance, bool jsonb, SqlExpression? predicate = null)
+    {
+        var valueType = GetDictionaryValueType(instance.Type);
+        var jsonTypeMapping = _typeMappingSource.FindMapping(valueType, jsonb ? "jsonb" : "json");
+        var isStringValue = valueType == StringType;
+        var valueNeedsConversion = !isStringValue && valueType == BoolType || valueType.IsNumeric();
+        var valueTypeMapping = isStringValue ? _typeMappingSource.FindMapping(StringType, _model)! :
+            valueNeedsConversion ? _typeMappingSource.FindMapping(valueType, _model) :
+            jsonTypeMapping;
+        return new(
+            new(
+                null,
+                [
+                    new TableValuedFunctionExpression(
+                        "j1", isStringValue ? (jsonb ? "jsonb_each_text" : "json_each_text") : (jsonb ? "jsonb_each" : "json_each"),
+                        [instance])
+                ],
+                predicate, [], null,
+                [
+                    new(
+                        _sqlExpressionFactory.Function(
+                            "array_agg",
+                            [
+                                valueNeedsConversion
+                                    ? _sqlExpressionFactory.Convert(
+                                        new ColumnExpression(
+                                            "value", "j1", valueType, jsonTypeMapping, false), valueType, valueTypeMapping)
+                                    : new ColumnExpression(
+                                        "value", "j1", valueType, valueTypeMapping, false)
+                            ],
+                            true, TrueArrays[1],
+                            isStringValue ? StringListType : GenericListType.MakeGenericType(valueType),
+                            isStringValue ? _typeMappingSource.FindMapping(StringListType, _model)! :
+                            valueNeedsConversion ? _typeMappingSource.FindMapping(GenericListType.MakeGenericType(valueType), _model) :
+                            _typeMappingSource.FindMapping(GenericListType.MakeGenericType(valueType), jsonb ? "jsonb[]" : "json[]")),
+                        string.Empty)
+                ], false, [], null, null, null!));
+    }
+
+    private PgJsonTraversalExpression JsonObjectValueForKey(SqlExpression instance, SqlExpression key, bool jsonb)
+    {
+        var valueType = GetDictionaryValueType(instance.Type);
+        return _sqlExpressionFactory.JsonTraversal(
+            instance, [key], valueType == StringType, valueType,
+            valueType == StringType ? _typeMappingSource.FindMapping(valueType, _model)!
+                : _typeMappingSource.FindMapping(jsonb ? "jsonb" : "json")!);
+    }
+
+    private ScalarSubqueryExpression ToHstore(SqlExpression instance, string jsonEachTextFn, bool immutable)
+        => new(
+            new(
+                null,
+                [new TableValuedFunctionExpression("j1", jsonEachTextFn, [instance])],
+                null, [], null,
+                [
+                    new(
+                        _sqlExpressionFactory.Function(
+                            "hstore",
+                            [
+                                _sqlExpressionFactory.Function(
+                                    "array_agg",
+                                    [
+                                        new ColumnExpression(
+                                            "key", "j1", StringType, _typeMappingSource.FindMapping(StringType, _model)!, false)
+                                    ],
+                                    true, TrueArrays[1], StringListType, _typeMappingSource.FindMapping(StringListType, _model)!),
+                                _sqlExpressionFactory.Function(
+                                    "array_agg",
+                                    [
+                                        new ColumnExpression(
+                                            "value", "j1", StringType, _typeMappingSource.FindMapping(StringType, _model)!, true)
+                                    ],
+                                    true, TrueArrays[1], StringListType, _typeMappingSource.FindMapping(StringListType, _model)!)
+                            ],
+                            true, TrueArrays[2], immutable ? ImmutableStringDictionaryType : StringDictionaryType,
+                            immutable
+                                ? _typeMappingSource.FindMapping(ImmutableStringDictionaryType, _model)!
+                                : _typeMappingSource.FindMapping(StringDictionaryType, _model)!), string.Empty)
+                ], false, [], null, null, null!));
+#pragma warning restore EF1001
+    #endregion Translation Methods
+}

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMemberTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMemberTranslatorProvider.cs
@@ -40,6 +40,7 @@ public class NpgsqlMemberTranslatorProvider : RelationalMemberTranslatorProvider
                 new NpgsqlDateTimeMemberTranslator(typeMappingSource, sqlExpressionFactory),
                 new NpgsqlJsonDomTranslator(typeMappingSource, sqlExpressionFactory, model),
                 new NpgsqlLTreeTranslator(typeMappingSource, sqlExpressionFactory, model),
+                new DictionaryTranslator(typeMappingSource, sqlExpressionFactory, model),
                 JsonPocoTranslator,
                 new NpgsqlRangeTranslator(typeMappingSource, sqlExpressionFactory, model, supportsMultiranges),
                 new NpgsqlStringMemberTranslator(sqlExpressionFactory),

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMethodCallTranslatorProvider.cs
@@ -62,7 +62,8 @@ public class NpgsqlMethodCallTranslatorProvider : RelationalMethodCallTranslator
                 new NpgsqlRegexTranslator(typeMappingSource, sqlExpressionFactory, supportRegexCount),
                 new NpgsqlRowValueTranslator(sqlExpressionFactory),
                 new NpgsqlStringMethodTranslator(typeMappingSource, sqlExpressionFactory),
-                new NpgsqlTrigramsMethodTranslator(typeMappingSource, sqlExpressionFactory, model)
+                new NpgsqlTrigramsMethodTranslator(typeMappingSource, sqlExpressionFactory, model),
+                new DictionaryTranslator(typeMappingSource, sqlExpressionFactory, model)
         ]);
     }
 }

--- a/src/EFCore.PG/Query/Expressions/Internal/PgBinaryExpression.cs
+++ b/src/EFCore.PG/Query/Expressions/Internal/PgBinaryExpression.cs
@@ -151,6 +151,11 @@ public class PgBinaryExpression : SqlExpression
 
                     PgExpressionType.Distance => "<->",
 
+                    PgExpressionType.DictionaryContainsKey => "?",
+                    PgExpressionType.DictionaryValueForKey => "->",
+                    PgExpressionType.DictionaryConcat => "||",
+                    PgExpressionType.DictionarySubtract => "-",
+
                     _ => throw new ArgumentOutOfRangeException($"Unhandled operator type: {OperatorType}")
                 })
             .Append(" ");

--- a/src/EFCore.PG/Query/Expressions/PgExpressionType.cs
+++ b/src/EFCore.PG/Query/Expressions/PgExpressionType.cs
@@ -159,4 +159,28 @@ public enum PgExpressionType
     LTreeFirstMatches, // ?~ or ?@
 
     #endregion LTree
+
+    #region Dictionary
+
+    /// <summary>
+    ///     Represents a PostgreSQL operator for accessing a hstore, json or bson value for a given key
+    /// </summary>
+    DictionaryValueForKey, // ->
+
+    /// <summary>
+    ///     Represents a PostgreSQL operator for checking if a hstore contains the given key
+    /// </summary>
+    DictionaryContainsKey, // ?
+
+    /// <summary>
+    ///     Represents a PostgreSQL operator for subtracting hstore or jsonb values
+    /// </summary>
+    DictionarySubtract, // -
+
+    /// <summary>
+    ///     Represents a PostgreSQL operator for concatenating hstores
+    /// </summary>
+    DictionaryConcat, // ||
+
+    #endregion Dictionary
 }

--- a/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
@@ -527,6 +527,11 @@ public class NpgsqlQuerySqlGenerator : QuerySqlGenerator
 
                     PgExpressionType.Distance => "<->",
 
+                    PgExpressionType.DictionaryContainsKey => "?",
+                    PgExpressionType.DictionaryValueForKey => "->",
+                    PgExpressionType.DictionaryConcat => "||",
+                    PgExpressionType.DictionarySubtract => "-",
+
                     _ => throw new ArgumentOutOfRangeException($"Unhandled operator type: {binaryExpression.OperatorType}")
                 })
             .Append(" ");

--- a/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
@@ -307,6 +307,7 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
             case PgExpressionType.JsonExists:
             case PgExpressionType.JsonExistsAny:
             case PgExpressionType.JsonExistsAll:
+            case PgExpressionType.DictionaryContainsKey:
                 returnType = typeof(bool);
                 break;
 
@@ -785,6 +786,7 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
             case PgExpressionType.JsonExists:
             case PgExpressionType.JsonExistsAny:
             case PgExpressionType.JsonExistsAll:
+            case PgExpressionType.DictionaryContainsKey:
             {
                 // TODO: For networking, this probably needs to be cleaned up, i.e. we know where the CIDR and INET are
                 // based on operator type?
@@ -835,6 +837,17 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
                 break;
             }
 
+            case PgExpressionType.DictionaryValueForKey:
+            case PgExpressionType.DictionarySubtract:
+            case PgExpressionType.DictionaryConcat:
+            {
+                return new PgBinaryExpression(
+                    operatorType,
+                    ApplyDefaultTypeMapping(left),
+                    ApplyDefaultTypeMapping(right),
+                    typeMapping!.ClrType,
+                    typeMapping);
+            }
             default:
                 throw new InvalidOperationException(
                     $"Incorrect {nameof(operatorType)} for {nameof(pgBinaryExpression)}: {operatorType}");

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
@@ -5,7 +5,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
 
 /// <summary>
 ///     The type mapping for the PostgreSQL hstore type. Supports both <see cref="Dictionary{TKey,TValue} " />
-///     and <see cref="ImmutableDictionary{TKey,TValue}" /> over strings.
+///     and <see cref="ImmutableDictionary{TKey,TValue}" /> where TKey and TValue are both strings.
 /// </summary>
 /// <remarks>
 ///     See: https://www.postgresql.org/docs/current/static/hstore.html

--- a/test/EFCore.PG.FunctionalTests/Query/DictionaryQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/DictionaryQueryTest.cs
@@ -1,0 +1,1069 @@
+using System.Collections.Immutable;
+// ReSharper disable ConvertToConstant.Local
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class DictionaryEntity
+{
+    public int Id { get; set; }
+
+    public Dictionary<string, string> Dictionary { get; set; } = null!;
+
+    public ImmutableDictionary<string, string> ImmutableDictionary { get; set; } = null!;
+    public Dictionary<string, string> JsonDictionary { get; set; } = null!;
+    public ImmutableDictionary<string, string> JsonbDictionary { get; set; } = null!;
+    public Dictionary<string, int> IntDictionary { get; set; } = null!;
+    public Dictionary<string, Dictionary<string, string>> NestedDictionary { get; set; } = null!;
+
+}
+
+public class DictionaryQueryContext(DbContextOptions options) : PoolableDbContext(options)
+{
+    public DbSet<DictionaryEntity> SomeEntities { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var entity = modelBuilder.Entity<DictionaryEntity>();
+        entity.Property(_ => _.JsonDictionary).HasColumnType("json").IsRequired();
+        entity.Property(_ => _.JsonbDictionary).HasColumnType("jsonb").IsRequired();
+        entity.Property(_ => _.IntDictionary).HasColumnType("jsonb").IsRequired();
+        entity.Property(_ => _.NestedDictionary).HasColumnType("jsonb").IsRequired();
+    }
+
+    public static async Task SeedAsync(DictionaryQueryContext context)
+    {
+        var arrayEntities = DictionaryQueryData.CreateDictionaryEntities();
+
+        context.SomeEntities.AddRange(arrayEntities);
+        await context.SaveChangesAsync();
+    }
+}
+
+public class DictionaryQueryData : ISetSource
+{
+    public IReadOnlyList<DictionaryEntity> DictionaryEntities { get; } = CreateDictionaryEntities();
+
+    public IQueryable<TEntity> Set<TEntity>()
+        where TEntity : class
+    {
+        if (typeof(TEntity) == typeof(DictionaryEntity))
+        {
+            return (IQueryable<TEntity>)DictionaryEntities.AsQueryable();
+        }
+
+        throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
+    }
+
+    public static IReadOnlyList<DictionaryEntity> CreateDictionaryEntities()
+        =>
+        [
+            new()
+            {
+                Id = 1,
+                Dictionary = new() { ["key"] = "value" },
+                ImmutableDictionary = new Dictionary<string, string> { ["key2"] = "value2" }.ToImmutableDictionary(),
+                JsonDictionary = new() { ["jkey"] = "value" },
+                JsonbDictionary = new Dictionary<string, string> { ["jkey2"] = "value" }.ToImmutableDictionary(),
+                IntDictionary = new() { ["ikey"] = 1},
+                NestedDictionary = new() { ["key"] = new() { ["nested"] = "value"}}
+            },
+            new()
+            {
+                Id = 2,
+                Dictionary = new() { ["key"] = "value" },
+                ImmutableDictionary = new Dictionary<string, string> { ["key3"] = "value3" }.ToImmutableDictionary(),
+                JsonDictionary = new() { ["jkey"] = "value" },
+                JsonbDictionary = new Dictionary<string, string> { ["jkey2"] = "value2" }.ToImmutableDictionary(),
+                IntDictionary = new() { ["ikey"] = 2},
+                NestedDictionary = new() { ["key"] = new() { ["nested2"] = "value2"}}
+            }
+        ];
+}
+
+public class DictionaryQueryFixture : SharedStoreFixtureBase<DictionaryQueryContext>, IQueryFixtureBase, ITestSqlLoggerFactory
+{
+    static DictionaryQueryFixture()
+    {
+        // TODO: Switch to using NpgsqlDataSource
+#pragma warning disable CS0618 // Type or member is obsolete
+        NpgsqlConnection.GlobalTypeMapper.EnableDynamicJson();
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+
+    protected override string StoreName
+        => "HstoreQueryTest";
+
+    protected override ITestStoreFactory TestStoreFactory
+        => NpgsqlTestStoreFactory.Instance;
+
+    public TestSqlLoggerFactory TestSqlLoggerFactory
+        => (TestSqlLoggerFactory)ListLoggerFactory;
+
+    private DictionaryQueryData _expectedData = null!;
+
+    public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        => base.AddOptions(builder).ConfigureWarnings(wcb => wcb.Ignore(CoreEventId.CollectionWithoutComparer));
+
+    protected override Task SeedAsync(DictionaryQueryContext context)
+        => DictionaryQueryContext.SeedAsync(context);
+
+    public Func<DbContext> GetContextCreator()
+        => CreateContext;
+
+    public ISetSource GetExpectedData()
+        => _expectedData ??= new DictionaryQueryData();
+
+    public IReadOnlyDictionary<Type, object> EntitySorters
+        => new Dictionary<Type, Func<object, object>>
+        {
+            { typeof(DictionaryEntity), e => ((DictionaryEntity)e)?.Id! }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+
+    public IReadOnlyDictionary<Type, object> EntityAsserters
+        => new Dictionary<Type, Action<object, object>>
+        {
+            {
+                typeof(DictionaryEntity), (e, a) =>
+                {
+                    Assert.Equal(e is null, a is null);
+                    if (a is not null)
+                    {
+                        var ee = (DictionaryEntity)e!;
+                        var aa = (DictionaryEntity)a;
+
+                        Assert.Equal(ee.Id, aa.Id);
+                        Assert.Equal(ee.Dictionary, ee.Dictionary);
+                        Assert.Equal(ee.ImmutableDictionary, ee.ImmutableDictionary);
+                        Assert.Equal(ee.JsonDictionary, ee.JsonDictionary);
+                        Assert.Equal(ee.JsonbDictionary, ee.JsonbDictionary);
+                        Assert.Equal(ee.IntDictionary, ee.IntDictionary);
+                        Assert.Equal(ee.NestedDictionary, ee.NestedDictionary);
+                    }
+                }
+            }
+        }.ToDictionary(e => e.Key, e => (object)e.Value);
+}
+
+public class DictionaryQueryTest : QueryTestBase<DictionaryQueryFixture>
+{
+    public DictionaryQueryTest(DictionaryQueryFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture)
+    {
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_ContainsKey(bool async)
+    {
+        var keyToTest = "key";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.Dictionary.ContainsKey(keyToTest)));
+        AssertSql("""
+@keyToTest='key'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."Dictionary" ? @keyToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_ContainsKey(bool async)
+    {
+        var keyToTest = "jkey2";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.JsonbDictionary.ContainsKey(keyToTest)));
+        AssertSql("""
+@keyToTest='jkey2'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."JsonbDictionary" ? @keyToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_ContainsKey(bool async)
+    {
+        var keyToTest = "key3";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.ImmutableDictionary.ContainsKey(keyToTest)));
+        AssertSql(
+            """
+@keyToTest='key3'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."ImmutableDictionary" ? @keyToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_ContainsValue(bool async)
+    {
+        var valueToTest = "value";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.Dictionary.ContainsValue(valueToTest)));
+        AssertSql(
+            """
+@valueToTest='value'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE @valueToTest = ANY (avals(s."Dictionary"))
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_ContainsValue(bool async)
+    {
+        var valueToTest = "value2";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.ImmutableDictionary.ContainsValue(valueToTest)));
+        AssertSql(
+            """
+@valueToTest='value2'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE @valueToTest = ANY (avals(s."ImmutableDictionary"))
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Keys_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Keys.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT akeys(s."Dictionary")
+FROM "SomeEntities" AS s
+""");
+    }
+
+    // Note: There is no "Dictionary_Keys" or "Dictionary_Values" tests as they return a Dictionary<string,string>.KeyCollection and Dictionary<string,string>.ValueCollection
+    // which cannot be translated from a `List<string>` which is what the `avals` and `akeys` functions returns. ImmutableDictionary<string,string>.Keys and ImmutableDictionary<string,string>.Values
+    // does have tests as they return an `IEnumerable<string>` that `List<string>` is compatible with
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Keys(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Keys), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT akeys(s."ImmutableDictionary")
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Keys(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.Keys), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT array((
+    SELECT jsonb_object_keys(s."JsonbDictionary")))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_Keys_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonDictionary.Keys.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT array((
+    SELECT json_object_keys(s."JsonDictionary")))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Keys_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.Keys.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT array((
+    SELECT jsonb_object_keys(s."JsonbDictionary")))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Keys_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Keys.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT akeys(s."ImmutableDictionary")
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Values_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Values.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT avals(s."Dictionary")
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Values(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Values), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT avals(s."ImmutableDictionary")
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Values_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Values.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT avals(s."ImmutableDictionary")
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_Values_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonDictionary.Values.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT (
+    SELECT array_agg(j.value)
+    FROM json_each_text(s."JsonDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Values_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.Values.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT (
+    SELECT array_agg(j.value)
+    FROM jsonb_each_text(s."JsonbDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task IntDictionary_Values_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss =>
+                ss.Set<DictionaryEntity>().Select(s => s.IntDictionary.Values.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT (
+    SELECT array_agg(j.value::int)
+    FROM jsonb_each(s."IntDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task NestedDictionary_Values_ToList(bool async)
+    {
+        await AssertQuery(
+            async, ss =>
+                ss.Set<DictionaryEntity>().Select(s => s.NestedDictionary.Values.ToList()), elementAsserter: Assert.Equal,
+            assertOrder: true);
+        AssertSql(
+            """
+SELECT (
+    SELECT array_agg(j.value)
+    FROM jsonb_each(s."NestedDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Item_equals(bool async)
+    {
+        var keyToTest = "key";
+        var valueToTest = "value";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.Dictionary[keyToTest] == valueToTest));
+        AssertSql(
+            """
+@valueToTest='value'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."Dictionary" -> 'key' = @valueToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Item_equals(bool async)
+    {
+        var keyToTest = "key2";
+        var valueToTest = "value2";
+        await AssertQuery(async, ss =>
+                ss.Set<DictionaryEntity>().Where(s => s.ImmutableDictionary[keyToTest] == valueToTest),
+            ss => ss.Set<DictionaryEntity>().Where(s =>
+                s.ImmutableDictionary.ContainsKey(keyToTest) && s.ImmutableDictionary[keyToTest] == valueToTest));
+        AssertSql(
+            """
+@keyToTest='key2'
+@valueToTest='value2'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."ImmutableDictionary" -> @keyToTest = @valueToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_Item_equals(bool async)
+    {
+        var keyToTest = "jkey";
+        var valueToTest = "value";
+        await AssertQuery(async, ss =>
+            ss.Set<DictionaryEntity>().Where(s => s.JsonDictionary[keyToTest] == valueToTest));
+        AssertSql(
+            """
+@valueToTest='value'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."JsonDictionary" ->> 'jkey' = @valueToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Item_equals(bool async)
+    {
+        var keyToTest = "jkey2";
+        var valueToTest = "value2";
+        await AssertQuery(async, ss =>
+            ss.Set<DictionaryEntity>().Where(s => s.JsonbDictionary[keyToTest] == valueToTest));
+        AssertSql(
+            """
+@keyToTest='jkey2'
+@valueToTest='value2'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."JsonbDictionary" ->> @keyToTest = @valueToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task IntDictionary_Item_equals(bool async)
+    {
+        var keyToTest = "ikey";
+        var valueToTest = 1;
+        await AssertQuery(async, ss =>
+            ss.Set<DictionaryEntity>().Where(s => s.IntDictionary[keyToTest] == valueToTest));
+        AssertSql(
+            """
+@valueToTest='1' (DbType = Object)
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."IntDictionary" -> 'ikey' = @valueToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task NestedDictionary_Item_equals(bool async)
+    {
+        var keyToTest = "key";
+        var key2ToTest = "nested";
+        var valueToTest = "value";
+        await AssertQuery(
+            async, ss =>
+                ss.Set<DictionaryEntity>().Where(s => s.NestedDictionary[keyToTest][key2ToTest] == valueToTest),
+            ss => ss.Set<DictionaryEntity>().Where(
+                s => s.NestedDictionary.ContainsKey(keyToTest)
+                    && s.NestedDictionary[keyToTest].ContainsKey(key2ToTest)
+                    && s.NestedDictionary[keyToTest][key2ToTest] == valueToTest));
+        AssertSql(
+            """
+@valueToTest='value'
+
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."NestedDictionary" -> 'key' ->> 'nested' = @valueToTest
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Where_Count(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.Dictionary.Count >= 1));
+        AssertSql(
+            """
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE cardinality(akeys(s."Dictionary")) >= 1
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Select_Count(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Count));
+        AssertSql(
+            """
+SELECT cardinality(akeys(s."Dictionary"))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Where_Count(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.ImmutableDictionary.Count >= 1));
+        AssertSql(
+            """
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE cardinality(akeys(s."ImmutableDictionary")) >= 1
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Select_Count(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Count));
+        AssertSql(
+            """
+SELECT cardinality(akeys(s."ImmutableDictionary"))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Enumerable_KeyValuePair_Count(bool async)
+    {
+        await AssertQuery(
+            // ReSharper disable once UseCollectionCountProperty
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Count()));
+        AssertSql(
+            """
+SELECT cardinality(akeys(s."Dictionary"))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Where_IsEmpty(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => !s.ImmutableDictionary.IsEmpty));
+        AssertSql(
+            """
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE cardinality(akeys(s."ImmutableDictionary")) <> 0
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Where_IsEmpty(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => !s.JsonbDictionary.IsEmpty));
+        AssertSql(
+            """
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE s."JsonbDictionary" <> '{}'
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Remove(bool async)
+    {
+        var key = "key";
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Remove(key)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+@key='key'
+
+SELECT s."ImmutableDictionary" - @key
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Where_Any(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.Dictionary.Any()));
+        AssertSql(
+            """
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE cardinality(akeys(s."Dictionary")) <> 0
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Where_Any(bool async)
+    {
+        await AssertQuery(async, ss => ss.Set<DictionaryEntity>().Where(s => s.ImmutableDictionary.Any()));
+        AssertSql(
+            """
+SELECT s."Id", s."Dictionary", s."ImmutableDictionary", s."IntDictionary", s."JsonDictionary", s."JsonbDictionary", s."NestedDictionary"
+FROM "SomeEntities" AS s
+WHERE cardinality(akeys(s."ImmutableDictionary")) <> 0
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_ToDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.ToDictionary()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."Dictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_ToDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonDictionary.ToDictionary()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_ToImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonDictionary.ToImmutableDictionary()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_ToDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.ToDictionary()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonbDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_ToImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+#pragma warning disable CA2009
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.ToImmutableDictionary()),
+#pragma warning restore CA2009
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonbDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_ToImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+#pragma warning disable CA2009
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.ToImmutableDictionary()),
+#pragma warning restore CA2009
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."ImmutableDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_ToImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.ToImmutableDictionary()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."Dictionary"::hstore
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_ToDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.ToDictionary()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."ImmutableDictionary"::hstore
+FROM "SomeEntities" AS s
+""");
+
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Concat_Dictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Concat(s.Dictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."ImmutableDictionary" || s."Dictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Concat_ImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Concat(s.ImmutableDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."Dictionary" || s."ImmutableDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Concat_ImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.Concat(s.ImmutableDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT (
+    SELECT hstore(array_agg(j.key), array_agg(j.value))
+    FROM jsonb_each_text(s."JsonbDictionary") AS j) || s."ImmutableDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonbDictionary_Concat_JsonbDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.Concat(s.JsonbDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonbDictionary" || s."JsonbDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_Concat_JsonbDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonDictionary.Concat(s.JsonbDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonDictionary"::jsonb || s."JsonbDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task JsonDictionary_Concat_JsonDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.JsonDictionary.Concat(s.JsonDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."JsonDictionary"::jsonb || s."JsonDictionary"::jsonb
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Concat_JsonbDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Concat(s.JsonbDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."Dictionary" || (
+    SELECT hstore(array_agg(j.key), array_agg(j.value))
+    FROM jsonb_each_text(s."JsonbDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Concat_JsonDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Concat(s.JsonDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."Dictionary" || (
+    SELECT hstore(array_agg(j.key), array_agg(j.value))
+    FROM json_each_text(s."JsonDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Keys_Concat_ImmutableDictionary_Keys(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Keys.Concat(s.ImmutableDictionary.Keys)),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT array_cat(akeys(s."Dictionary"), akeys(s."ImmutableDictionary"))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Values_Concat_Dictionary_Values(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Values.Concat(s.Dictionary.Values)),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+SELECT array_cat(avals(s."ImmutableDictionary"), avals(s."Dictionary"))
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task ImmutableDictionary_Except_Dictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.ImmutableDictionary.Except(s.Dictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."ImmutableDictionary" - s."Dictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Dictionary_Except_ImmutableDictionary(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => s.Dictionary.Except(s.ImmutableDictionary)),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT s."Dictionary" - s."ImmutableDictionary"
+FROM "SomeEntities" AS s
+""");
+    }
+
+    // [Theory]
+    // [MemberData(nameof(IsAsyncData))]
+    public async Task Extensions_ValuesForKeys(bool async)
+    {
+        string[] keys = ["key"];
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => keys.Select(key => s.Dictionary[key])),
+            ss => ss.Set<DictionaryEntity>().Select(s
+                => s.Dictionary.Where(d => keys.Contains(d.Key)).Select(d => d.Value).ToList()),
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+@__keys_1={ 'key' } (DbType = Object)
+
+SELECT s."Dictionary" -> @__keys_1
+FROM "SomeEntities" AS s
+""");
+    }
+
+    // [Theory]
+    // [MemberData(nameof(IsAsyncData))]
+    public async Task Extensions_ValuesForKeys_JsonDictionary(bool async)
+    {
+        string[] keys = ["key"];
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => keys.Select(key => s.JsonDictionary[key])),
+            ss => ss.Set<DictionaryEntity>().Select(
+                s
+                    // ReSharper disable once CanSimplifyDictionaryLookupWithTryGetValue
+#pragma warning disable CA1854
+                    => keys.Select(key => s.JsonDictionary.ContainsKey(key) ? s.JsonDictionary[key] : null)),
+#pragma warning restore CA1854
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+@__keys_1={ 'key' } (DbType = Object)
+
+SELECT (
+    SELECT hstore(array_agg(j.key), array_agg(j.value))
+    FROM json_each_text(s."JsonDictionary") AS j) -> @__keys_1
+FROM "SomeEntities" AS s
+""");
+    }
+
+    // [Theory]
+    // [MemberData(nameof(IsAsyncData))]
+    public async Task Extensions_ValuesForKeys_JsonbDictionary(bool async)
+    {
+        string[] keys = ["key"];
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => keys.Select(key => s.JsonbDictionary[key])),
+            ss => ss.Set<DictionaryEntity>().Select(
+                s
+                    // ReSharper disable once CanSimplifyDictionaryLookupWithTryGetValue
+#pragma warning disable CA1854
+                    => keys.Select(key => s.JsonbDictionary.ContainsKey(key) ? s.JsonbDictionary[key] : null)),
+#pragma warning restore CA1854
+            elementAsserter: Assert.Equal, assertOrder: true);
+        AssertSql(
+            """
+@__keys_1={ 'key' } (DbType = Object)
+
+SELECT (
+    SELECT hstore(array_agg(j.key), array_agg(j.value))
+    FROM jsonb_each_text(s."JsonbDictionary") AS j) -> @__keys_1
+FROM "SomeEntities" AS s
+""");
+    }
+
+    [Theory]
+    [MemberData(nameof(IsAsyncData))]
+    public async Task Extensions_ToHstore(bool async)
+    {
+        await AssertQuery(
+            async, ss => ss.Set<DictionaryEntity>().Select(s => EF.Functions.ToHstore(s.JsonbDictionary)),
+            ss => ss.Set<DictionaryEntity>().Select(s => s.JsonbDictionary.ToDictionary()),
+            elementAsserter: AssertEqualsIgnoringOrder, assertOrder: true);
+        AssertSql(
+            """
+SELECT (
+    SELECT hstore(array_agg(j.key), array_agg(j.value))
+    FROM jsonb_each_text(s."JsonbDictionary") AS j)
+FROM "SomeEntities" AS s
+""");
+    }
+
+    // ReSharper disable twice PossibleMultipleEnumeration
+    private static void AssertEqualsIgnoringOrder<T>(IEnumerable<T> left, IEnumerable<T> right)
+    {
+        Console.WriteLine(left);
+        Console.WriteLine(right);
+        Assert.Empty(left.Except(right));
+        Assert.Empty(right.Except(left));
+    }
+
+    protected void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+}


### PR DESCRIPTION
This PR adds support for querying on `hstore` type columns which can map to either `Dictionary<string, string>` or `ImmutableDictionary<string, string>` in C# and for querying any other `Dictionary<,>` or `ImmutableDictionary<,>` for `json` and `jsonb` types.

See https://github.com/npgsql/doc/pull/369 for full documentation.

Fixes #212