### PR TITLE
Sync to EF 11.0.0-preview.4.26224.122

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.4.26215.121</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.4.26215.121</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.4.26215.121</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.4.26224.122</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.4.26224.122</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.4.26224.122</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Bumps EF Core dependency from `11.0.0-preview.4.26215.121` to `11.0.0-preview.4.26224.122`.

Clean sync — no code changes were required (builds and all tests pass).

### Notable EF Core PRs in this range

No EF changes required updates in EFCore.PG. For reference, notable EF PRs merged since the previous sync include:

* dotnet/efcore#38145 — Remove pre-v11 obsolete APIs
* dotnet/efcore#38157 — Add support for file-based apps to dotnet-ef tools
* dotnet/efcore#38155 — Better error when using EF.Constant/Parameter with compiled queries or query filters
* dotnet/efcore#38133 — Refactor CommandBatchPreparer
* dotnet/efcore#38070 — Fix insert order bug when using TPC (#35978)
* dotnet/efcore#38115 — Fix .Update() marking AfterSaveBehavior.Throw properties as modified via DetectChanges
* dotnet/efcore#38114 — Add NuGet dependency version bounds for EF Core inter-package references
* dotnet/efcore#38110 — Allow temporal period properties to be mapped to CLR properties
* dotnet/efcore#37966 — Add dotnet-ef JSON config defaults and validation features