### PR TITLE
Preserve ConfigureDataSource() callback when applying other context options

### DIFF
--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -109,6 +109,7 @@ public class NpgsqlOptionsExtension : RelationalOptionsExtension
         : base(copyFrom)
     {
         DataSource = copyFrom.DataSource;
+        DataSourceBuilderAction = copyFrom.DataSourceBuilderAction;
         AdminDatabase = copyFrom.AdminDatabase;
         _postgresVersion = copyFrom._postgresVersion;
         UseRedshift = copyFrom.UseRedshift;


### PR DESCRIPTION
Fixes #3478