### PR TITLE
Sync to EF 11.0.0-preview.3.26167.112

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.3.26160.112</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.3.26160.112</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26160.112</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.3.26167.112</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.3.26167.112</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26167.112</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesNpgsqlTest.cs
@@ -202,7 +202,6 @@ DELETE FROM "Context30572_Principal" AS c
 WHERE c."Id" IN (
     SELECT c0."Id"
     FROM "Context30572_Principal" AS c0
-    LEFT JOIN "Context30572_Dependent" AS c1 ON c0."DependentId" = c1."Id"
 )
 """);
     }

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
@@ -516,20 +516,10 @@ WHERE o."OrderID" = o1."OrderID"
 
         AssertSql(
             """
-@p1='100'
-@p='0'
-
 DELETE FROM "Order Details" AS o
 WHERE EXISTS (
     SELECT 1
     FROM "Order Details" AS o0
-    LEFT JOIN (
-        SELECT o2."OrderID"
-        FROM "Orders" AS o2
-        WHERE o2."OrderID" < 10300
-        ORDER BY o2."OrderID" NULLS FIRST
-        LIMIT @p1 OFFSET @p
-    ) AS o1 ON o0."OrderID" = o1."OrderID"
     WHERE o0."OrderID" < 10276 AND o0."OrderID" = o."OrderID" AND o0."ProductID" = o."ProductID")
 """);
     }
@@ -540,20 +530,10 @@ WHERE EXISTS (
 
         AssertSql(
             """
-@p1='100'
-@p='0'
-
 DELETE FROM "Order Details" AS o
 WHERE EXISTS (
     SELECT 1
     FROM "Order Details" AS o0
-    LEFT JOIN (
-        SELECT o2."OrderID"
-        FROM "Orders" AS o2
-        WHERE o2."OrderID" < 10300
-        ORDER BY o2."OrderID" NULLS FIRST
-        LIMIT @p1 OFFSET @p
-    ) AS o1 ON o0."OrderID" = o1."OrderID"
     WHERE o0."OrderID" < 10276 AND o0."OrderID" = o."OrderID" AND o0."ProductID" = o."ProductID")
 """);
     }

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionNpgsqlTest.cs
@@ -12,7 +12,7 @@ public class NavigationsCollectionNpgsqlTest(NavigationsNpgsqlFixture fixture, I
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a0."Id", n."Id", n0."Id", a1."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a0."OptionalNestedAssociateId" = n."Id"
@@ -21,7 +21,7 @@ INNER JOIN "AssociateType" AS a1 ON r."RequiredAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a1."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a1."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a2
     LEFT JOIN "NestedAssociateType" AS n3 ON a2."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a2."RequiredNestedAssociateId" = n4."Id"
@@ -33,7 +33,7 @@ WHERE (
     SELECT count(*)::int
     FROM "AssociateType" AS a
     WHERE r."Id" = a."CollectionRootId") = 2
-ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a1."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -43,7 +43,7 @@ ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NU
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a0."Id", n."Id", n0."Id", a1."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a0."OptionalNestedAssociateId" = n."Id"
@@ -52,7 +52,7 @@ INNER JOIN "AssociateType" AS a1 ON r."RequiredAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a1."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a1."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a2
     LEFT JOIN "NestedAssociateType" AS n3 ON a2."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a2."RequiredNestedAssociateId" = n4."Id"
@@ -64,7 +64,7 @@ WHERE (
     SELECT count(*)::int
     FROM "AssociateType" AS a
     WHERE r."Id" = a."CollectionRootId" AND a."Int" <> 8) = 2
-ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a1."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -74,7 +74,7 @@ ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NU
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a0."Id", n."Id", n0."Id", a1."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a0."OptionalNestedAssociateId" = n."Id"
@@ -83,7 +83,7 @@ INNER JOIN "AssociateType" AS a1 ON r."RequiredAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a1."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a1."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a2
     LEFT JOIN "NestedAssociateType" AS n3 ON a2."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a2."RequiredNestedAssociateId" = n4."Id"
@@ -97,7 +97,7 @@ WHERE (
     WHERE r."Id" = a."CollectionRootId"
     ORDER BY a."Id" NULLS FIRST
     LIMIT 1 OFFSET 0) = 8
-ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a1."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -109,7 +109,7 @@ ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NU
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a1."Id", n."Id", n0."Id", a2."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a1 ON r."OptionalAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a1."OptionalNestedAssociateId" = n."Id"
@@ -118,7 +118,7 @@ INNER JOIN "AssociateType" AS a2 ON r."RequiredAssociateId" = a2."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a2."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a2."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a3."Id", a3."CollectionRootId", a3."Int", a3."Ints", a3."Name", a3."OptionalNestedAssociateId", a3."RequiredNestedAssociateId", a3."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a3."Id", a3."CollectionRootId", a3."Int", a3."Ints", a3."Name", a3."OptionalNestedAssociateId", a3."RequiredNestedAssociateId", a3."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a3
     LEFT JOIN "NestedAssociateType" AS n3 ON a3."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a3."RequiredNestedAssociateId" = n4."Id"
@@ -133,7 +133,7 @@ WHERE (
         FROM "AssociateType" AS a
         WHERE r."Id" = a."CollectionRootId"
     ) AS a0) = 2
-ORDER BY r."Id" NULLS FIRST, a1."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a2."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -143,10 +143,10 @@ ORDER BY r."Id" NULLS FIRST, a1."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NU
 
         AssertSql(
             """
