### PR TITLE
Listing partitioned tables during scaffolding

### DIFF
--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -201,7 +201,7 @@ FROM pg_class AS cls
 JOIN pg_namespace AS ns ON ns.oid = cls.relnamespace
 LEFT OUTER JOIN pg_description AS des ON des.objoid = cls.oid AND des.objsubid=0
 WHERE
-  cls.relkind IN ('r', 'v', 'm', 'f') AND
+  cls.relkind IN ('r', 'v', 'm', 'f', 'p') AND
   ns.nspname NOT IN ({internalSchemas}) AND
   cls.relname <> '{HistoryRepository.DefaultTableName}' AND
   -- Exclude tables which are members of PG extensions
@@ -236,6 +236,7 @@ WHERE
                 {
                     'r' => new DatabaseTable(),
                     'f' => new DatabaseTable(),
+                    'p' => new DatabaseTable(),
                     'v' => new DatabaseView(),
                     'm' => new DatabaseView(),
                     _ => throw new ArgumentOutOfRangeException($"Unknown relkind '{type}' when scaffolding {DisplayName(schema, name)}")
@@ -318,7 +319,7 @@ LEFT JOIN pg_description AS des ON des.objoid = cls.oid AND des.objsubid = attnu
 LEFT JOIN pg_depend AS dep ON dep.refobjid = cls.oid AND dep.refobjsubid = attr.attnum AND dep.deptype = 'i'
 {(connection.PostgreSqlVersion >= new Version(10, 0) ? "LEFT JOIN pg_sequence AS seq ON seq.seqrelid = dep.objid" : "")}
 WHERE
-  cls.relkind IN ('r', 'v', 'm', 'f') AND
+  cls.relkind IN ('r', 'v', 'm', 'f', 'p') AND
   nspname NOT IN ({internalSchemas}) AND
   attnum > 0 AND
   cls.relname <> '{HistoryRepository.DefaultTableName}' AND

--- a/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
+++ b/src/EFCore.PG/Scaffolding/Internal/NpgsqlDatabaseModelFactory.cs
@@ -204,6 +204,8 @@ WHERE
   cls.relkind IN ('r', 'v', 'm', 'f', 'p') AND
   ns.nspname NOT IN ({internalSchemas}) AND
   cls.relname <> '{HistoryRepository.DefaultTableName}' AND
+  -- Exclude child partitions
+  cls.relispartition <> true AND
   -- Exclude tables which are members of PG extensions
   NOT EXISTS (
     SELECT 1 FROM pg_depend WHERE
@@ -323,6 +325,8 @@ WHERE
   nspname NOT IN ({internalSchemas}) AND
   attnum > 0 AND
   cls.relname <> '{HistoryRepository.DefaultTableName}' AND
+  -- Exclude child partitions
+  cls.relispartition <> true AND
   -- Exclude tables which are members of PG extensions
   NOT EXISTS (
     SELECT 1 FROM pg_depend WHERE
@@ -620,10 +624,12 @@ JOIN pg_index AS idx ON indrelid = cls.oid
 JOIN pg_class AS idxcls ON idxcls.oid = indexrelid
 JOIN pg_am AS am ON am.oid = idxcls.relam
 WHERE
-  cls.relkind = 'r' AND
+  cls.relkind IN ('r','p') AND
   nspname NOT IN ({internalSchemas}) AND
   NOT indisprimary AND
   cls.relname <> '{HistoryRepository.DefaultTableName}' AND
+  -- Exclude child partitions
+  cls.relispartition <> true AND
   -- Exclude tables which are members of PG extensions
   NOT EXISTS (
     SELECT 1 FROM pg_depend WHERE
@@ -829,10 +835,12 @@ JOIN pg_constraint as con ON con.conrelid = cls.oid
 LEFT OUTER JOIN pg_class AS frncls ON frncls.oid = con.confrelid
 LEFT OUTER JOIN pg_namespace as frnns ON frnns.oid = frncls.relnamespace
 WHERE
-  cls.relkind = 'r' AND
+  cls.relkind IN ('r','p') AND
   ns.nspname NOT IN ({internalSchemas}) AND
   con.contype IN ('p', 'f', 'u') AND
   cls.relname <> '{HistoryRepository.DefaultTableName}' AND
+  -- Exclude child partitions
+  cls.relispartition <> true AND
   -- Exclude tables which are members of PG extensions
   NOT EXISTS (
     SELECT 1 FROM pg_depend WHERE

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -2155,6 +2155,28 @@ CREATE TABLE column_types (
             },
             "DROP TABLE column_types");
 
+    [Fact]
+    public void Partition_tables()
+    => Test(
+        """
+DROP TABLE IF EXISTS test_table;
+DROP TABLE IF EXISTS foo;
+CREATE TABLE foo (some_num int UNIQUE);
+CREATE TABLE test_table (
+    partition_id smallint,
+    partition_key integer
+    ) PARTITION BY LIST (partition_key);
+""",
+        [],
+        [],
+        dbModel =>
+        {
+            Assert.Equal(2, dbModel.Tables.Count);
+            Assert.Equal(3, dbModel.Tables.SelectMany(x => x.Columns).Count());
+        },
+        "DROP TABLE test_table;DROP TABLE foo;");
+
+
     [ConditionalFact]
     [RequiresPostgis]
     public void System_tables_are_ignored()


### PR DESCRIPTION
Added support for main partitioned tables during scaffolding.
I have included the virtual table, which is partitioned, but haven't excluded the actual partitions.

Related to issue #2934.
