### PR TITLE
NpgsqlRelationalConnection owns newly created connection.

### DIFF
--- a/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
+++ b/src/EFCore.PG/Infrastructure/Internal/NpgsqlOptionsExtension.cs
@@ -182,6 +182,16 @@ public class NpgsqlOptionsExtension : RelationalOptionsExtension
         return clone;
     }
 
+    /// <inheritdoc />
+    public override RelationalOptionsExtension WithConnection(DbConnection? connection, bool owned)
+    {
+        var clone = (NpgsqlOptionsExtension)base.WithConnection(connection, owned);
+
+        clone.DataSource = null;
+
+        return clone;
+    }
+
     /// <summary>
     ///     Returns a copy of the current instance configured with the specified range mapping.
     /// </summary>

--- a/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlRelationalConnection.cs
@@ -205,7 +205,7 @@ public class NpgsqlRelationalConnection : RelationalConnection, INpgsqlRelationa
         var adminNpgsqlOptions = DataSource is not null
             ? npgsqlOptions.WithConnection(((NpgsqlConnection)CreateDbConnection()).CloneWith(adminConnectionString))
             : npgsqlOptions.Connection is not null
-                ? npgsqlOptions.WithConnection(DbConnection.CloneWith(adminConnectionString))
+                ? npgsqlOptions.WithConnection(DbConnection.CloneWith(adminConnectionString), owned: true)
                 : npgsqlOptions.WithConnectionString(adminConnectionString);
 
         var optionsBuilder = new DbContextOptionsBuilder();
@@ -243,7 +243,7 @@ public class NpgsqlRelationalConnection : RelationalConnection, INpgsqlRelationa
 
         var relationalOptions = RelationalOptionsExtension.Extract(Dependencies.ContextOptions)
             .WithConnectionString(null)
-            .WithConnection(clonedDbConnection);
+            .WithConnection(clonedDbConnection, owned: true);
 
         var optionsBuilder = new DbContextOptionsBuilder();
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(relationalOptions);


### PR DESCRIPTION
Resets datasource when you decide to control the ownership of a connection. Used once in the setup UseNpgsql when you pass a connection. So no practical affect aside from enforcing no datasource.

The owned flag does not impact NpgsqlRelationalConnection CloneWith either, which seems like a bug to me in the RelationalConnection. Since the connection is opened in RelationalConnection it takes it as it should close it when Close is called. The dispose ignores it. Would make more sense to also enforce the ownership in Close and not only in Dispose, but that is not related to this repo.

This would however make it more correct since the datasource is reset and the RelationalConnection knows it has ownership of the connection when the connection is directly injected from a newly created connection which is not tracked elsewhere.