-SELECT r."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2"
+SELECT r."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2"
 FROM "RootEntity" AS r
 LEFT JOIN LATERAL (
-    SELECT a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n."Id" AS "Id0", n0."Id" AS "Id1", n1."Id" AS "Id2", n1."CollectionAssociateId", n1."Int" AS "Int0", n1."Ints" AS "Ints0", n1."Name" AS "Name0", n1."String" AS "String0", n."CollectionAssociateId" AS "CollectionAssociateId0", n."Int" AS "Int1", n."Ints" AS "Ints1", n."Name" AS "Name1", n."String" AS "String1", n0."CollectionAssociateId" AS "CollectionAssociateId1", n0."Int" AS "Int2", n0."Ints" AS "Ints2", n0."Name" AS "Name2", n0."String" AS "String2"
+    SELECT a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n1."Id" AS "Id0", n1."CollectionAssociateId", n1."Int" AS "Int0", n1."Ints" AS "Ints0", n1."Name" AS "Name0", n1."String" AS "String0", n."Id" AS "Id1", n."CollectionAssociateId" AS "CollectionAssociateId0", n."Int" AS "Int1", n."Ints" AS "Ints1", n."Name" AS "Name1", n."String" AS "String1", n0."Id" AS "Id2", n0."CollectionAssociateId" AS "CollectionAssociateId1", n0."Int" AS "Int2", n0."Ints" AS "Ints2", n0."Name" AS "Name2", n0."String" AS "String2"
     FROM (
         SELECT DISTINCT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String"
         FROM "AssociateType" AS a
@@ -156,7 +156,7 @@ LEFT JOIN LATERAL (
     INNER JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id"
     LEFT JOIN "NestedAssociateType" AS n1 ON a0."Id" = n1."CollectionAssociateId"
 ) AS s ON TRUE
-ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST
 """);
     }
 
@@ -217,7 +217,7 @@ ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NU
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a0."Id", n."Id", n0."Id", a1."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a0."OptionalNestedAssociateId" = n."Id"
@@ -226,7 +226,7 @@ INNER JOIN "AssociateType" AS a1 ON r."RequiredAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a1."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a1."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a2
     LEFT JOIN "NestedAssociateType" AS n3 ON a2."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a2."RequiredNestedAssociateId" = n4."Id"
@@ -240,7 +240,7 @@ WHERE 16 IN (
     WHERE r."Id" = a."CollectionRootId"
     GROUP BY a."String"
 )
-ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a1."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsIncludeNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsIncludeNpgsqlTest.cs
@@ -12,7 +12,7 @@ public class NavigationsIncludeNpgsqlTest(NavigationsNpgsqlFixture fixture, ITes
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -21,7 +21,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -29,7 +29,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -39,7 +39,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -48,7 +48,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -56,7 +56,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -66,7 +66,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -75,7 +75,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -83,7 +83,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -93,7 +93,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -102,7 +102,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -110,7 +110,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -120,7 +120,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -129,7 +129,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -137,7 +137,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -147,7 +147,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -156,7 +156,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -164,7 +164,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -174,7 +174,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -183,7 +183,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -191,7 +191,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -201,7 +201,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -210,7 +210,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -218,7 +218,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -228,7 +228,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -237,7 +237,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -245,7 +245,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsMiscellaneousNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsMiscellaneousNpgsqlTest.cs
@@ -16,7 +16,7 @@ public class NavigationsMiscellaneousNpgsqlTest(
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -25,7 +25,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -34,7 +34,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE a."Int" = 8
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -44,7 +44,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -53,7 +53,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -62,7 +62,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
 WHERE a."Int" = 8
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -72,7 +72,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", a0."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 INNER JOIN "NestedAssociateType" AS n ON a."RequiredNestedAssociateId" = n."Id"
@@ -81,7 +81,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."OptionalNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id"
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -90,7 +90,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE n."Int" = 8
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -103,7 +103,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NUL
 
         AssertSql(
             """
-SELECT m."Id", m."Name", m."OptionalAssociateId", m."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT m."Id", m."Name", m."OptionalAssociateId", m."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM (
     SELECT * FROM "RootEntity"
 ) AS m
@@ -114,7 +114,7 @@ INNER JOIN "AssociateType" AS a0 ON m."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -122,7 +122,7 @@ LEFT JOIN (
 ) AS s ON m."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY m."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY m."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsPrimitiveCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsPrimitiveCollectionNpgsqlTest.cs
@@ -9,7 +9,7 @@ public class NavigationsPrimitiveCollectionNpgsqlTest(NavigationsNpgsqlFixture f
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -18,7 +18,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -27,7 +27,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE cardinality(a."Ints") = 3
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -37,7 +37,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -46,7 +46,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -55,7 +55,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE a."Ints"[1] = 1
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -65,7 +65,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -74,7 +74,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -83,7 +83,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE 3 = ANY (a."Ints")
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -93,7 +93,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -102,7 +102,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -111,7 +111,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE 2 = ANY (a."Ints")
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -121,7 +121,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", a0."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 INNER JOIN "NestedAssociateType" AS n ON a."RequiredNestedAssociateId" = n."Id"
@@ -130,7 +130,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."OptionalNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id"
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -139,7 +139,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE cardinality(n."Ints") = 3
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsProjectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsProjectionNpgsqlTest.cs
@@ -12,7 +12,7 @@ public class NavigationsProjectionNpgsqlTest(NavigationsNpgsqlFixture fixture, I
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -21,7 +21,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -29,7 +29,7 @@ LEFT JOIN (
 ) AS s ON r."Id" = s."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -93,13 +93,13 @@ LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 
         AssertSql(
             """
-SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n."Id", n0."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
+SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 INNER JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -109,13 +109,13 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n."Id", n0."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
+SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 LEFT JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -177,14 +177,14 @@ LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 
         AssertSql(
             """
-SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", r0."Id", n."Id", n0."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
+SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
 FROM "RootReferencingEntity" AS r
 LEFT JOIN "RootEntity" AS r0 ON r."RootEntityId" = r0."Id"
 LEFT JOIN "AssociateType" AS a ON r0."RequiredAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 LEFT JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, r0."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -194,13 +194,13 @@ ORDER BY r."Id" NULLS FIRST, r0."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n."Id", n0."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
+SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 INNER JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -226,16 +226,16 @@ INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 
         AssertSql(
             """
-SELECT r."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2"
+SELECT r."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2"
 FROM "RootEntity" AS r
 LEFT JOIN (
-    SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n."Id" AS "Id0", n0."Id" AS "Id1", n1."Id" AS "Id2", n1."CollectionAssociateId", n1."Int" AS "Int0", n1."Ints" AS "Ints0", n1."Name" AS "Name0", n1."String" AS "String0", n."CollectionAssociateId" AS "CollectionAssociateId0", n."Int" AS "Int1", n."Ints" AS "Ints1", n."Name" AS "Name1", n."String" AS "String1", n0."CollectionAssociateId" AS "CollectionAssociateId1", n0."Int" AS "Int2", n0."Ints" AS "Ints2", n0."Name" AS "Name2", n0."String" AS "String2"
+    SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n1."Id" AS "Id0", n1."CollectionAssociateId", n1."Int" AS "Int0", n1."Ints" AS "Ints0", n1."Name" AS "Name0", n1."String" AS "String0", n."Id" AS "Id1", n."CollectionAssociateId" AS "CollectionAssociateId0", n."Int" AS "Int1", n."Ints" AS "Ints1", n."Name" AS "Name1", n."String" AS "String1", n0."Id" AS "Id2", n0."CollectionAssociateId" AS "CollectionAssociateId1", n0."Int" AS "Int2", n0."Ints" AS "Ints2", n0."Name" AS "Name2", n0."String" AS "String2"
     FROM "AssociateType" AS a
     LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
     INNER JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
     LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
 ) AS s ON r."Id" = s."CollectionRootId"
-ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST
 """);
     }
 
@@ -245,11 +245,11 @@ ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NU
 
         AssertSql(
             """
-SELECT r."Id", a."Id", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."Id" = n."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -259,11 +259,11 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST
 
         AssertSql(
             """
-SELECT r."Id", a."Id", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."Id" = n."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -273,13 +273,13 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST
 
         AssertSql(
             """
-SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n."Id", n0."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
+SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", r."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."Id" = a."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 INNER JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST
 """);
     }
 
@@ -319,7 +319,7 @@ INNER JOIN "NestedAssociateType" AS n ON a."Id" = n."CollectionAssociateId"
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", s0."Id", s0."CollectionRootId", s0."Int", s0."Ints", s0."Name", s0."OptionalNestedAssociateId", s0."RequiredNestedAssociateId", s0."String", s0."Id0", s0."Id1", s0."Id2", s0."CollectionAssociateId", s0."Int0", s0."Ints0", s0."Name0", s0."String0", s0."CollectionAssociateId0", s0."Int1", s0."Ints1", s0."Name1", s0."String1", s0."CollectionAssociateId1", s0."Int2", s0."Ints2", s0."Name2", s0."String2", n11."Id", n11."CollectionAssociateId", n11."Int", n11."Ints", n11."Name", n11."String", n12."Id", n12."CollectionAssociateId", n12."Int", n12."Ints", n12."Name", n12."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", s0."Id", s0."CollectionRootId", s0."Int", s0."Ints", s0."Name", s0."OptionalNestedAssociateId", s0."RequiredNestedAssociateId", s0."String", s0."Id0", s0."CollectionAssociateId", s0."Int0", s0."Ints0", s0."Name0", s0."String0", s0."Id1", s0."CollectionAssociateId0", s0."Int1", s0."Ints1", s0."Name1", s0."String1", s0."Id2", s0."CollectionAssociateId1", s0."Int2", s0."Ints2", s0."Name2", s0."String2", n11."Id", n11."CollectionAssociateId", n11."Int", n11."Ints", n11."Name", n11."String", n12."Id", n12."CollectionAssociateId", n12."Int", n12."Ints", n12."Name", n12."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -328,7 +328,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -337,7 +337,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
 LEFT JOIN (
-    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n8."Id" AS "Id0", n9."Id" AS "Id1", n10."Id" AS "Id2", n10."CollectionAssociateId", n10."Int" AS "Int0", n10."Ints" AS "Ints0", n10."Name" AS "Name0", n10."String" AS "String0", n8."CollectionAssociateId" AS "CollectionAssociateId0", n8."Int" AS "Int1", n8."Ints" AS "Ints1", n8."Name" AS "Name1", n8."String" AS "String1", n9."CollectionAssociateId" AS "CollectionAssociateId1", n9."Int" AS "Int2", n9."Ints" AS "Ints2", n9."Name" AS "Name2", n9."String" AS "String2"
+    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n10."Id" AS "Id0", n10."CollectionAssociateId", n10."Int" AS "Int0", n10."Ints" AS "Ints0", n10."Name" AS "Name0", n10."String" AS "String0", n8."Id" AS "Id1", n8."CollectionAssociateId" AS "CollectionAssociateId0", n8."Int" AS "Int1", n8."Ints" AS "Ints1", n8."Name" AS "Name1", n8."String" AS "String1", n9."Id" AS "Id2", n9."CollectionAssociateId" AS "CollectionAssociateId1", n9."Int" AS "Int2", n9."Ints" AS "Ints2", n9."Name" AS "Name2", n9."String" AS "String2"
     FROM "AssociateType" AS a2
     LEFT JOIN "NestedAssociateType" AS n8 ON a2."OptionalNestedAssociateId" = n8."Id"
     INNER JOIN "NestedAssociateType" AS n9 ON a2."RequiredNestedAssociateId" = n9."Id"
@@ -345,7 +345,7 @@ LEFT JOIN (
 ) AS s0 ON r."Id" = s0."CollectionRootId"
 LEFT JOIN "NestedAssociateType" AS n11 ON a."Id" = n11."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n12 ON a0."Id" = n12."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST, n7."Id" NULLS FIRST, s0."Id" NULLS FIRST, s0."Id0" NULLS FIRST, s0."Id1" NULLS FIRST, s0."Id2" NULLS FIRST, n11."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST, n7."Id" NULLS FIRST, s0."Id" NULLS FIRST, s0."Id0" NULLS FIRST, n11."Id" NULLS FIRST
 """);
     }
 
@@ -355,13 +355,13 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n."Id", n0."Id", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
+SELECT r."Id", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
 INNER JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST
 """);
     }
 
@@ -417,7 +417,7 @@ LEFT JOIN LATERAL (
         {
             AssertSql(
                 """
-SELECT r."Id", r1."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", r1.c
+SELECT r."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", r1.c
 FROM "RootEntity" AS r
 LEFT JOIN LATERAL (
     SELECT 1 AS c, r0."Id"
@@ -426,13 +426,13 @@ LEFT JOIN LATERAL (
     LIMIT 1
 ) AS r1 ON TRUE
 LEFT JOIN (
-    SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n."Id" AS "Id0", n0."Id" AS "Id1", n1."Id" AS "Id2", n1."CollectionAssociateId", n1."Int" AS "Int0", n1."Ints" AS "Ints0", n1."Name" AS "Name0", n1."String" AS "String0", n."CollectionAssociateId" AS "CollectionAssociateId0", n."Int" AS "Int1", n."Ints" AS "Ints1", n."Name" AS "Name1", n."String" AS "String1", n0."CollectionAssociateId" AS "CollectionAssociateId1", n0."Int" AS "Int2", n0."Ints" AS "Ints2", n0."Name" AS "Name2", n0."String" AS "String2"
+    SELECT a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n1."Id" AS "Id0", n1."CollectionAssociateId", n1."Int" AS "Int0", n1."Ints" AS "Ints0", n1."Name" AS "Name0", n1."String" AS "String0", n."Id" AS "Id1", n."CollectionAssociateId" AS "CollectionAssociateId0", n."Int" AS "Int1", n."Ints" AS "Ints1", n."Name" AS "Name1", n."String" AS "String1", n0."Id" AS "Id2", n0."CollectionAssociateId" AS "CollectionAssociateId1", n0."Int" AS "Int2", n0."Ints" AS "Ints2", n0."Name" AS "Name2", n0."String" AS "String2"
     FROM "AssociateType" AS a
     LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
     INNER JOIN "NestedAssociateType" AS n0 ON a."RequiredNestedAssociateId" = n0."Id"
     LEFT JOIN "NestedAssociateType" AS n1 ON a."Id" = n1."CollectionAssociateId"
 ) AS s ON r1."Id" = s."CollectionRootId"
-ORDER BY r."Id" NULLS FIRST, r1."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST
 """);
         }
     }

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsSetOperationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsSetOperationsNpgsqlTest.cs
@@ -14,7 +14,7 @@ public class NavigationsSetOperationsNpgsqlTest(
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a1."Id", n."Id", n0."Id", a2."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a1 ON r."OptionalAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a1."OptionalNestedAssociateId" = n."Id"
@@ -23,7 +23,7 @@ INNER JOIN "AssociateType" AS a2 ON r."RequiredAssociateId" = a2."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a2."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a2."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a3."Id", a3."CollectionRootId", a3."Int", a3."Ints", a3."Name", a3."OptionalNestedAssociateId", a3."RequiredNestedAssociateId", a3."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a3."Id", a3."CollectionRootId", a3."Int", a3."Ints", a3."Name", a3."OptionalNestedAssociateId", a3."RequiredNestedAssociateId", a3."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a3
     LEFT JOIN "NestedAssociateType" AS n3 ON a3."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a3."RequiredNestedAssociateId" = n4."Id"
@@ -42,7 +42,7 @@ WHERE (
         FROM "AssociateType" AS a0
         WHERE r."Id" = a0."CollectionRootId" AND a0."String" = 'foo'
     ) AS u) = 4
-ORDER BY r."Id" NULLS FIRST, a1."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a2."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -83,7 +83,7 @@ FROM "RootEntity" AS r
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n1."Id", n2."Id", n3."Id", n4."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n9."Id", n9."CollectionAssociateId", n9."Int", n9."Ints", n9."Name", n9."String", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String", n4."CollectionAssociateId", n4."Int", n4."Ints", n4."Name", n4."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n9."Id", n9."CollectionAssociateId", n9."Int", n9."Ints", n9."Name", n9."String", n3."Id", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String", n4."Id", n4."CollectionAssociateId", n4."Int", n4."Ints", n4."Name", n4."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -92,7 +92,7 @@ LEFT JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id
 LEFT JOIN "NestedAssociateType" AS n3 ON a."OptionalNestedAssociateId" = n3."Id"
 INNER JOIN "NestedAssociateType" AS n4 ON a."RequiredNestedAssociateId" = n4."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n6."Id" AS "Id1", n7."Id" AS "Id2", n7."CollectionAssociateId", n7."Int" AS "Int0", n7."Ints" AS "Ints0", n7."Name" AS "Name0", n7."String" AS "String0", n5."CollectionAssociateId" AS "CollectionAssociateId0", n5."Int" AS "Int1", n5."Ints" AS "Ints1", n5."Name" AS "Name1", n5."String" AS "String1", n6."CollectionAssociateId" AS "CollectionAssociateId1", n6."Int" AS "Int2", n6."Ints" AS "Ints2", n6."Name" AS "Name2", n6."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id" AS "Id0", n7."CollectionAssociateId", n7."Int" AS "Int0", n7."Ints" AS "Ints0", n7."Name" AS "Name0", n7."String" AS "String0", n5."Id" AS "Id1", n5."CollectionAssociateId" AS "CollectionAssociateId0", n5."Int" AS "Int1", n5."Ints" AS "Ints1", n5."Name" AS "Name1", n5."String" AS "String1", n6."Id" AS "Id2", n6."CollectionAssociateId" AS "CollectionAssociateId1", n6."Int" AS "Int2", n6."Ints" AS "Ints2", n6."Name" AS "Name2", n6."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n5 ON a1."OptionalNestedAssociateId" = n5."Id"
     INNER JOIN "NestedAssociateType" AS n6 ON a1."RequiredNestedAssociateId" = n6."Id"
@@ -111,7 +111,7 @@ WHERE (
         FROM "NestedAssociateType" AS n0
         WHERE a."Id" = n0."CollectionAssociateId" AND n0."String" = 'foo'
     ) AS u) = 4
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, n3."Id" NULLS FIRST, n4."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n8."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n8."Id" NULLS FIRST
 """);
     }
 
@@ -121,7 +121,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NU
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n1."Id", n2."Id", n3."Id", n4."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n9."Id", n9."CollectionAssociateId", n9."Int", n9."Ints", n9."Name", n9."String", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String", n4."CollectionAssociateId", n4."Int", n4."Ints", n4."Name", n4."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n9."Id", n9."CollectionAssociateId", n9."Int", n9."Ints", n9."Name", n9."String", n3."Id", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String", n4."Id", n4."CollectionAssociateId", n4."Int", n4."Ints", n4."Name", n4."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -130,7 +130,7 @@ LEFT JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id
 LEFT JOIN "NestedAssociateType" AS n3 ON a."OptionalNestedAssociateId" = n3."Id"
 INNER JOIN "NestedAssociateType" AS n4 ON a."RequiredNestedAssociateId" = n4."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n6."Id" AS "Id1", n7."Id" AS "Id2", n7."CollectionAssociateId", n7."Int" AS "Int0", n7."Ints" AS "Ints0", n7."Name" AS "Name0", n7."String" AS "String0", n5."CollectionAssociateId" AS "CollectionAssociateId0", n5."Int" AS "Int1", n5."Ints" AS "Ints1", n5."Name" AS "Name1", n5."String" AS "String1", n6."CollectionAssociateId" AS "CollectionAssociateId1", n6."Int" AS "Int2", n6."Ints" AS "Ints2", n6."Name" AS "Name2", n6."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id" AS "Id0", n7."CollectionAssociateId", n7."Int" AS "Int0", n7."Ints" AS "Ints0", n7."Name" AS "Name0", n7."String" AS "String0", n5."Id" AS "Id1", n5."CollectionAssociateId" AS "CollectionAssociateId0", n5."Int" AS "Int1", n5."Ints" AS "Ints1", n5."Name" AS "Name1", n5."String" AS "String1", n6."Id" AS "Id2", n6."CollectionAssociateId" AS "CollectionAssociateId1", n6."Int" AS "Int2", n6."Ints" AS "Ints2", n6."Name" AS "Name2", n6."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n5 ON a1."OptionalNestedAssociateId" = n5."Id"
     INNER JOIN "NestedAssociateType" AS n6 ON a1."RequiredNestedAssociateId" = n6."Id"
@@ -149,7 +149,7 @@ WHERE (
         FROM "NestedAssociateType" AS n0
         WHERE a0."Id" IS NOT NULL AND a0."Id" = n0."CollectionAssociateId"
     ) AS u) = 4
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, n3."Id" NULLS FIRST, n4."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n8."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n8."Id" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsStructuralEqualityNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsStructuralEqualityNpgsqlTest.cs
@@ -14,7 +14,7 @@ public class NavigationsStructuralEqualityNpgsqlTest(
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -23,7 +23,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -32,7 +32,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE a."Id" = a0."Id"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -42,7 +42,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", a0."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 INNER JOIN "NestedAssociateType" AS n ON a."RequiredNestedAssociateId" = n."Id"
@@ -51,7 +51,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -60,7 +60,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE n."Id" = n0."Id"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -70,7 +70,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -79,7 +79,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -88,7 +88,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE a."Id" <> a0."Id" OR a0."Id" IS NULL
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -98,7 +98,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -107,7 +107,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -116,7 +116,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
 WHERE a."Id" IS NULL
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -126,7 +126,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", n0."Id", a0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a ON r."OptionalAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -135,7 +135,7 @@ INNER JOIN "AssociateType" AS a0 ON r."RequiredAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a0."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -144,7 +144,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a0."Id" = n7."CollectionAssociateId"
 WHERE a."Id" IS NULL
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -154,7 +154,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", a0."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a."OptionalNestedAssociateId" = n."Id"
@@ -163,7 +163,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."OptionalNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -172,7 +172,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE n."Id" IS NULL
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -182,7 +182,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", a0."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 INNER JOIN "NestedAssociateType" AS n ON a."RequiredNestedAssociateId" = n."Id"
@@ -191,7 +191,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."OptionalNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id"
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -200,7 +200,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE n."Id" = 1000
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -212,7 +212,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NUL
             """
 @entity_equality_nested_Id='1000' (Nullable = true)
 
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", n."Id", a0."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 INNER JOIN "NestedAssociateType" AS n ON a."RequiredNestedAssociateId" = n."Id"
@@ -221,7 +221,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."OptionalNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id"
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -230,7 +230,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE n."Id" = @entity_equality_nested_Id
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -240,7 +240,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, n."Id" NULLS FIRST, a0."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n."Id", n0."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -249,7 +249,7 @@ LEFT JOIN "NestedAssociateType" AS n0 ON a0."RequiredNestedAssociateId" = n0."Id
 LEFT JOIN "NestedAssociateType" AS n1 ON a."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n3 ON a1."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a1."RequiredNestedAssociateId" = n4."Id"
@@ -258,7 +258,7 @@ LEFT JOIN (
 LEFT JOIN "NestedAssociateType" AS n6 ON a0."Id" = n6."CollectionAssociateId"
 LEFT JOIN "NestedAssociateType" AS n7 ON a."Id" = n7."CollectionAssociateId"
 WHERE a."Id" = a0."Id"
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 
@@ -284,7 +284,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NUL
 
         AssertSql(
             """
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n0."Id", n1."Id", n2."Id", n3."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n3."Id", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -293,7 +293,7 @@ LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 INNER JOIN "NestedAssociateType" AS n3 ON a."RequiredNestedAssociateId" = n3."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n4."Id" AS "Id0", n5."Id" AS "Id1", n6."Id" AS "Id2", n6."CollectionAssociateId", n6."Int" AS "Int0", n6."Ints" AS "Ints0", n6."Name" AS "Name0", n6."String" AS "String0", n4."CollectionAssociateId" AS "CollectionAssociateId0", n4."Int" AS "Int1", n4."Ints" AS "Ints1", n4."Name" AS "Name1", n4."String" AS "String1", n5."CollectionAssociateId" AS "CollectionAssociateId1", n5."Int" AS "Int2", n5."Ints" AS "Ints2", n5."Name" AS "Name2", n5."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id" AS "Id0", n6."CollectionAssociateId", n6."Int" AS "Int0", n6."Ints" AS "Ints0", n6."Name" AS "Name0", n6."String" AS "String0", n4."Id" AS "Id1", n4."CollectionAssociateId" AS "CollectionAssociateId0", n4."Int" AS "Int1", n4."Ints" AS "Ints1", n4."Name" AS "Name1", n4."String" AS "String1", n5."Id" AS "Id2", n5."CollectionAssociateId" AS "CollectionAssociateId1", n5."Int" AS "Int2", n5."Ints" AS "Ints2", n5."Name" AS "Name2", n5."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n4 ON a1."OptionalNestedAssociateId" = n4."Id"
     INNER JOIN "NestedAssociateType" AS n5 ON a1."RequiredNestedAssociateId" = n5."Id"
@@ -305,7 +305,7 @@ WHERE EXISTS (
     SELECT 1
     FROM "NestedAssociateType" AS n
     WHERE a."Id" = n."CollectionAssociateId" AND n."Id" = 1002)
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, n3."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n7."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n7."Id" NULLS FIRST
 """);
     }
 
@@ -317,7 +317,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NU
             """
 @entity_equality_nested_Id='1002' (Nullable = true)
 
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n0."Id", n1."Id", n2."Id", n3."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n3."Id", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -326,7 +326,7 @@ LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 INNER JOIN "NestedAssociateType" AS n3 ON a."RequiredNestedAssociateId" = n3."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n4."Id" AS "Id0", n5."Id" AS "Id1", n6."Id" AS "Id2", n6."CollectionAssociateId", n6."Int" AS "Int0", n6."Ints" AS "Ints0", n6."Name" AS "Name0", n6."String" AS "String0", n4."CollectionAssociateId" AS "CollectionAssociateId0", n4."Int" AS "Int1", n4."Ints" AS "Ints1", n4."Name" AS "Name1", n4."String" AS "String1", n5."CollectionAssociateId" AS "CollectionAssociateId1", n5."Int" AS "Int2", n5."Ints" AS "Ints2", n5."Name" AS "Name2", n5."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id" AS "Id0", n6."CollectionAssociateId", n6."Int" AS "Int0", n6."Ints" AS "Ints0", n6."Name" AS "Name0", n6."String" AS "String0", n4."Id" AS "Id1", n4."CollectionAssociateId" AS "CollectionAssociateId0", n4."Int" AS "Int1", n4."Ints" AS "Ints1", n4."Name" AS "Name1", n4."String" AS "String1", n5."Id" AS "Id2", n5."CollectionAssociateId" AS "CollectionAssociateId1", n5."Int" AS "Int2", n5."Ints" AS "Ints2", n5."Name" AS "Name2", n5."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n4 ON a1."OptionalNestedAssociateId" = n4."Id"
     INNER JOIN "NestedAssociateType" AS n5 ON a1."RequiredNestedAssociateId" = n5."Id"
@@ -338,7 +338,7 @@ WHERE EXISTS (
     SELECT 1
     FROM "NestedAssociateType" AS n
     WHERE a."Id" = n."CollectionAssociateId" AND n."Id" = @entity_equality_nested_Id)
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, n3."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n7."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n7."Id" NULLS FIRST
 """);
     }
 
