### PR TITLE
Reload types should close the newly opened connection.

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -396,7 +396,7 @@ WHERE
             {
                 await npgsqlConnection.ReloadTypesAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch
+            finally
             {
                 await npgsqlConnection.CloseAsync().ConfigureAwait(false);
             }

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -354,7 +354,7 @@ WHERE
             {
                 npgsqlConnection.ReloadTypes();
             }
-            catch
+            finally
             {
                 npgsqlConnection.Close();
             }


### PR DESCRIPTION
Always close connection after types was reloaded.

Fixes #3560