### PR TITLE
Fix hstore SQL literal generation for null and escaped values

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlHstoreTypeMapping.cs
@@ -66,28 +66,35 @@ public class NpgsqlHstoreTypeMapping : NpgsqlTypeMapping
     protected override string GenerateNonNullSqlLiteral(object value)
     {
         var sb = new StringBuilder("HSTORE '");
-        foreach (var kv in (IReadOnlyDictionary<string, string?>)value)
+
+        if (value is not IReadOnlyDictionary<string, string?> dict)
         {
-            sb.Append('"');
-            sb.Append(kv.Key); // TODO: Escape
-            sb.Append("\"=>");
-            if (kv.Value is null)
-            {
-                sb.Append("NULL");
-            }
-            else
-            {
-                sb.Append('"');
-                sb.Append(kv.Value); // TODO: Escape
-                sb.Append("\",");
-            }
+            throw new ArgumentException($"Expected a dictionary, but got {value.GetType()}", nameof(value));
         }
 
-        sb.Remove(sb.Length - 1, 1);
+        foreach (var kv in dict)
+        {
+            sb.Append(QuoteHStoreString(kv.Key));
+            sb.Append("=>");
+            sb.Append(kv.Value is null ? "NULL" : QuoteHStoreString(kv.Value));
+            sb.Append(',');
+        }
+
+        if (sb[^1] == ',')
+        {
+            sb.Remove(sb.Length - 1, 1);
+        }
 
         sb.Append('\'');
         return sb.ToString();
     }
+
+    // Quote string for use in an HStore literal.
+    // Escape \ as \\
+    // Escape " as \"
+    // Escape ' as ''
+    private static string QuoteHStoreString(string s)
+        => string.Concat("\"", s.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "''"), "\"");
 
     private static ValueComparer? GetComparer(Type clrType)
     {

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -458,7 +458,7 @@ public class NpgsqlTypeMappingTest
     public void GenerateSqlLiteral_returns_hstore_literal_when_first_value_is_null()
         => Assert.Equal(
             """HSTORE '"k1"=>NULL,"k2"=>"v2"'""",
-            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string> { { "k1", null }, { "k2", "v2" } }));
+            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string?> { { "k1", null }, { "k2", "v2" } }));
 
     [Fact]
     public void GenerateSqlLiteral_returns_hstore_literal_with_escaped_keys_and_values()

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -458,7 +458,7 @@ public class NpgsqlTypeMappingTest
     public void GenerateSqlLiteral_returns_hstore_literal_when_first_value_is_null()
         => Assert.Equal(
             """HSTORE '"k1"=>NULL,"k2"=>"v2"'""",
-            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string?> { { "k1", null }, { "k2", "v2" } }));
+            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string> { { "k1", null }, { "k2", "v2" } }));
 
     [Fact]
     public void GenerateSqlLiteral_returns_hstore_literal_with_escaped_keys_and_values()

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -455,6 +455,29 @@ public class NpgsqlTypeMappingTest
             GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" } }));
 
     [Fact]
+    public void GenerateSqlLiteral_returns_hstore_literal_when_first_value_is_null()
+        => Assert.Equal(
+            """HSTORE '"k1"=>NULL,"k2"=>"v2"'""",
+            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string> { { "k1", null }, { "k2", "v2" } }));
+
+    [Fact]
+    public void GenerateSqlLiteral_returns_hstore_literal_with_escaped_keys_and_values()
+        => Assert.Equal(
+            """HSTORE '"k\"1\""=>"v\"1\"","k\\2"=>"v\\2","k''3''"=>"v''3''"'""",
+            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string>
+            {
+                { "k\"1\"", "v\"1\"" },
+                { "k\\2", "v\\2" },
+                { "k'3'", "v'3'" }
+            }));
+
+    [Fact]
+    public void GenerateSqlLiteral_returns_hstore_literal_from_empty_dictionary()
+        => Assert.Equal(
+            "HSTORE ''",
+            GetMapping("hstore").GenerateSqlLiteral(new Dictionary<string, string>()));
+
+    [Fact]
     public void GenerateSqlLiteral_returns_BigInteger_literal()
     {
         var mapping = GetMapping(typeof(BigInteger));


### PR DESCRIPTION
### Summary

Fix hstore SQL literal generation bugs in NpgsqlHstoreTypeMapping.

### Details

The previous implementation produced invalid or corrupted literals in several cases:

* A null-valued entry would not have the separating comma emitted leading to unexpected results
* Empty dictionaries produced an unterminated literal
* Keys/values containing special characters were not escaped correctly

This PR updates hstore literal generation to:
* Emit separators independently of null handling
* Handle empty dictionaries correctly
* Escape `\`, `"` and `'` appropriately for use inside the generated SQL literal

Unit tests were added for each of these fixed cases.