@@ -351,7 +351,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NU
 @get_Item_Int='106'
 @entity_equality_get_Item_Id='3003' (Nullable = true)
 
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a."Id", a0."Id", n0."Id", n1."Id", n2."Id", n3."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", a."Id", a."CollectionRootId", a."Int", a."Ints", a."Name", a."OptionalNestedAssociateId", a."RequiredNestedAssociateId", a."String", n8."Id", n8."CollectionAssociateId", n8."Int", n8."Ints", n8."Name", n8."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String", n3."Id", n3."CollectionAssociateId", n3."Int", n3."Ints", n3."Name", n3."String"
 FROM "RootEntity" AS r
 INNER JOIN "AssociateType" AS a ON r."RequiredAssociateId" = a."Id"
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
@@ -360,7 +360,7 @@ LEFT JOIN "NestedAssociateType" AS n1 ON a0."RequiredNestedAssociateId" = n1."Id
 LEFT JOIN "NestedAssociateType" AS n2 ON a."OptionalNestedAssociateId" = n2."Id"
 INNER JOIN "NestedAssociateType" AS n3 ON a."RequiredNestedAssociateId" = n3."Id"
 LEFT JOIN (
-    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n4."Id" AS "Id0", n5."Id" AS "Id1", n6."Id" AS "Id2", n6."CollectionAssociateId", n6."Int" AS "Int0", n6."Ints" AS "Ints0", n6."Name" AS "Name0", n6."String" AS "String0", n4."CollectionAssociateId" AS "CollectionAssociateId0", n4."Int" AS "Int1", n4."Ints" AS "Ints1", n4."Name" AS "Name1", n4."String" AS "String1", n5."CollectionAssociateId" AS "CollectionAssociateId1", n5."Int" AS "Int2", n5."Ints" AS "Ints2", n5."Name" AS "Name2", n5."String" AS "String2"
+    SELECT a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n6."Id" AS "Id0", n6."CollectionAssociateId", n6."Int" AS "Int0", n6."Ints" AS "Ints0", n6."Name" AS "Name0", n6."String" AS "String0", n4."Id" AS "Id1", n4."CollectionAssociateId" AS "CollectionAssociateId0", n4."Int" AS "Int1", n4."Ints" AS "Ints1", n4."Name" AS "Name1", n4."String" AS "String1", n5."Id" AS "Id2", n5."CollectionAssociateId" AS "CollectionAssociateId1", n5."Int" AS "Int2", n5."Ints" AS "Ints2", n5."Name" AS "Name2", n5."String" AS "String2"
     FROM "AssociateType" AS a1
     LEFT JOIN "NestedAssociateType" AS n4 ON a1."OptionalNestedAssociateId" = n4."Id"
     INNER JOIN "NestedAssociateType" AS n5 ON a1."RequiredNestedAssociateId" = n5."Id"
@@ -372,7 +372,7 @@ WHERE EXISTS (
     SELECT 1
     FROM "NestedAssociateType" AS n
     WHERE a."Id" = n."CollectionAssociateId" AND n."Int" > @get_Item_Int AND n."Id" = @entity_equality_get_Item_Id)
-ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, n3."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n7."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n7."Id" NULLS FIRST
 """);
     }
 
@@ -385,7 +385,7 @@ ORDER BY r."Id" NULLS FIRST, a."Id" NULLS FIRST, a0."Id" NULLS FIRST, n0."Id" NU
 @get_Item_Id='302'
 @entity_equality_get_Item_Id='303' (Nullable = true)
 
-SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", a0."Id", n."Id", n0."Id", a1."Id", n1."Id", n2."Id", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."Id1", s."Id2", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
+SELECT r."Id", r."Name", r."OptionalAssociateId", r."RequiredAssociateId", s."Id", s."CollectionRootId", s."Int", s."Ints", s."Name", s."OptionalNestedAssociateId", s."RequiredNestedAssociateId", s."String", s."Id0", s."CollectionAssociateId", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."CollectionAssociateId0", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."CollectionAssociateId1", s."Int2", s."Ints2", s."Name2", s."String2", a0."Id", a0."CollectionRootId", a0."Int", a0."Ints", a0."Name", a0."OptionalNestedAssociateId", a0."RequiredNestedAssociateId", a0."String", n6."Id", n6."CollectionAssociateId", n6."Int", n6."Ints", n6."Name", n6."String", n."Id", n."CollectionAssociateId", n."Int", n."Ints", n."Name", n."String", n0."Id", n0."CollectionAssociateId", n0."Int", n0."Ints", n0."Name", n0."String", a1."Id", a1."CollectionRootId", a1."Int", a1."Ints", a1."Name", a1."OptionalNestedAssociateId", a1."RequiredNestedAssociateId", a1."String", n7."Id", n7."CollectionAssociateId", n7."Int", n7."Ints", n7."Name", n7."String", n1."Id", n1."CollectionAssociateId", n1."Int", n1."Ints", n1."Name", n1."String", n2."Id", n2."CollectionAssociateId", n2."Int", n2."Ints", n2."Name", n2."String"
 FROM "RootEntity" AS r
 LEFT JOIN "AssociateType" AS a0 ON r."OptionalAssociateId" = a0."Id"
 LEFT JOIN "NestedAssociateType" AS n ON a0."OptionalNestedAssociateId" = n."Id"
@@ -394,7 +394,7 @@ INNER JOIN "AssociateType" AS a1 ON r."RequiredAssociateId" = a1."Id"
 LEFT JOIN "NestedAssociateType" AS n1 ON a1."OptionalNestedAssociateId" = n1."Id"
 INNER JOIN "NestedAssociateType" AS n2 ON a1."RequiredNestedAssociateId" = n2."Id"
 LEFT JOIN (
-    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n3."Id" AS "Id0", n4."Id" AS "Id1", n5."Id" AS "Id2", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
+    SELECT a2."Id", a2."CollectionRootId", a2."Int", a2."Ints", a2."Name", a2."OptionalNestedAssociateId", a2."RequiredNestedAssociateId", a2."String", n5."Id" AS "Id0", n5."CollectionAssociateId", n5."Int" AS "Int0", n5."Ints" AS "Ints0", n5."Name" AS "Name0", n5."String" AS "String0", n3."Id" AS "Id1", n3."CollectionAssociateId" AS "CollectionAssociateId0", n3."Int" AS "Int1", n3."Ints" AS "Ints1", n3."Name" AS "Name1", n3."String" AS "String1", n4."Id" AS "Id2", n4."CollectionAssociateId" AS "CollectionAssociateId1", n4."Int" AS "Int2", n4."Ints" AS "Ints2", n4."Name" AS "Name2", n4."String" AS "String2"
     FROM "AssociateType" AS a2
     LEFT JOIN "NestedAssociateType" AS n3 ON a2."OptionalNestedAssociateId" = n3."Id"
     INNER JOIN "NestedAssociateType" AS n4 ON a2."RequiredNestedAssociateId" = n4."Id"
@@ -406,7 +406,7 @@ WHERE EXISTS (
     SELECT 1
     FROM "AssociateType" AS a
     WHERE r."Id" = a."CollectionRootId" AND a."Id" > @get_Item_Id AND a."Id" = @entity_equality_get_Item_Id)
-ORDER BY r."Id" NULLS FIRST, a0."Id" NULLS FIRST, n."Id" NULLS FIRST, n0."Id" NULLS FIRST, a1."Id" NULLS FIRST, n1."Id" NULLS FIRST, n2."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, s."Id1" NULLS FIRST, s."Id2" NULLS FIRST, n6."Id" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST, s."Id0" NULLS FIRST, n6."Id" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsProjectionNpgsqlTest.cs
@@ -197,14 +197,14 @@ LEFT JOIN "OptionalRelated_OptionalNested" AS o0 ON o."RootEntityId" = o0."Assoc
         {
             AssertSql(
                 """
-SELECT r1."RootEntityId", r1."Id", r1."Int", r1."Ints", r1."Name", r1."String", r."Id", r0."Id", r2."AssociateTypeRootEntityId", r3."AssociateTypeRootEntityId", r4."AssociateTypeRootEntityId", r4."Id", r4."Int", r4."Ints", r4."Name", r4."String", r2."Id", r2."Int", r2."Ints", r2."Name", r2."String", r3."Id", r3."Int", r3."Ints", r3."Name", r3."String"
+SELECT r1."RootEntityId", r1."Id", r1."Int", r1."Ints", r1."Name", r1."String", r."Id", r2."AssociateTypeRootEntityId", r3."AssociateTypeRootEntityId", r4."AssociateTypeRootEntityId", r4."Id", r4."Int", r4."Ints", r4."Name", r4."String", r2."Id", r2."Int", r2."Ints", r2."Name", r2."String", r3."Id", r3."Int", r3."Ints", r3."Name", r3."String"
 FROM "RootReferencingEntity" AS r
 LEFT JOIN "RootEntity" AS r0 ON r."RootEntityId" = r0."Id"
 LEFT JOIN "RequiredRelated" AS r1 ON r0."Id" = r1."RootEntityId"
 LEFT JOIN "RequiredRelated_OptionalNested" AS r2 ON r1."RootEntityId" = r2."AssociateTypeRootEntityId"
 LEFT JOIN "RequiredRelated_RequiredNested" AS r3 ON r1."RootEntityId" = r3."AssociateTypeRootEntityId"
 LEFT JOIN "RequiredRelated_NestedCollection" AS r4 ON r1."RootEntityId" = r4."AssociateTypeRootEntityId"
-ORDER BY r."Id" NULLS FIRST, r0."Id" NULLS FIRST, r1."RootEntityId" NULLS FIRST, r2."AssociateTypeRootEntityId" NULLS FIRST, r3."AssociateTypeRootEntityId" NULLS FIRST, r4."AssociateTypeRootEntityId" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, r1."RootEntityId" NULLS FIRST, r2."AssociateTypeRootEntityId" NULLS FIRST, r3."AssociateTypeRootEntityId" NULLS FIRST, r4."AssociateTypeRootEntityId" NULLS FIRST
 """);
         }
     }
@@ -468,7 +468,7 @@ LEFT JOIN LATERAL (
         {
             AssertSql(
                 """
-SELECT r."Id", r5."Id", s."RootEntityId", s."Id", s."Int", s."Ints", s."Name", s."String", s."AssociateTypeRootEntityId", s."AssociateTypeId", s."AssociateTypeRootEntityId0", s."AssociateTypeId0", s."AssociateTypeRootEntityId1", s."AssociateTypeId1", s."Id0", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."Int2", s."Ints2", s."Name2", s."String2", r5.c
+SELECT r."Id", s."RootEntityId", s."Id", s."Int", s."Ints", s."Name", s."String", s."AssociateTypeRootEntityId", s."AssociateTypeId", s."AssociateTypeRootEntityId0", s."AssociateTypeId0", s."AssociateTypeRootEntityId1", s."AssociateTypeId1", s."Id0", s."Int0", s."Ints0", s."Name0", s."String0", s."Id1", s."Int1", s."Ints1", s."Name1", s."String1", s."Id2", s."Int2", s."Ints2", s."Name2", s."String2", r5.c
 FROM "RootEntity" AS r
 LEFT JOIN LATERAL (
     SELECT 1 AS c, r0."Id"
@@ -483,7 +483,7 @@ LEFT JOIN (
     LEFT JOIN "RelatedCollection_RequiredNested" AS r3 ON r1."RootEntityId" = r3."AssociateTypeRootEntityId" AND r1."Id" = r3."AssociateTypeId"
     LEFT JOIN "RelatedCollection_NestedCollection" AS r4 ON r1."RootEntityId" = r4."AssociateTypeRootEntityId" AND r1."Id" = r4."AssociateTypeId"
 ) AS s ON r5."Id" = s."RootEntityId"
-ORDER BY r."Id" NULLS FIRST, r5."Id" NULLS FIRST, s."RootEntityId" NULLS FIRST, s."Id" NULLS FIRST, s."AssociateTypeRootEntityId" NULLS FIRST, s."AssociateTypeId" NULLS FIRST, s."AssociateTypeRootEntityId0" NULLS FIRST, s."AssociateTypeId0" NULLS FIRST, s."AssociateTypeRootEntityId1" NULLS FIRST, s."AssociateTypeId1" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."RootEntityId" NULLS FIRST, s."Id" NULLS FIRST, s."AssociateTypeRootEntityId" NULLS FIRST, s."AssociateTypeId" NULLS FIRST, s."AssociateTypeRootEntityId0" NULLS FIRST, s."AssociateTypeId0" NULLS FIRST, s."AssociateTypeRootEntityId1" NULLS FIRST, s."AssociateTypeId1" NULLS FIRST
 """);
         }
     }

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedTableSplitting/OwnedTableSplittingProjectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedTableSplitting/OwnedTableSplittingProjectionNpgsqlTest.cs
@@ -179,7 +179,7 @@ SELECT r0."Id", r0."RequiredAssociate_Id", r0."RequiredAssociate_Int", r0."Requi
 FROM "RootReferencingEntity" AS r
 LEFT JOIN "RootEntity" AS r0 ON r."RootEntityId" = r0."Id"
 LEFT JOIN "RequiredRelated_NestedCollection" AS r1 ON r0."Id" = r1."AssociateTypeRootEntityId"
-ORDER BY r."Id" NULLS FIRST, r0."Id" NULLS FIRST, r1."AssociateTypeRootEntityId" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, r1."AssociateTypeRootEntityId" NULLS FIRST
 """);
         }
     }
