### PR TITLE
Sync to EF 11.0.0-preview.5.26227.124

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.4.26224.122</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.4.26224.122</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.4.26224.122</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.5.26227.124</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.5.26227.124</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26227.124</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -34,10 +34,6 @@ public class TestRelationalCommandBuilderFactory(RelationalCommandBuilderDepende
             return this;
         }
 
-        [Obsolete("Code trying to add parameter should add type mapped parameter using TypeMappingSource directly.")]
-        public IRelationalTypeMappingSource TypeMappingSource
-            => Dependencies.TypeMappingSource;
-
         public IRelationalCommand Build()
             => new TestRelationalCommand(
                 Dependencies,

--- a/test/EFCore.PG.FunctionalTests/TransactionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/TransactionNpgsqlTest.cs
@@ -11,13 +11,6 @@ public class TransactionNpgsqlTest(TransactionNpgsqlTest.TransactionNpgsqlFixtur
         // (see https://github.com/npgsql/npgsql/issues/1307)
         => Task.CompletedTask;
 
-#pragma warning disable CS0618 // AutoTransactionsEnabled is obsolete
-    public override Task SaveChanges_can_be_used_with_AutoTransactionsEnabled_false(bool async)
-        // Npgsql batches the inserts, creating an implicit transaction which fails the test
-        // (see https://github.com/npgsql/npgsql/issues/1307)
-        => Task.CompletedTask;
-#pragma warning restore CS0618
-
     protected override DbContext CreateContextWithConnectionString()
     {
         var options = Fixture.AddOptions(


### PR DESCRIPTION
Syncs EFCore.PG to the latest EF Core daily build for preview.5: `11.0.0-preview.5.26227.124`.

## Changes

- Updated `EFCoreVersion`, `MicrosoftExtensionsVersion`, and `MicrosoftExtensionsConfigurationVersion` to `11.0.0-preview.5.26227.124`
- Removed `SaveChanges_can_be_used_with_AutoTransactionsEnabled_false` test override (obsolete API removed)
- Removed `TypeMappingSource` property from `TestRelationalCommandBuilder` (removed from `RelationalCommandBuilderDependencies` and `IRelationalCommandBuilder`)

## EF Core PRs that required changes

- https://github.com/dotnet/efcore/pull/38145 — Remove pre-v11 obsolete APIs

## Test results

- Unit tests: 501 total, 495 passed, 6 skipped, 0 failed
- Functional tests: 28,451 total, 28,177 passed, 273 skipped, 1 failed (pre-existing infrastructure issue with `DefaultValuesTest.Can_use_Npgsql_default_values` — unrelated to EF sync)