### PR TITLE
Fix SQL baseline for Parameter_collection_Concat_column_collection test

### DIFF
--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -1432,11 +1432,11 @@ WHERE (
 
         AssertSql(
             """
-@__ints_0={ '11', '111' } (DbType = Object)
+@__p_0={ '11', '111' } (DbType = Object)
 
 SELECT p."Id", p."Bool", p."Bools", p."DateTime", p."DateTimes", p."Enum", p."Enums", p."Int", p."Ints", p."NullableInt", p."NullableInts", p."NullableString", p."NullableStrings", p."String", p."Strings"
 FROM "PrimitiveCollectionsEntity" AS p
-WHERE cardinality(@__ints_0 || p."Ints") = 2
+WHERE cardinality(@__p_0 || p."Ints") = 2
 """);
     }
 


### PR DESCRIPTION
Fix the CI failure on `hotfix/9.0.5` by updating the `AssertSql` baseline in `Parameter_collection_Concat_column_collection`.

The expected parameter name changed from `@__ints_0` to `@__p_0` in the EF Core base test, but the baseline in EFCore.PG wasn't updated to match.

Fixes the test failure seen in https://github.com/npgsql/efcore.pg/actions/runs/24957846612