### PR TITLE
Use NpgsqlConnection when checking if database exists.

### DIFF
--- a/src/EFCore.PG/Storage/Internal/INpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/INpgsqlRelationalConnection.cs
@@ -32,5 +32,5 @@ public interface INpgsqlRelationalConnection : IRelationalConnection
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    ValueTask<INpgsqlRelationalConnection> CloneWith(string connectionString, bool async, CancellationToken cancellationToken = default);
+    ValueTask<NpgsqlConnection> CloneWith(string connectionString, bool async, CancellationToken cancellationToken = default);
 }

--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -215,12 +215,12 @@ WHERE
         {
             if (async)
             {
-                await unpooledRelationalConnection.OpenAsync(errorsExpected: true, cancellationToken: cancellationToken)
+                await unpooledRelationalConnection.OpenAsync(cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
             else
             {
-                unpooledRelationalConnection.Open(errorsExpected: true);
+                unpooledRelationalConnection.Open();
             }
 
             return true;

--- a/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
@@ -232,7 +232,7 @@ public class NpgsqlRelationalConnection : RelationalConnection, INpgsqlRelationa
     ///     any release. You should only use it directly in your code with extreme caution and knowing that
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
-    public virtual async ValueTask<INpgsqlRelationalConnection> CloneWith(
+    public virtual async ValueTask<NpgsqlConnection> CloneWith(
         string connectionString,
         bool async,
         CancellationToken cancellationToken = default)
@@ -241,13 +241,6 @@ public class NpgsqlRelationalConnection : RelationalConnection, INpgsqlRelationa
             ? await DbConnection.CloneWithAsync(connectionString, cancellationToken).ConfigureAwait(false)
             : DbConnection.CloneWith(connectionString);
 
-        var relationalOptions = RelationalOptionsExtension.Extract(Dependencies.ContextOptions)
-            .WithConnectionString(null)
-            .WithConnection(clonedDbConnection);
-
-        var optionsBuilder = new DbContextOptionsBuilder();
-        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(relationalOptions);
-
-        return new NpgsqlRelationalConnection(Dependencies with { ContextOptions = optionsBuilder.Options }, dataSource: null);
+        return clonedDbConnection;
     }
 }


### PR DESCRIPTION
The NpgsqlRelationalConnection gets an implicit reference to the DbContext from the original connection (through Dependencies). That could tamper with the original DbContext's ServiceProvider when adding a connection to completly different pool. Also, the test only wants a connection to the database which NpgsqlConnection could provide. 

`CreateAdminConnection` suffers from the same problem. That together with this may be the root of the problem of #3560.