### PR TITLE
Filter out extension-related operations in creation scripts of history table

### DIFF
--- a/src/EFCore.PG/Migrations/Internal/NpgsqlHistoryRepository.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlHistoryRepository.cs
@@ -102,23 +102,40 @@ public class NpgsqlHistoryRepository : HistoryRepository, IHistoryRepository
     {
         // TODO: This is all a hack around https://github.com/dotnet/efcore/issues/34991: we have provider-specific conventions which add
         // enums and extensions to the model, and the default EF logic causes them to be created at this point, when the history table is
-        // being created.
+        // being created. This causes problems when:
+        // (a) we create an enum here when creating the history table, and then try to create it again when the actual migration
+        //     runs (#3324), and
+        // (b) we shouldn't be creating extensions at this early point either, and doing so can cause issues (e.g. #3496).
+        //
+        // So we filter out any extension/enum migration operations.
+        // Note that the approach in EF is to remove specific conventions (e.g. DbSetFindingConvention), but we don't want to hardcode
+        // specific conventions here; for example, the NetTopologySuite plugin has its NpgsqlNetTopologySuiteExtensionAddingConvention
+        // which adds PostGIS. So we just filter out the annotations on the operations themselves.
         var model = EnsureModel();
 
         var operations = Dependencies.ModelDiffer.GetDifferences(null, model.GetRelationalModel());
 
-        // Workaround for https://github.com/npgsql/efcore.pg/issues/3496: filter out extension-related operations.
-        // On managed PostgreSQL services (e.g. Azure Flexible Server), CREATE EXTENSION requires sometimes superuser privileges
-        // even with IF NOT EXISTS. Since extension creation isn't needed for the history table, we exclude these
-        // operations to avoid permission errors for non-superuser application accounts.
-        var operationsWithoutExtensions = operations
-            .Where(o => !o.GetAnnotations().Any(a => a.Name.StartsWith(NpgsqlAnnotationNames.PostgresExtensionPrefix, StringComparison.Ordinal)))
-            .ToList();
+        foreach (var operation in operations)
+        {
+            if (operation is not AlterDatabaseOperation alterDatabaseOperation)
+            {
+                continue;
+            }
 
-        var commandList = Dependencies.MigrationsSqlGenerator.Generate(operationsWithoutExtensions, model);
-        return commandList;
+            foreach (var annotation in alterDatabaseOperation.GetAnnotations())
+            {
+                if (annotation.Name.StartsWith(NpgsqlAnnotationNames.PostgresExtensionPrefix, StringComparison.Ordinal)
+                    || annotation.Name.StartsWith(NpgsqlAnnotationNames.EnumPrefix, StringComparison.Ordinal))
+                {
+                    alterDatabaseOperation.RemoveAnnotation(annotation.Name);
+                }
+            }
+        }
+
+        return Dependencies.MigrationsSqlGenerator.Generate(operations, model);
     }
 