@@ -422,7 +422,7 @@ LEFT JOIN LATERAL (
         {
             AssertSql(
                 """
-SELECT r."Id", r3."Id", s."RootEntityId", s."Id", s."Int", s."Ints", s."Name", s."String", s."AssociateTypeRootEntityId", s."AssociateTypeId", s."Id0", s."Int0", s."Ints0", s."Name0", s."String0", s."OptionalNestedAssociate_Id", s."OptionalNestedAssociate_Int", s."OptionalNestedAssociate_Ints", s."OptionalNestedAssociate_Name", s."OptionalNestedAssociate_String", s."RequiredNestedAssociate_Id", s."RequiredNestedAssociate_Int", s."RequiredNestedAssociate_Ints", s."RequiredNestedAssociate_Name", s."RequiredNestedAssociate_String", r3.c
+SELECT r."Id", s."RootEntityId", s."Id", s."Int", s."Ints", s."Name", s."String", s."AssociateTypeRootEntityId", s."AssociateTypeId", s."Id0", s."Int0", s."Ints0", s."Name0", s."String0", s."OptionalNestedAssociate_Id", s."OptionalNestedAssociate_Int", s."OptionalNestedAssociate_Ints", s."OptionalNestedAssociate_Name", s."OptionalNestedAssociate_String", s."RequiredNestedAssociate_Id", s."RequiredNestedAssociate_Int", s."RequiredNestedAssociate_Ints", s."RequiredNestedAssociate_Name", s."RequiredNestedAssociate_String", r3.c
 FROM "RootEntity" AS r
 LEFT JOIN LATERAL (
     SELECT 1 AS c, r0."Id"
@@ -435,7 +435,7 @@ LEFT JOIN (
     FROM "RelatedCollection" AS r1
     LEFT JOIN "RelatedCollection_NestedCollection" AS r2 ON r1."RootEntityId" = r2."AssociateTypeRootEntityId" AND r1."Id" = r2."AssociateTypeId"
 ) AS s ON r3."Id" = s."RootEntityId"
-ORDER BY r."Id" NULLS FIRST, r3."Id" NULLS FIRST, s."RootEntityId" NULLS FIRST, s."Id" NULLS FIRST, s."AssociateTypeRootEntityId" NULLS FIRST, s."AssociateTypeId" NULLS FIRST
+ORDER BY r."Id" NULLS FIRST, s."RootEntityId" NULLS FIRST, s."Id" NULLS FIRST, s."AssociateTypeRootEntityId" NULLS FIRST, s."AssociateTypeId" NULLS FIRST
 """);
         }
     }

