### PR TITLE
Translate `bytea.Any()` as `length > 0`

### DIFF
--- a/src/EFCore.PG/Internal/EnumerableMethods.cs
+++ b/src/EFCore.PG/Internal/EnumerableMethods.cs
@@ -10,7 +10,7 @@ internal static class EnumerableMethods
 
     public static MethodInfo All { get; }
 
-    // public static MethodInfo AnyWithoutPredicate { get; }
+    public static MethodInfo AnyWithoutPredicate { get; }
 
     public static MethodInfo AnyWithPredicate { get; }
 
@@ -259,8 +259,9 @@ internal static class EnumerableMethods
             nameof(Enumerable.All), 1,
             types => [typeof(IEnumerable<>).MakeGenericType(types[0]), typeof(Func<,>).MakeGenericType(types[0], typeof(bool))]);
 
-        // AnyWithoutPredicate = GetMethod(nameof(Enumerable.Any), 1,
-        //     types => new[] { typeof(IEnumerable<>).MakeGenericType(types[0]) });
+        AnyWithoutPredicate = GetMethod(
+            nameof(Enumerable.Any), 1,
+            types => [typeof(IEnumerable<>).MakeGenericType(types[0])]);
 
         AnyWithPredicate = GetMethod(
             nameof(Enumerable.Any), 1,

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
@@ -46,18 +46,6 @@ public class NpgsqlByteArrayMethodTranslator : IMethodCallTranslator
             // Note: we only translate if the array argument is a column mapped to bytea. There are various other
             // cases (e.g. Where(b => new byte[] { 1, 2, 3 }.Contains(b.SomeByte))) where we prefer to translate via
             // regular PostgreSQL array logic.
-            if (method.GetGenericMethodDefinition().Equals(EnumerableMethods.AnyWithoutPredicate))
-            {
-                return _sqlExpressionFactory.GreaterThan(
-                    _sqlExpressionFactory.Function(
-                        "length",
-                        [arguments[0]],
-                        nullable: true,
-                        argumentsPropagateNullability: TrueArrays[1],
-                        typeof(int)),
-                    _sqlExpressionFactory.Constant(0));
-            }
-
             if (method.GetGenericMethodDefinition().Equals(EnumerableMethods.Contains))
             {
                 var source = arguments[0];
@@ -88,6 +76,18 @@ public class NpgsqlByteArrayMethodTranslator : IMethodCallTranslator
                         builtIn: true,
                         typeof(int),
                         null),
+                    _sqlExpressionFactory.Constant(0));
+            }
+
+            if (method.GetGenericMethodDefinition().Equals(EnumerableMethods.AnyWithoutPredicate))
+            {
+                return _sqlExpressionFactory.GreaterThan(
+                    _sqlExpressionFactory.Function(
+                        "length",
+                        [arguments[0]],
+                        nullable: true,
+                        argumentsPropagateNullability: TrueArrays[1],
+                        typeof(int)),
                     _sqlExpressionFactory.Constant(0));
             }
 

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
@@ -46,6 +46,18 @@ public class NpgsqlByteArrayMethodTranslator : IMethodCallTranslator
             // Note: we only translate if the array argument is a column mapped to bytea. There are various other
             // cases (e.g. Where(b => new byte[] { 1, 2, 3 }.Contains(b.SomeByte))) where we prefer to translate via
             // regular PostgreSQL array logic.
