### PR TITLE
Sync to EF 11.0.0-preview.3.26203.107

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.3.26174.112</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.3.26174.112</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26174.112</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.3.26203.107</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.1.26104.118",
+    "version": "11.0.100-preview.2.26159.112",
     "rollForward": "latestMinor",
     "allowPrerelease": true
   }

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/StringTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/StringTranslationsNpgsqlTest.cs
@@ -215,6 +215,20 @@ WHERE strpos('12559', b."Int"::text) - 1 = 1
 """);
     }
 
+    public override async Task IndexOf_with_non_string_column_using_double_cast()
+    {
+        await base.IndexOf_with_non_string_column_using_double_cast();
+
+        AssertSql(
+            """
+@pattern='5'
+
+SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
+FROM "BasicTypesEntities" AS b
+WHERE strpos(b."Int"::text, @pattern) - 1 <> -1
+""");
+    }
+
     #endregion IndexOf
 
     #region Replace
@@ -256,6 +270,18 @@ WHERE b."String" <> '' AND replace(b."String", b."String", '') = ''
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."String" <> '' AND replace(b."String", b."String", b."Int"::text) = b."Int"::text
+""");
+    }
+
+    public override async Task Replace_with_non_string_column_using_double_cast()
+    {
+        await base.Replace_with_non_string_column_using_double_cast();
+
+        AssertSql(
+            """
+SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
+FROM "BasicTypesEntities" AS b
+WHERE replace(b."Int"::text, '8', '3') = '3'
 """);
     }
 


### PR DESCRIPTION
Updates the EF Core dependency from `11.0.0-preview.3.26174.112` to `11.0.0-preview.3.26203.107`, and the .NET SDK from `11.0.100-preview.1` to `11.0.100-preview.2`.

## Changes

- Updated `EFCoreVersion`, `MicrosoftExtensionsVersion`, and `MicrosoftExtensionsConfigurationVersion` in `Directory.Packages.props`
- Updated SDK version in `global.json` to `11.0.100-preview.2.26159.112`
- Added 2 new test overrides in `StringTranslationsNpgsqlTest` to match new tests added in the EF base class

## EF PRs requiring changes

- dotnet/efcore#37956 - Fix NullReferenceException in SqlServerStringMethodTranslator.TranslateIndexOf for casted parameters (added `IndexOf_with_non_string_column_using_double_cast` and `Replace_with_non_string_column_using_double_cast` tests)

## Test results

All 28,535 tests pass (0 failures, 279 skipped).