--- a/test/EFCore.PG.FunctionalTests/Query/JsonQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonQueryNpgsqlTest.cs
@@ -2024,7 +2024,7 @@ SELECT j."Id", j."EntityBasicId", j."Name", j."OwnedCollectionRoot", j."OwnedRef
 FROM "JsonEntitiesBasic" AS j
 LEFT JOIN "JsonEntitiesBasicForReference" AS j0 ON j."Id" = j0."ParentId"
 LEFT JOIN "JsonEntitiesBasicForCollection" AS j1 ON j."Id" = j1."ParentId"
-ORDER BY j."Id" NULLS FIRST, j0."Id" NULLS FIRST
+ORDER BY j."Id" NULLS FIRST
 """);
     }
 
@@ -2103,7 +2103,7 @@ SELECT j."OwnedCollectionRoot" -> 0, j."Id", j0."Id", j0."Name", j0."ParentId", 
 FROM "JsonEntitiesBasic" AS j
 LEFT JOIN "JsonEntitiesBasicForReference" AS j0 ON j."Id" = j0."ParentId"
 LEFT JOIN "JsonEntitiesBasicForCollection" AS j1 ON j."Id" = j1."ParentId"
-ORDER BY j."Id" NULLS FIRST, j0."Id" NULLS FIRST
+ORDER BY j."Id" NULLS FIRST
 """);
     }
 
