### PR TITLE
Fix nullability of IncludeProperties includeExpression parameter

### DIFF
--- a/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlIndexBuilderExtensions.cs
+++ b/src/EFCore.PG/Extensions/BuilderExtensions/NpgsqlIndexBuilderExtensions.cs
@@ -526,7 +526,7 @@ public static class NpgsqlIndexBuilderExtensions
     /// <returns>A builder to further configure the index.</returns>
     public static IndexBuilder<TEntity> IncludeProperties<TEntity>(
         this IndexBuilder<TEntity> indexBuilder,
-        Expression<Func<TEntity, object>> includeExpression)
+        Expression<Func<TEntity, object?>> includeExpression)
     {
         Check.NotNull(indexBuilder, nameof(indexBuilder));
         Check.NotNull(includeExpression, nameof(includeExpression));


### PR DESCRIPTION
Fixes #3825

The `IncludeProperties` overload accepting an expression had its parameter typed as `Expression<Func<TEntity, object>>`, but it should be `Expression<Func<TEntity, object?>>` (nullable `object`). This matches the SQL Server provider's equivalent API (`SqlServerIndexBuilderExtensions.IncludeProperties`).