### PR TITLE
Fix: Resolve ambiguity in TryGetElementType() for Mono runtime (#3395)

### DIFF
--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -215,23 +215,27 @@ internal static class SharedTypeExtensions
             return null;
         }
 
-        var types = GetGenericTypeImplementations(type, interfaceOrBaseType);
+	    var types = GetGenericTypeImplementations(type, interfaceOrBaseType);
 
-        Type? singleImplementation = null;
-        foreach (var implementation in types)
-        {
-            if (singleImplementation is null)
-            {
-                singleImplementation = implementation;
-            }
-            else
-            {
-                singleImplementation = null;
-                break;
-            }
-        }
+	    if (!types.Any())
+    	{	
+            return null;
+    	}
 
-        return singleImplementation?.GenericTypeArguments.FirstOrDefault();
+    	if (type.IsArray)
+    	{
+            var elementType = type.GetElementType();
+            if (elementType != null)
+            {
+                var arrayCompatible = types.FirstOrDefault(t => t.GenericTypeArguments.Contains(elementType));
+                if (arrayCompatible != null)
+                {
+                    return arrayCompatible.GenericTypeArguments.First();
+                }
+            }
+    	}
+
+    	return types.First().GenericTypeArguments.FirstOrDefault();
     }
 
 #nullable disable


### PR DESCRIPTION
### Summary

Fixes #3395

This PR addresses a discrepancy in the Mono runtime that adds extra generic interfaces, such as `IEnumerable<int>`, for arrays and collections. This behavior causes failures in the EFCore.PG test suite, particularly in the `TryGetElementType()` logic used for interface resolution.


@uweigand @giritrivedi @saitama951