### PR TITLE
Always close connection after reloading types in migration.

### DIFF
--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrator.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrator.cs
@@ -85,7 +85,7 @@ public class NpgsqlMigrator : Migrator
             {
                 npgsqlConnection.ReloadTypes();
             }
-            catch
+            finally
             {
                 _connection.Close();
             }
@@ -128,7 +128,7 @@ public class NpgsqlMigrator : Migrator
             {
                 await npgsqlConnection.ReloadTypesAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch
+            finally
             {
                 await _connection.CloseAsync().ConfigureAwait(false);
             }


### PR DESCRIPTION
Closes #3464

Branch is derived from hotix/9.0.4

If not wanted there, it could probably be cherry picked elsewhere.