+    // Copied as-is from EF's HistoryRepository, since it's private (see https://github.com/dotnet/efcore/issues/34991)
     private IModel EnsureModel()
     {
         if (_model == null)
@@ -127,16 +144,13 @@ public class NpgsqlHistoryRepository : HistoryRepository, IHistoryRepository
 
             conventionSet.Remove(typeof(DbSetFindingConvention));
             conventionSet.Remove(typeof(RelationalDbFunctionAttributeConvention));
-            // TODO: this whole method exists only so we can remove this convention (https://github.com/dotnet/efcore/issues/34991)
-            conventionSet.Remove(typeof(NpgsqlPostgresModelFinalizingConvention));
 
             var modelBuilder = new ModelBuilder(conventionSet);
-            modelBuilder.Entity<HistoryRow>(
-                x =>
-                {
-                    ConfigureTable(x);
-                    x.ToTable(TableName, TableSchema);
-                });
+            modelBuilder.Entity<HistoryRow>(x =>
+            {
+                ConfigureTable(x);
+                x.ToTable(TableName, TableSchema);
+            });
 
             _model = Dependencies.ModelRuntimeInitializer.Initialize(
                 (IModel)modelBuilder.Model, designTime: true, validationLogger: null);

--- a/test/EFCore.PG.Tests/Migrations/NpgsqlHistoryRepositoryTest.cs
+++ b/test/EFCore.PG.Tests/Migrations/NpgsqlHistoryRepositoryTest.cs
@@ -81,19 +81,64 @@ CREATE TABLE IF NOT EXISTS my."__EFMigrationsHistory" (
     }
 
     [ConditionalFact]
-    public void GetCreateIfNotExistsScript_works_with_schema_and_extension()
+    public void GetCreateIfNotExistsScript_does_not_include_extensions()
     {
-        var sql = CreateHistoryRepositoryWithNetTopologySuite("my").GetCreateIfNotExistsScript();
+        var historyRepository = new TestDbContext(
+                new DbContextOptionsBuilder()
+                    .UseInternalServiceProvider(
+                        NpgsqlTestHelpers.Instance.CreateServiceProvider(
+                            new ServiceCollection().AddEntityFrameworkNpgsqlNetTopologySuite()))
+                    .UseNpgsql(
+                        new NpgsqlConnection("Host=localhost;Database=DummyDatabase"),
+                        b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, "some_schema")
+                            .UseNetTopologySuite())
+                    .Options)
+            .GetService<IHistoryRepository>();;
+
+        var sql = historyRepository.GetCreateIfNotExistsScript();
 
         Assert.Equal(
             """
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'my') THEN
-        CREATE SCHEMA my;
+    IF NOT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'some_schema') THEN
+        CREATE SCHEMA some_schema;
     END IF;
 END $EF$;
-CREATE TABLE IF NOT EXISTS my."__EFMigrationsHistory" (
+CREATE TABLE IF NOT EXISTS some_schema."__EFMigrationsHistory" (
+    "MigrationId" character varying(150) NOT NULL,
+    "ProductVersion" character varying(32) NOT NULL,
+    CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId")
+);
+
+""", sql, ignoreLineEndingDifferences: true);
+    }
+
+    enum TestEnum { Value1, Value2 }
+
+    [ConditionalFact]
+    public void GetCreateIfNotExistsScript_does_not_include_enums()
+    {
+        var historyRepository = new TestDbContext(
+                new DbContextOptionsBuilder()
+                    .UseNpgsql(
+                        new NpgsqlConnection("Host=localhost;Database=DummyDatabase"),
+                        b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, "some_schema")
+                            .MapEnum<TestEnum>("test_enum"))
+                    .Options)
+            .GetService<IHistoryRepository>();;
+
+        var sql = historyRepository.GetCreateIfNotExistsScript();
+
+        Assert.Equal(
+            """
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'some_schema') THEN
+        CREATE SCHEMA some_schema;
+    END IF;
+END $EF$;
+CREATE TABLE IF NOT EXISTS some_schema."__EFMigrationsHistory" (
     "MigrationId" character varying(150) NOT NULL,
     "ProductVersion" character varying(32) NOT NULL,
     CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId")
@@ -175,19 +220,6 @@ END $EF$;
                     .UseNpgsql(
                         new NpgsqlConnection("Host=localhost;Database=DummyDatabase"),
                         b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, schema))
-                    .Options)
-            .GetService<IHistoryRepository>();
-
-    private static IHistoryRepository CreateHistoryRepositoryWithNetTopologySuite(string schema = null)
-        => new TestDbContext(
-                new DbContextOptionsBuilder()
-                    .UseInternalServiceProvider(
-                        NpgsqlTestHelpers.Instance.CreateServiceProvider(
-                            new ServiceCollection().AddEntityFrameworkNpgsqlNetTopologySuite()))
-                    .UseNpgsql(
-                        new NpgsqlConnection("Host=localhost;Database=DummyDatabase"),
-                        b => b.MigrationsHistoryTable(HistoryRepository.DefaultTableName, schema)
-                            .UseNetTopologySuite())
                     .Options)
             .GetService<IHistoryRepository>();
 


### PR DESCRIPTION
Some Managed PostgreSQL services (e.g., Azure Flexible Server) do not grant users permission to create extensions, [just superusers](https://feedback.azure.com/d365community/idea/b50ec30b-4dd8-ef11-95f5-000d3a7e7c18). Previously, when extensions like NetTopologySuite were configured, efcore.pg would include `CREATE EXTENSION IF NOT EXISTS postgis;` in every GetCreateScript() initialization script on startup, which then would break the application because of this permission error.

This PR adds a workaround to filter out extension-related operations from the creation scripts of the history table.

Fixes #3496