### PR TITLE
Sync to EF 11.0.0-preview.4.26215.121

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.4.26210.110</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.4.26210.110</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.4.26210.110</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.4.26215.121</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.4.26215.121</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.4.26215.121</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 

--- a/src/EFCore.PG/Migrations/Internal/NpgsqlHistoryRepository.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlHistoryRepository.cs
@@ -11,8 +11,6 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations.Internal;
 /// </summary>
 public class NpgsqlHistoryRepository : HistoryRepository, IHistoryRepository
 {
-    private IModel? _model;
-
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -111,7 +109,9 @@ public class NpgsqlHistoryRepository : HistoryRepository, IHistoryRepository
         // Note that the approach in EF is to remove specific conventions (e.g. DbSetFindingConvention), but we don't want to hardcode
         // specific conventions here; for example, the NetTopologySuite plugin has its NpgsqlNetTopologySuiteExtensionAddingConvention
         // which adds PostGIS. So we just filter out the annotations on the operations themselves.
+#pragma warning disable EF1001 // Internal EF Core API usage.
         var model = EnsureModel();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         var operations = Dependencies.ModelDiffer.GetDifferences(null, model.GetRelationalModel());
 
@@ -133,30 +133,6 @@ public class NpgsqlHistoryRepository : HistoryRepository, IHistoryRepository
         }
 
         return Dependencies.MigrationsSqlGenerator.Generate(operations, model);
-    }
-
-    // Copied as-is from EF's HistoryRepository, since it's private (see https://github.com/dotnet/efcore/issues/34991)
-    private IModel EnsureModel()
-    {
-        if (_model == null)
-        {
-            var conventionSet = Dependencies.ConventionSetBuilder.CreateConventionSet();
-
-            conventionSet.Remove(typeof(DbSetFindingConvention));
-            conventionSet.Remove(typeof(RelationalDbFunctionAttributeConvention));
-
-            var modelBuilder = new ModelBuilder(conventionSet);
-            modelBuilder.Entity<HistoryRow>(x =>
-            {
-                ConfigureTable(x);
-                x.ToTable(TableName, TableSchema);
-            });
-
-            _model = Dependencies.ModelRuntimeInitializer.Initialize(
-                (IModel)modelBuilder.Model, designTime: true, validationLogger: null);
-        }
-
-        return _model;
     }
 
     bool IHistoryRepository.CreateIfNotExists()

--- a/test/EFCore.PG.FunctionalTests/JsonTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/JsonTypesNpgsqlTest.cs
@@ -155,14 +155,14 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
     // Cannot override since the base test contains [InlineData] attributes which still apply, and which contain data we need
     // to override. See Can_read_write_nullable_TimeSpan_JSON_values_npgsql instead.
     // TODO: Implement Can_read_write_collection_of_TimeSpan_JSON_values_npgsql
-    public override Task Can_read_write_collection_of_TimeSpan_JSON_values()
+    public override Task Can_read_write_collection_of_TimeSpan_JSON_values(string expected)
         => Task.CompletedTask;
 
     // Cannot override since the base test contains [InlineData] attributes which still apply, and which contain data we need
     // to override. See Can_read_write_nullable_TimeSpan_JSON_values_npgsql instead.
     // TODO: Implement Can_read_write_collection_of_nullable_TimeSpan_JSON_values_npgsql
-    public override Task Can_read_write_collection_of_nullable_TimeSpan_JSON_values()
-    => Task.CompletedTask;
+    public override Task Can_read_write_collection_of_nullable_TimeSpan_JSON_values(string expected)
+        => Task.CompletedTask;
 
     #endregion TimeSpan
 

--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -2355,6 +2355,63 @@ ORDER BY p."Id" NULLS FIRST
         AssertSql();
     }
 
