### PR TITLE
Improve error message when duplicate enum definitions are registered.

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlTypeMappingSource.cs
@@ -785,7 +785,14 @@ public class NpgsqlTypeMappingSource : RelationalTypeMappingSource
         EnumDefinition? enumDefinition;
         if (storeType is null)
         {
-            enumDefinition = _enumDefinitions.SingleOrDefault(m => m.ClrType == clrType);
+            var matches = _enumDefinitions.Where(m => m.ClrType == clrType).ToList();
+            if (matches.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Multiple enum definitions registered for CLR type '{clrType?.FullName}'. ");
+            }
+
+            enumDefinition = matches.FirstOrDefault();
 
             if (enumDefinition is null)
             {


### PR DESCRIPTION
### Context  

While running tests, I encountered an issue where `DbContext` creation failed with the error:  
*"Sequence contains more than one matching element."*  
This made it difficult to identify the root cause of the exception.  

### Changes  
- Improved error handling to detect duplicate enum registrations.  
- Updated exception message for better debugging.  

### Impact  
This change helps developers quickly identify and resolve enum registration issues in the future.  

### Notes  
If any changes are needed, I’m happy to make adjustments.  