@@ -2117,7 +2117,7 @@ SELECT j."OwnedReferenceRoot" #> '{OwnedReferenceBranch,OwnedCollectionLeaf}', j
 FROM "JsonEntitiesBasic" AS j
 LEFT JOIN "JsonEntitiesBasicForReference" AS j0 ON j."Id" = j0."ParentId"
 LEFT JOIN "JsonEntitiesBasicForCollection" AS j1 ON j."Id" = j1."ParentId"
-ORDER BY j."Id" NULLS FIRST, j0."Id" NULLS FIRST
+ORDER BY j."Id" NULLS FIRST
 """);
 
 //        AssertSql(

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindGroupByQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindGroupByQueryNpgsqlTest.cs
@@ -1383,7 +1383,6 @@ GROUP BY c."CustomerID"
             """
 SELECT o."CustomerID" AS "Key", avg(o."OrderID"::double precision) AS "Average"
 FROM "Orders" AS o
-LEFT JOIN "Customers" AS c ON o."CustomerID" = c."CustomerID"
 GROUP BY o."CustomerID"
 """);
     }
@@ -1409,7 +1408,6 @@ GROUP BY c."CustomerID"
             """
 SELECT o."OrderID" AS "Value", avg(o."OrderID"::double precision) AS "Average"
 FROM "Orders" AS o
