### PR TITLE
Create collation "if not exists"

### DIFF
--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -1176,7 +1176,7 @@ public class NpgsqlMigrationsSqlGenerator : MigrationsSqlGenerator
         }
 
         builder
-            .Append("CREATE COLLATION ")
+            .Append("CREATE COLLATION IF NOT EXISTS ")
             .Append(DelimitIdentifier(collation.Name, schema))
             .Append(" (")
             .IncrementIndent();


### PR DESCRIPTION
For reasons, I am creating a collation in the public schema for case insensitivity. This keeps getting in the way when my modular monolith on single database instance grows, with multiple DbContexts with their own migrations pointing to the same database, and all of these contexts needs to ensure the collation exists, so they all have a `modelBuilder.HasCollation("public", "case_insensitive", "und-u-icu-ka-shifted-ks-level2", "icu", false);` statement. This crashes frequently when I do bigger migrations or move things about. So for pure ego reasons I propose this change to allow the multiple collation annotations go through without exceptions.