### PR TITLE
Rewrite NpgsqlDatabaseCreator.Exists() to do SELECT 1

### DIFF
--- a/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
+++ b/src/EFCore.PG/Storage/Internal/NpgsqlDatabaseCreator.cs
@@ -13,8 +13,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 public class NpgsqlDatabaseCreator(
         RelationalDatabaseCreatorDependencies dependencies,
         INpgsqlRelationalConnection connection,
-        IRawSqlCommandBuilder rawSqlCommandBuilder,
-        IRelationalConnectionDiagnosticsLogger connectionLogger)
+        IRawSqlCommandBuilder rawSqlCommandBuilder)
     : RelationalDatabaseCreator(dependencies)
 {
     /// <summary>
@@ -174,7 +173,41 @@ WHERE
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override bool Exists()
-        => Exists(async: false).GetAwaiter().GetResult();
+        => Dependencies.ExecutionStrategy.Execute(() =>
+        {
+            using var _ = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+            var opened = false;
+
+            try
+            {
+                connection.Open(errorsExpected: true);
+                opened = true;
+
+                rawSqlCommandBuilder
+                    .Build("SELECT 1")
+                    .ExecuteNonQuery(
+                        new RelationalCommandParameterObject(
+                            connection,
+                            parameterValues: null,
+                            readerColumns: null,
+                            Dependencies.CurrentContext.Context,
+                            Dependencies.CommandLogger,
+                            CommandSource.Migrations));
+
+                return true;
+            }
+            catch (Exception e) when (IsDoesNotExist(e))
+            {
+                return false;
+            }
+            finally
+            {
+                if (opened)
+                {
+                    connection.Close();
+                }
+            }
+        });
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
@@ -183,87 +216,61 @@ WHERE
     ///     doing so can result in application failures when updating to a new Entity Framework Core release.
     /// </summary>
     public override Task<bool> ExistsAsync(CancellationToken cancellationToken = default)
-        => Exists(async: true, cancellationToken);
-
-    private async Task<bool> Exists(bool async, CancellationToken cancellationToken = default)
-    {
-        var logger = connectionLogger;
-        var startTime = DateTimeOffset.UtcNow;
-
-        var interceptionResult = async
-            ? await logger.ConnectionOpeningAsync(connection, startTime, cancellationToken).ConfigureAwait(false)
-            : logger.ConnectionOpening(connection, startTime);
-
-        if (interceptionResult.IsSuppressed)
+        => Dependencies.ExecutionStrategy.ExecuteAsync(async ct =>
         {
-            // If the connection attempt was suppressed by an interceptor, assume that the interceptor took care of all the opening
-            // details, and the database exists.
-            return true;
-        }
+            using var _ = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+            var opened = false;
 
-        // When checking whether a database exists, pooling must be off, otherwise we may
-        // attempt to reuse a pooled connection, which may be broken (this happened in the tests).
-        // If Pooling is off, but Multiplexing is on - NpgsqlConnectionStringBuilder.Validate will throw,
-        // so we turn off Multiplexing as well.
-        var unpooledCsb = new NpgsqlConnectionStringBuilder(connection.ConnectionString) { Pooling = false, Multiplexing = false };
-
-        using var _ = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
-        var unpooledRelationalConnection =
-            await connection.CloneWith(unpooledCsb.ToString(), async, cancellationToken).ConfigureAwait(false);
-
-        try
-        {
-            if (async)
+            try
             {
-                await unpooledRelationalConnection.OpenAsync(errorsExpected: true, cancellationToken: cancellationToken)
+                await connection.OpenAsync(cancellationToken, errorsExpected: true).ConfigureAwait(false);
+                opened = true;
+
+                await rawSqlCommandBuilder
+                    .Build("SELECT 1")
+                    .ExecuteNonQueryAsync(
+                        new RelationalCommandParameterObject(
+                            connection,
+                            parameterValues: null,
+                            readerColumns: null,
+                            Dependencies.CurrentContext.Context,
+                            Dependencies.CommandLogger,
+                            CommandSource.Migrations),
+                        cancellationToken)
                     .ConfigureAwait(false);
-            }
-            else
-            {
-                unpooledRelationalConnection.Open(errorsExpected: true);
-            }
 
-            return true;
-        }
-        catch (PostgresException e)
-        {
-            if (IsDoesNotExist(e))
+                return true;
+            }
+            catch (Exception e) when (IsDoesNotExist(e))
             {
                 return false;
             }
+            finally
+            {
+                if (opened)
+                {
+                    await connection.CloseAsync().ConfigureAwait(false);
+                }
+            }
+        }, cancellationToken);
 
-            throw;
-        }
-        catch (NpgsqlException e) when (
+    private static bool IsDoesNotExist(Exception exception)
+        => exception switch
+        {
+            // Login failed is thrown when database does not exist (See Issue #776)
+            PostgresException { SqlState: "3D000" }
+                => true,
+
             // This can happen when Npgsql attempts to connect to multiple hosts
-            e.InnerException is AggregateException ae && ae.InnerExceptions.Any(ie => ie is PostgresException pe && IsDoesNotExist(pe)))
-        {
-            return false;
-        }
-        catch (NpgsqlException e) when (
-            e.InnerException is IOException { InnerException: SocketException { SocketErrorCode: SocketError.ConnectionReset } })
-        {
-            // Pretty awful hack around #104
-            return false;
-        }
-        finally
-        {
-            if (async)
-            {
-                await unpooledRelationalConnection.CloseAsync().ConfigureAwait(false);
-                await unpooledRelationalConnection.DisposeAsync().ConfigureAwait(false);
-            }
-            else
-            {
-                unpooledRelationalConnection.Close();
-                unpooledRelationalConnection.Dispose();
-            }
-        }
-    }
+            NpgsqlException { InnerException: AggregateException ae } when ae.InnerExceptions.Any(ie => ie is PostgresException { SqlState: "3D000" })
+                => true,
 
