### PR TITLE
Make sure that when using PadLeft/PadRight we don't truncate if given length is less than the string length

### DIFF
--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlStringMethodTranslator.cs
@@ -326,13 +326,15 @@ public class NpgsqlStringMethodTranslator : IMethodCallTranslator
                     ? [instance!, arguments[0]]
                     : new[] { instance!, arguments[0], arguments[1] };
 
-            return _sqlExpressionFactory.Function(
+            var padFunc = _sqlExpressionFactory.Function(
                 method == PadLeft || method == PadLeftWithChar ? "lpad" : "rpad",
                 args,
                 nullable: true,
                 argumentsPropagateNullability: TrueArrays[args.Length],
                 instance!.Type,
                 instance.TypeMapping);
+            var lengthFunc = _sqlExpressionFactory.Function("length", [instance], true, [true], typeof(int));
+            return _sqlExpressionFactory.Case([new CaseWhenClause(_sqlExpressionFactory.MakeBinary(ExpressionType.GreaterThanOrEqual, lengthFunc, arguments[0], null)!, instance)], padFunc);
         }
 
         if (method.DeclaringType == typeof(string)

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindFunctionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindFunctionsQueryNpgsqlTest.cs
@@ -300,6 +300,17 @@ ORDER BY {UuidGenerationFunction}() NULLS FIRST
 
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
+    public Task PadLeft_with_parameter_does_not_truncate(bool async)
+    {
+        var length = 5;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(x => x.Address.PadLeft(length).EndsWith("Walserweg 21")));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
     public Task PadLeft_char_with_parameter(bool async)
     {
         var length = 20;
@@ -328,6 +339,17 @@ ORDER BY {UuidGenerationFunction}() NULLS FIRST
     public Task PadRight_with_parameter(bool async)
     {
         var length = 20;
+
+        return AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Where(x => x.Address.PadRight(length).StartsWith("Walserweg 21")));
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(IsAsyncData))]
+    public Task PadRight_with_parameter_does_not_truncate(bool async)
+    {
+        var length = 5;
 
         return AssertQuery(
             async,


### PR DESCRIPTION
From #3116 the lpad/rpad in npgsql truncate the string if the length given is less than the string length. This is different to .Net where it doesn't truncate

This fixes the SQL so that it matches the .Net expectation

Closes #3116