### PR TITLE
Add support for ENCODING during database creation

### DIFF
--- a/src/EFCore.PG/Design/Internal/NpgsqlCSharpRuntimeAnnotationCodeGenerator.cs
+++ b/src/EFCore.PG/Design/Internal/NpgsqlCSharpRuntimeAnnotationCodeGenerator.cs
@@ -205,6 +205,7 @@ public class NpgsqlCSharpRuntimeAnnotationCodeGenerator
             annotations.Remove(NpgsqlAnnotationNames.DatabaseTemplate);
             annotations.Remove(NpgsqlAnnotationNames.Tablespace);
             annotations.Remove(NpgsqlAnnotationNames.CollationDefinitionPrefix);
+            annotations.Remove(NpgsqlAnnotationNames.Encoding);
 
 #pragma warning disable CS0618
             annotations.Remove(NpgsqlAnnotationNames.DefaultColumnCollation);
@@ -232,6 +233,7 @@ public class NpgsqlCSharpRuntimeAnnotationCodeGenerator
             annotations.Remove(NpgsqlAnnotationNames.DatabaseTemplate);
             annotations.Remove(NpgsqlAnnotationNames.Tablespace);
             annotations.Remove(NpgsqlAnnotationNames.CollationDefinitionPrefix);
+            annotations.Remove(NpgsqlAnnotationNames.Encoding);
 
 #pragma warning disable CS0618
             annotations.Remove(NpgsqlAnnotationNames.DefaultColumnCollation);

--- a/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlModelBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlModelBuilderExtensions.cs
@@ -653,6 +653,20 @@ public static class NpgsqlModelBuilderExtensions
 
     #endregion
 
+    #region Encoding
+    /// <summary>
+    ///     Specifies the encoding to use when creating a new database for this model.
+    /// </summary>
+    public static ModelBuilder UseDatabaseEncoding(this ModelBuilder modelBuilder, string encoding)
+    {
+        Check.NotNull(modelBuilder, nameof(modelBuilder));
+        Check.NotEmpty(encoding, nameof(encoding));
+
+        modelBuilder.Model.SetDatabaseEncoding(encoding);
+        return modelBuilder;
+    }
+    #endregion
+
     #region Collation management
 
     /// <summary>

--- a/src/EFCore.PG/Extensions/MetadataExtensions/NpgsqlModelExtensions.cs
+++ b/src/EFCore.PG/Extensions/MetadataExtensions/NpgsqlModelExtensions.cs
@@ -516,4 +516,24 @@ public static class NpgsqlModelExtensions
         => PostgresCollation.GetCollations(model).ToArray();
 
     #endregion Collation management
+
+    #region Encoding
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static string? GetEncoding(this IReadOnlyModel model)
+        => (string?)model[NpgsqlAnnotationNames.Encoding];
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public static void SetDatabaseEncoding(this IMutableModel model, string? encoding)
+        => model.SetOrRemoveAnnotation(NpgsqlAnnotationNames.Encoding, encoding);
+    #endregion
 }

--- a/src/EFCore.PG/Metadata/Conventions/NpgsqlRuntimeModelConvention.cs
+++ b/src/EFCore.PG/Metadata/Conventions/NpgsqlRuntimeModelConvention.cs
@@ -33,6 +33,7 @@ public class NpgsqlRuntimeModelConvention : RelationalRuntimeModelConvention
             annotations.Remove(NpgsqlAnnotationNames.DatabaseTemplate);
             annotations.Remove(NpgsqlAnnotationNames.Tablespace);
             annotations.Remove(NpgsqlAnnotationNames.CollationDefinitionPrefix);
+            annotations.Remove(NpgsqlAnnotationNames.Encoding);
 
 #pragma warning disable CS0618
             annotations.Remove(NpgsqlAnnotationNames.DefaultColumnCollation);

--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationNames.cs
@@ -46,6 +46,14 @@ public static class NpgsqlAnnotationNames
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
+    public const string Encoding = Prefix + "Encoding";
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
     public const string HiLoSequenceName = Prefix + "HiLoSequenceName";
 
     /// <summary>

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -1044,6 +1044,14 @@ public class NpgsqlMigrationsSqlGenerator : MigrationsSqlGenerator
                 .Append(DelimitIdentifier(operation.Collation));
         }
 
+        if (!string.IsNullOrEmpty(operation.Encoding))
+        {
+            builder
+                .AppendLine()
+                .Append("ENCODING ")
+                .Append(DelimitIdentifier(operation.Encoding));
+        }
+
         builder.AppendLine(";");
 
         EndStatement(builder, suppressTransaction: true);

--- a/src/EFCore.PG/Migrations/Operations/NpgsqlCreateDatabaseOperation.cs
+++ b/src/EFCore.PG/Migrations/Operations/NpgsqlCreateDatabaseOperation.cs
@@ -23,4 +23,9 @@ public class NpgsqlCreateDatabaseOperation : DatabaseOperation
     ///     The PostgreSQL tablespace in which to create the database.
     /// </summary>
     public virtual string? Tablespace { get; set; }
+
+    /// <summary>
+    ///     The PostgreSQL encoding to use for the database.
+    /// </summary>
+    public virtual string? Encoding { get; set; }
 }

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -162,7 +162,8 @@ WHERE
                     Name = connection.DbConnection.Database,
                     Template = designTimeModel.GetDatabaseTemplate(),
                     Collation = designTimeModel.GetCollation(),
-                    Tablespace = designTimeModel.GetTablespace()
+                    Tablespace = designTimeModel.GetTablespace(),
+                    Encoding = designTimeModel.GetEncoding(),
                 }
         ]);
     }

--- a/test/EFCore.PG.FunctionalTests/Migrations/NpgsqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/NpgsqlMigrationsSqlGeneratorTest.cs
@@ -68,6 +68,19 @@ TABLESPACE "MyTablespace";
 """);
     }
 
+    [Fact]
+    public virtual void CreateDatabaseOperation_with_encoding()
+    {
+        Generate(new NpgsqlCreateDatabaseOperation { Name = "Northwind", Encoding = "UTF8" });
+
+        AssertSql(
+            """
+CREATE DATABASE "Northwind"
+ENCODING "UTF8";
+
+""");
+    }
+
     #endregion
 
     public override void AddColumnOperation_without_column_type()


### PR DESCRIPTION
I have added support for ENCODING during database creation [like described in the documentation](https://www.postgresql.org/docs/current/sql-createdatabase.html). It follows the same approach like TEMPLATE and can be used the same way.

I have also added a test case, but maybe I have missed some other tests. Please point me to the correct location and I can add them. 

This PR is related to issue #3526 

If any changes are needed, I’m happy to make adjustments.