### PR TITLE
Sync to EF 11.0.0-preview.4.26203.108

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.3.26203.107</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.3.26203.107</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.4.26203.108</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.4.26203.108</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.4.26203.108</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Updates the EF Core dependency from `11.0.0-preview.3.26203.107` to `11.0.0-preview.4.26203.108`.

## Changes

- Bumped `EFCoreVersion`, `MicrosoftExtensionsVersion`, and `MicrosoftExtensionsConfigurationVersion` in `Directory.Packages.props` to `11.0.0-preview.4.26203.108`.

## Validation

- Build: ✅ succeeded with 0 warnings and 0 errors
- Unit tests (`EFCore.PG.Tests`): ✅ 495 passed, 6 skipped, 0 failed
- Functional tests (`EFCore.PG.FunctionalTests`): ✅ 27,766 passed, 273 skipped, 0 failed

## EF Core PRs requiring changes

No breaking changes were encountered — the version bump was clean with no code modifications needed.