### PR TITLE
Use .NET/EF 10.0 GA

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>10.0.0-rc.2.25502.107</EFCoreVersion>
-    <MicrosoftExtensionsVersion>10.0.0-rc.2.25502.107</MicrosoftExtensionsVersion>
+    <EFCoreVersion>10.0.0</EFCoreVersion>
+    <MicrosoftExtensionsVersion>10.0.0</MicrosoftExtensionsVersion>
     <NpgsqlVersion>10.0.0-rc.2-ci.20251107T191940</NpgsqlVersion>
   </PropertyGroup>
 
@@ -10,11 +10,11 @@
       Dependencies on EF preview versions should be locked to a specific version (as provider-facing breaking changes are frequent).
       For released versions, depend on anything in the current major version to allow users to update to higher patch versions.
     -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="[$(EFCoreVersion)]" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="[$(EFCoreVersion)]" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="[$(EFCoreVersion)]" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="[$(EFCoreVersion)]" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[$(EFCoreVersion)]" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="[$(EFCoreVersion),11.0.0)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="[$(EFCoreVersion),11.0.0)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="[$(EFCoreVersion),11.0.0)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="[$(EFCoreVersion),11.0.0)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[$(EFCoreVersion),11.0.0)" />
 
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />


### PR DESCRIPTION
## Summary
- Updated EFCoreVersion from 10.0.0-rc.2.25502.107 to 10.0.0
- Updated MicrosoftExtensionsVersion from RC to 10.0.0  
- Changed EF Core package version constraints from exact version [$(EFCoreVersion)] to range [$(EFCoreVersion),11.0.0) to allow patch version updates

This resolves the dependency conflict that prevented users from upgrading to .NET 10 production releases.

## Test plan
- [x] Build succeeds with no warnings or errors
- [x] Package restore works correctly
- [x] Follows established project pattern for GA releases (same as EF 9.0 GA transition)

Fixes #3656