+    public override async Task Parameter_collection_of_enum_Cast_from_different_enum_type(ParameterTranslationMode mode)
+    {
+        await base.Parameter_collection_of_enum_Cast_from_different_enum_type(mode);
+
+        switch (mode)
+        {
+            case ParameterTranslationMode.Constant:
+            {
+                AssertSql(
+                    """
+SELECT t."Id"
+FROM "TestEntity38008" AS t
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (2::int)) AS f("Value")
+    WHERE f."Value" = t."Status")
+""");
+                break;
+            }
+
+            case ParameterTranslationMode.Parameter:
+            {
+                AssertSql(
+                    """
+@filter={ '2' } (DbType = Object)
+
+SELECT t."Id"
+FROM "TestEntity38008" AS t
+WHERE EXISTS (
+    SELECT 1
+    FROM unnest(@filter) AS f(value)
+    WHERE f.value = t."Status")
+""");
+                break;
+            }
+
+            case ParameterTranslationMode.MultipleParameters:
+            {
+                AssertSql(
+                    """
+@filter1='2'
+
+SELECT t."Id"
+FROM "TestEntity38008" AS t
+WHERE EXISTS (
+    SELECT 1
+    FROM (VALUES (@filter1)) AS f("Value")
+    WHERE f."Value" = t."Status")
+""");
+                break;
+            }
+
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
     public override async Task Nested_contains_with_Lists_and_no_inferred_type_mapping()
     {
         await base.Nested_contains_with_Lists_and_no_inferred_type_mapping();

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/Temporal/DateTimeOffsetTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/Temporal/DateTimeOffsetTranslationsNpgsqlTest.cs
@@ -139,6 +139,34 @@ FROM "BasicTypesEntities" AS b
 """);
     }
 
+    public override async Task DateTime()
+    {
+        await base.DateTime();
+
+        AssertSql(
+            """
+SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
+FROM "BasicTypesEntities" AS b
+WHERE b."DateTimeOffset" AT TIME ZONE 'UTC' = TIMESTAMP '1998-05-04T15:30:10'
+""");
+    }
+
+    // The base test compares DateTimeOffset.UtcDateTime with an Unspecified DateTime, which Npgsql can't generate as a timestamptz literal
+    public override Task UtcDateTime()
+        => Assert.ThrowsAsync<ArgumentException>(() => base.UtcDateTime());
+
+    public override async Task LocalDateTime()
+    {
+        await base.LocalDateTime();
+
+        AssertSql(
+            """
+SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
+FROM "BasicTypesEntities" AS b
+WHERE b."DateTimeOffset"::timestamp > TIMESTAMP '1999-01-01T00:00:00'
+""");
+    }
+
     public override async Task AddYears()
     {
         await base.AddYears();
@@ -221,6 +249,15 @@ FROM "BasicTypesEntities" AS b
 
     public override Task ToUnixTimeSecond()
         => AssertTranslationFailed(() => base.ToUnixTimeSecond());
+
+    public override Task ToOffset()
+        => AssertTranslationFailed(() => base.ToOffset());
+
+    public override Task Ctor_DateTime()
+        => AssertTranslationFailed(() => base.Ctor_DateTime());
+
+    public override Task Ctor_DateTime_TimeSpan()
+        => AssertTranslationFailed(() => base.Ctor_DateTime_TimeSpan());
 
     public override async Task Milliseconds_parameter_and_constant()
     {


### PR DESCRIPTION
Syncs EFCore.PG to use EF Core daily build `11.0.0-preview.4.26215.121` (from `11.0.0-preview.4.26210.110`).

## Changes

- **Directory.Packages.props**: Updated EFCoreVersion and MicrosoftExtensionsVersion to `11.0.0-preview.4.26215.121`
- **NpgsqlHistoryRepository.cs**: Removed the copied `EnsureModel()` method — the base class `HistoryRepository.EnsureModel()` is now `protected virtual` instead of `private`
- **DateTimeOffsetTranslationsNpgsqlTest.cs**: Added overrides for 6 new base test methods (`DateTime`, `UtcDateTime`, `LocalDateTime`, `ToOffset`, `Ctor_DateTime`, `Ctor_DateTime_TimeSpan`)
- **PrimitiveCollectionsQueryNpgsqlTest.cs**: Added override for new `Parameter_collection_of_enum_Cast_from_different_enum_type` test
- **JsonTypesNpgsqlTest.cs**: Updated signatures for `Can_read_write_collection_of_TimeSpan_JSON_values` and `Can_read_write_collection_of_nullable_TimeSpan_JSON_values` (added `string expected` parameter)

## EF Core PRs that required changes

- dotnet/efcore#38050 — Filter out full-text catalog operations from history table creation (made `HistoryRepository.EnsureModel()` protected virtual)
- dotnet/efcore#38076 — Additional translations for SQL Server DateTimeOffset (added new DateTimeOffset translation tests)
- dotnet/efcore#38024 — Cosmos: Modernize JSON serialization (changed collection JSON test signatures)
- dotnet/efcore#38021 — Fix InvalidCastException when query parameter is IEnumerable with mismatched enum types (added `Parameter_collection_of_enum_Cast_from_different_enum_type` test)

## Test results

- Unit tests: 495 passed, 6 skipped
- Functional tests: 28,167 passed, 273 skipped, 0 failures