-LEFT JOIN "Customers" AS c ON o."CustomerID" = c."CustomerID"
 GROUP BY o."OrderID"
 """);
     }
@@ -3346,7 +3344,6 @@ ORDER BY o."CustomerID" NULLS FIRST
             """
 SELECT o."OrderID" + o."OrderID" AS "Value", avg(o."OrderID"::double precision) AS "Average"
 FROM "Orders" AS o
-LEFT JOIN "Customers" AS c ON o."CustomerID" = c."CustomerID"
 GROUP BY o."OrderID"
 """);
     }
@@ -3409,7 +3406,7 @@ LEFT JOIN LATERAL (
     ) AS o3 ON o1."CustomerID" = o3."CustomerID"
 ) AS s ON TRUE
 WHERE c."CustomerID" LIKE 'F%'
-ORDER BY c."CustomerID" NULLS FIRST, s."CustomerID0" NULLS FIRST
+ORDER BY c."CustomerID" NULLS FIRST
 """);
     }
 
@@ -3878,7 +3875,7 @@ ORDER BY c."City" NULLS FIRST
 
         AssertSql(
             """
-SELECT s1."Key", s3."OrderID", s3."CustomerID", s3."EmployeeID", s3."OrderDate", s3."CustomerID0"
+SELECT s1."Key", s3."OrderID", s3."CustomerID", s3."EmployeeID", s3."OrderDate"
 FROM (
     SELECT s."Key"
     FROM (
@@ -3889,18 +3886,18 @@ FROM (
     GROUP BY s."Key"
 ) AS s1
 LEFT JOIN (
-    SELECT s2."OrderID", s2."CustomerID", s2."EmployeeID", s2."OrderDate", s2."CustomerID0", s2."Key"
+    SELECT s2."OrderID", s2."CustomerID", s2."EmployeeID", s2."OrderDate", s2."Key"
     FROM (
-        SELECT s0."OrderID", s0."CustomerID", s0."EmployeeID", s0."OrderDate", s0."CustomerID0", s0."Key", ROW_NUMBER() OVER(PARTITION BY s0."Key" ORDER BY s0."OrderID" NULLS FIRST, s0."CustomerID0" NULLS FIRST) AS row
+        SELECT s0."OrderID", s0."CustomerID", s0."EmployeeID", s0."OrderDate", s0."Key", ROW_NUMBER() OVER(PARTITION BY s0."Key" ORDER BY s0."OrderID" NULLS FIRST) AS row
         FROM (
-            SELECT o0."OrderID", o0."CustomerID", o0."EmployeeID", o0."OrderDate", c0."CustomerID" AS "CustomerID0", substring(c0."CustomerID", 1, 1) AS "Key"
+            SELECT o0."OrderID", o0."CustomerID", o0."EmployeeID", o0."OrderDate", substring(c0."CustomerID", 1, 1) AS "Key"
             FROM "Orders" AS o0
             LEFT JOIN "Customers" AS c0 ON o0."CustomerID" = c0."CustomerID"
         ) AS s0
     ) AS s2
     WHERE 1 < s2.row AND s2.row <= 3
 ) AS s3 ON s1."Key" = s3."Key"
-ORDER BY s1."Key" NULLS FIRST, s3."OrderID" NULLS FIRST
+ORDER BY s1."Key" NULLS FIRST
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/UpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/UpdatesNpgsqlTest.cs
@@ -29,7 +29,7 @@ public class UpdatesNpgsqlTest : UpdatesRelationalTestBase<UpdatesNpgsqlTest.Upd
             "FK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameTh~",
             entityType.GetForeignKeys().Single().GetConstraintName());
         Assert.Equal(
-            "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameTh~",
+            "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameT~1",
             entityType.GetIndexes().Single().GetDatabaseName());
 
         var entityType2 = context.Model.FindEntityType(
@@ -50,7 +50,7 @@ public class UpdatesNpgsqlTest : UpdatesRelationalTestBase<UpdatesNpgsqlTest.Upd
             "LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatI~",
             entityType2.GetProperties().ElementAt(2).GetColumnName(StoreObjectIdentifier.Table(entityType2.GetTableName()!)));
         Assert.Equal(
-            "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameT~1",
+            "IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameTh~",
             entityType2.GetIndexes().Single().GetDatabaseName());
     }
 


### PR DESCRIPTION
## Summary

Sync to the latest EF Core daily build: `11.0.0-preview.3.26167.112` (from `11.0.0-preview.3.26160.112`).

All **28,602 tests pass** (28,110 functional + 492 unit, 0 failures).

## Changes

- Updated `Directory.Packages.props` to reference EF Core `11.0.0-preview.3.26167.112`
- Updated SQL baselines for navigation/association, bulk update, group-by, and JSON query tests
- Fixed `Identifiers_are_generated_correctly` test for updated constraint name uniquification ordering

## EF Core PRs requiring updates

The following EF Core PRs caused changes that required updates in EFCore.PG:

- **dotnet/efcore#37819** – [Better SQL for to-one joins](https://github.com/dotnet/efcore/pull/37819): Changed SQL generation for navigation/association queries, causing SQL baseline updates across navigation, bulk update, group-by, and JSON query tests.
- **dotnet/efcore#37861** – [Add KeysUniqueAcrossSchemas property to SharedTableConvention](https://github.com/dotnet/efcore/pull/37861): Changed the iteration order in `SharedTableConvention.ProcessModelFinalizing` to sort tables by name within schema groups, which changed which index gets the uniquifier suffix when truncated names collide.