-    // Login failed is thrown when database does not exist (See Issue #776)
-    private static bool IsDoesNotExist(PostgresException exception)
-        => exception.SqlState == "3D000";
+            // Pretty awful hack around #104
+            NpgsqlException { InnerException: IOException { InnerException: SocketException { SocketErrorCode: SocketError.ConnectionReset } } }
+                => true,
+
+            _ => false
+        };
 
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to

--- a/test/EFCore.PG.FunctionalTests/NpgsqlDatabaseCreatorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/NpgsqlDatabaseCreatorTest.cs
@@ -633,9 +633,8 @@ public class NpgsqlDatabaseCreatorTest
     public class TestDatabaseCreator(
         RelationalDatabaseCreatorDependencies dependencies,
         INpgsqlRelationalConnection connection,
-        IRawSqlCommandBuilder rawSqlCommandBuilder,
-        IRelationalConnectionDiagnosticsLogger connectionLogger)
-        : NpgsqlDatabaseCreator(dependencies, connection, rawSqlCommandBuilder, connectionLogger)
+        IRawSqlCommandBuilder rawSqlCommandBuilder)
+        : NpgsqlDatabaseCreator(dependencies, connection, rawSqlCommandBuilder)
     {
         public bool HasTablesBase()
             => HasTables();


### PR DESCRIPTION
#3646 reported a memory leak: when NpgsqlDatabaseCreateor.Exists() is called (from DatabaseFacadeExtensions.CanConnect()), it was using NpgsqlConnection.CloneWith() to create a new, unpooled connection, which it then tried to connect to the database. The problem is, the cloned connection doesn't use an explicit data source, meaning that a data source is internally created inside Npgsql, referenced by the internal static dictionary. If the password continuously changes (rotating auth tokens), that led to increasing memory use which never gets freed.

This is ultimately https://github.com/npgsql/npgsql/issues/3387: we should be able to call ClearPool() on the cloned connection to have it unreference the internal data source, allowing it to get garbage collected - though in theory, a real user in the application might be using the same connection string, which EF would then cause to get cleared; while quite contrived, it shows how bad the legacy connection mechanism is.

This PR simply changes to sending `SELECT 1` to the database, which is what the SQL Server provider does as well. This does have the drawback of returning "exists" (and also "can connect") even when e.g. the password has changed (because there are pooled connections which allow executing `SELECT 1`), but that's seems like an unimportant edge case (the same pooled connections will be there for actual usage etc.). And the CloneWith() mechanism here has been the source of lots of trouble over the years, without adding much real value.

This also adds the execution strategy to Exists(), which allows retrying on transient errors.

Fixes #3646

Thanks @vonzshik for the initial investigation.