### PR TITLE
Sync to EF 11.0.0-preview.3.26174.112

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.3.26167.112</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.3.26167.112</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26167.112</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.3.26174.112</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.3.26174.112</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26174.112</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
@@ -667,6 +667,18 @@ WHERE c."CustomerID" LIKE 'F%'
 """);
     }
 
+    public override async Task Update_Where_set_nullable_int_constant_via_discard_lambda(bool async)
+    {
+        await base.Update_Where_set_nullable_int_constant_via_discard_lambda(async);
+
+        AssertExecuteUpdateSql(
+            """
+UPDATE "Products" AS p
+SET "SupplierID" = 1
+WHERE p."ProductID" < 5
+""");
+    }
+
     public override async Task Update_Where_parameter_set_constant(bool async)
     {
         await base.Update_Where_parameter_set_constant(async);

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionNpgsqlTest.cs
@@ -226,6 +226,24 @@ WHERE (CAST(r."RequiredAssociate" #>> '{NestedCollection,0,Int}' AS integer)) = 
 """);
     }
 
+    public override async Task Project_struct_complex_type_with_entity_collection_navigation()
+    {
+        await base.Project_struct_complex_type_with_entity_collection_navigation();
+
+        AssertSql(
+            """
+SELECT p0."Coords_X", p0."Coords_Y", p0."Id", c."Id", c."Name", c."ParentId"
+FROM (
+    SELECT p."Coords_X", p."Coords_Y", p."Id"
+    FROM "Parent" AS p
+    ORDER BY p."Id" NULLS FIRST
+    LIMIT 1
+) AS p0
+LEFT JOIN "Child" AS c ON p0."Id" = c."ParentId"
+ORDER BY p0."Id" NULLS FIRST
+""");
+    }
+
     [ConditionalFact]
     public virtual void Check_all_tests_overridden()
         => TestHelpers.AssertAllMethodsOverridden(GetType());


### PR DESCRIPTION
Update EF Core daily build from `11.0.0-preview.3.26167.112` to `11.0.0-preview.3.26174.112`.

## Changes

- Updated `EFCoreVersion`, `MicrosoftExtensionsVersion`, and `MicrosoftExtensionsConfigurationVersion` in `Directory.Packages.props`
- Added missing test overrides for new EF Core tests:
  - `NorthwindBulkUpdatesNpgsqlTest.Update_Where_set_nullable_int_constant_via_discard_lambda`
  - `ComplexJsonCollectionNpgsqlTest.Project_struct_complex_type_with_entity_collection_navigation`

## EF Core PRs requiring changes in EFCore.PG

- [dotnet/efcore#37975](https://github.com/dotnet/efcore/pull/37975) — Fix SetProperty discard lambda failing for nullable value type properties in ExecuteUpdate (added `Update_Where_set_nullable_int_constant_via_discard_lambda` test)
- [dotnet/efcore#37934](https://github.com/dotnet/efcore/pull/37934) — Fix struct complex type boxing in collection materialization (added `Project_struct_complex_type_with_entity_collection_navigation` test)

## Test results

All tests pass:
- **Unit tests**: 492 passed, 6 skipped
- **Functional tests**: 28,117 passed, 273 skipped, 0 failures