+            if (method.GetGenericMethodDefinition().Equals(EnumerableMethods.AnyWithoutPredicate))
+            {
+                return _sqlExpressionFactory.GreaterThan(
+                    _sqlExpressionFactory.Function(
+                        "length",
+                        [arguments[0]],
+                        nullable: true,
+                        argumentsPropagateNullability: TrueArrays[1],
+                        typeof(int)),
+                    _sqlExpressionFactory.Constant(0));
+            }
+
             if (method.GetGenericMethodDefinition().Equals(EnumerableMethods.Contains))
             {
                 var source = arguments[0];

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
@@ -50,7 +50,7 @@ public class NpgsqlByteArrayMethodTranslator : IMethodCallTranslator
             {
                 return _sqlExpressionFactory.GreaterThan(
                     _sqlExpressionFactory.Function(
-                        "octet_length",
+                        "length",
                         [arguments[0]],
                         nullable: true,
                         argumentsPropagateNullability: TrueArrays[1],

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlByteArrayMethodTranslator.cs
@@ -50,7 +50,7 @@ public class NpgsqlByteArrayMethodTranslator : IMethodCallTranslator
             {
                 return _sqlExpressionFactory.GreaterThan(
                     _sqlExpressionFactory.Function(
-                        "length",
+                        "octet_length",
                         [arguments[0]],
                         nullable: true,
                         argumentsPropagateNullability: TrueArrays[1],

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
@@ -679,6 +679,19 @@ WHERE cardinality(s."IntArray") = 2
 """);
     }
 
+    [ConditionalFact]
+    public virtual async Task Bytea_Length_greater_than_zero()
+    {
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.Bytea.Length > 0));
+
+        AssertSql(
+            """
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE length(s."Bytea") > 0
+""");
+    }
+
     #endregion Length/Count
 
     #region Any/All

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
@@ -688,7 +688,7 @@ WHERE cardinality(s."IntArray") = 2
             """
 SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
 FROM "SomeEntities" AS s
-WHERE length(s."Bytea") > 0
+WHERE octet_length(s."Bytea") > 0
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
@@ -679,19 +679,6 @@ WHERE cardinality(s."IntArray") = 2
 """);
     }
 
-    [ConditionalFact]
-    public virtual async Task Bytea_Length_greater_than_zero()
-    {
-        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.Bytea.Length > 0));
-
-        AssertSql(
-            """
-SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
-FROM "SomeEntities" AS s
-WHERE length(s."Bytea") > 0
-""");
-    }
-
     #endregion Length/Count
 
     #region Any/All

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
@@ -688,7 +688,7 @@ WHERE cardinality(s."IntArray") = 2
             """
 SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
 FROM "SomeEntities" AS s
-WHERE octet_length(s."Bytea") > 0
+WHERE length(s."Bytea") > 0
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
@@ -101,19 +101,6 @@ WHERE b."ByteArray" = @byteArrayParam
     }
 
     [ConditionalFact]
-    public virtual async Task Length_greater_than_zero()
-    {
-        await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Length > 0));
-
-        AssertSql(
-"""
-SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
-FROM "BasicTypesEntities" AS b
-WHERE length(b."ByteArray") > 0
-""");
-    }
-
-    [ConditionalFact]
     public virtual async Task Any()
     {
         await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Any()));

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore.TestModels.BasicTypesModel;
+
 namespace Microsoft.EntityFrameworkCore.Query.Translations;
 
 public class ByteArrayTranslationsNpgsqlTest : ByteArrayTranslationsTestBase<BasicTypesQueryNpgsqlFixture>
@@ -95,6 +97,32 @@ WHERE position(set_byte(BYTEA E'\\x00', 0, b."Byte") IN b."ByteArray") > 0
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."ByteArray" = @byteArrayParam
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Length_greater_than_zero()
+    {
+        await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Length > 0));
+
+        AssertSql(
+"""
+SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
+FROM "BasicTypesEntities" AS b
+WHERE length(b."ByteArray") > 0
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Any()
+    {
+        await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Any()));
+
+        AssertSql(
+"""
+SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
+FROM "BasicTypesEntities" AS b
+WHERE length(b."ByteArray") > 0
 """);
     }
 


### PR DESCRIPTION
Fixes #3816 

~~I opted for `octet_length` here because it communicates clearly that it is about byte length, not text length.~~

Let me know if this goes in the right direction and/or if I should change something.

Have a nice weekend!

(Note that I chose [hotfix/10.0.2](https://github.com/npgsql/efcore.pg/tree/hotfix/10.0.2) as target branch; mostly because executing the test suite with an unreleased preview sdk was somewhat hard to setup)