### PR TITLE
Add missing test overrides for Contains_on_Enumerable/MemoryExtensions

### DIFF
--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -898,6 +898,30 @@ WHERE p."Bools" @> ARRAY[TRUE]::boolean[]
 """);
     }
 
+    public override async Task Contains_on_Enumerable(bool async)
+    {
+        await base.Contains_on_Enumerable(async);
+
+        AssertSql(
+            """
+SELECT p."Id", p."Bool", p."Bools", p."DateTime", p."DateTimes", p."Enum", p."Enums", p."Int", p."Ints", p."NullableInt", p."NullableInts", p."NullableString", p."NullableStrings", p."String", p."Strings"
+FROM "PrimitiveCollectionsEntity" AS p
+WHERE p."Int" IN (10, 999)
+""");
+    }
+
+    public override async Task Contains_on_MemoryExtensions(bool async)
+    {
+        await base.Contains_on_MemoryExtensions(async);
+
+        AssertSql(
+            """
+SELECT p."Id", p."Bool", p."Bools", p."DateTime", p."DateTimes", p."Enum", p."Enums", p."Int", p."Ints", p."NullableInt", p."NullableInts", p."NullableString", p."NullableStrings", p."String", p."Strings"
+FROM "PrimitiveCollectionsEntity" AS p
+WHERE p."Int" IN (10, 999)
+""");
+    }
+
     public override async Task Column_collection_Count_method(bool async)
     {
         await base.Column_collection_Count_method(async);


### PR DESCRIPTION
EF Core 9.0.14 added `Contains_on_Enumerable` and `Contains_on_MemoryExtensions` to `PrimitiveCollectionsQueryTestBase` (for C# 14 first-class span support). This adds the required overrides with SQL assertions to `PrimitiveCollectionsQueryNpgsqlTest`, fixing the `Check_all_tests_overridden` failure on all CI jobs.

Fixes the CI failure at https://github.com/npgsql/efcore.pg/actions/runs/24959840704.