### PR TITLE
Sync to EF 11.0.0-preview.5.26251.112

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.5.26227.124</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.5.26227.124</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26227.124</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.5.26251.112</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.5.26251.112</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26251.112</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 

--- a/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMemberTranslatorPlugin.cs
@@ -193,7 +193,8 @@ public class NpgsqlNodaTimeMemberTranslator(
                 => _sqlExpressionFactory.Convert(
                     _sqlExpressionFactory.Subtract(
                         Upper(),
-                        _sqlExpressionFactory.Constant(Period.FromDays(1), _periodTypeMapping)), typeof(LocalDate),
+                        _sqlExpressionFactory.Constant(Period.FromDays(1), _periodTypeMapping),
+                        _typeMappingSource.FindMapping(typeof(LocalDateTime))), typeof(LocalDate),
                     _typeMappingSource.FindMapping(typeof(LocalDate))),
 
             nameof(DateInterval.Length) => _sqlExpressionFactory.Subtract(Upper(), Lower()),

--- a/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQuerySqlGenerator.cs
@@ -889,6 +889,14 @@ public class NpgsqlQuerySqlGenerator : QuerySqlGenerator
 
         Visit(expression.Array);
 
+        // When the array operand is a scalar subquery, PostgreSQL interprets = ANY(subquery) as a subquery comparison
+        // (comparing against each row), not as an array comparison. We need to add an explicit cast to force
+        // PostgreSQL to treat it as an array expression (see #1803).
+        if (expression.Array is ScalarSubqueryExpression { TypeMapping.StoreType: var storeType })
+        {
+            Sql.Append("::").Append(storeType);
+        }
+
         Sql.Append(")");
 
         return expression;

--- a/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -719,14 +719,14 @@ public class NpgsqlQueryableMethodTranslatingExpressionVisitor : RelationalQuery
 
                     // Similar to ParameterExpression below, but when a bare subquery is present inside ANY(), PostgreSQL just compares
                     // against each of its resulting rows (just like IN). To "extract" the array result of the scalar subquery, we need
-                    // to add an explicit cast (see #1803).
+                    // to add an explicit cast (see #1803). This is handled in the SQL generator (VisitArrayAny) rather than via
+                    // SqlUnaryExpression(Convert), since it's a same-type cast that would be removed by EF's simplifier.
                     ScalarSubqueryExpression subqueryExpression
                         => BuildSimplifiedShapedQuery(
                             source,
                             _sqlExpressionFactory.Any(
                                 translatedItem,
-                                _sqlExpressionFactory.Convert(
-                                    subqueryExpression, subqueryExpression.Type, subqueryExpression.TypeMapping),
+                                subqueryExpression,
                                 PgAnyOperatorType.Equal)),
 
                     // For ParameterExpression, and for all other cases - e.g. array returned from some function -

--- a/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
@@ -447,7 +447,7 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
             {
                 var newLeft = ApplyTypeMapping(left, typeMapping);
                 var newRight = ApplyDefaultTypeMapping(right);
-                return new SqlBinaryExpression(binary.OperatorType, newLeft, newRight, binary.Type, newLeft.TypeMapping);
+                return new SqlBinaryExpression(binary.OperatorType, newLeft, newRight, binary.Type, typeMapping ?? newLeft.TypeMapping);
             }
 
             // DateTime - DateTime => TimeSpan

--- a/src/EFCore.PG/Update/Internal/NpgsqlUpdateSqlGenerator.cs
+++ b/src/EFCore.PG/Update/Internal/NpgsqlUpdateSqlGenerator.cs
@@ -166,7 +166,7 @@ public class NpgsqlUpdateSqlGenerator : UpdateSqlGenerator
 
                 if (segment.IsArray)
                 {
-                    stringBuilder.Append(jsonPath.Ordinals[ordinalIndex++]);
+                    stringBuilder.Append(jsonPath.Indices[ordinalIndex++]);
                 }
                 else
                 {

--- a/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/GearsOfWarQueryNpgsqlTest.cs
@@ -50,7 +50,7 @@ WHERE length(s."Banner5") = 5
 
 SELECT m."Id", m."CodeName", m."Date", m."Difficulty", m."Duration", m."Rating", m."Time", m."Timeline"
 FROM "Missions" AS m
-WHERE date_trunc('day', m."Timeline" AT TIME ZONE 'UTC')::timestamp >= @dateTimeOffset_Date
+WHERE date_trunc('day', m."Timeline" AT TIME ZONE 'UTC') >= @dateTimeOffset_Date
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPCGearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPCGearsOfWarQueryNpgsqlTest.cs
@@ -64,7 +64,7 @@ WHERE @start <= date_trunc('day', m."Timeline" AT TIME ZONE 'UTC')::timestamptz 
 
 SELECT m."Id", m."CodeName", m."Date", m."Difficulty", m."Duration", m."Rating", m."Time", m."Timeline"
 FROM "Missions" AS m
-WHERE date_trunc('day', m."Timeline" AT TIME ZONE 'UTC')::timestamp >= @dateTimeOffset_Date
+WHERE date_trunc('day', m."Timeline" AT TIME ZONE 'UTC') >= @dateTimeOffset_Date
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPTGearsOfWarQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPTGearsOfWarQueryNpgsqlTest.cs
@@ -68,7 +68,7 @@ WHERE @start <= date_trunc('day', m."Timeline" AT TIME ZONE 'UTC')::timestamptz 
 
 SELECT m."Id", m."CodeName", m."Date", m."Difficulty", m."Duration", m."Rating", m."Time", m."Timeline"
 FROM "Missions" AS m
-WHERE date_trunc('day', m."Timeline" AT TIME ZONE 'UTC')::timestamp >= @dateTimeOffset_Date
+WHERE date_trunc('day', m."Timeline" AT TIME ZONE 'UTC') >= @dateTimeOffset_Date
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindSqlQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindSqlQueryNpgsqlTest.cs
@@ -43,11 +43,11 @@ WHERE o."OrderID" IN (
 
         AssertSql(
             """
-SELECT o."OrderID", o."CustomerID", o."EmployeeID", o."OrderDate", s."Value"::int AS p
+SELECT o."OrderID", o."CustomerID", o."EmployeeID", o."OrderDate", s."Value" AS p
 FROM "Orders" AS o
 INNER JOIN (
     SELECT "ProductID" AS "Value" FROM "Products"
-) AS s ON o."OrderID" = s."Value"::int
+) AS s ON o."OrderID" = s."Value"
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -411,7 +411,7 @@ SELECT p."Id", p."Bool", p."Bools", p."DateTime", p."DateTimes", p."Enum", p."En
 FROM "PrimitiveCollectionsEntity" AS p
 WHERE (
     SELECT count(*)::int
-    FROM (VALUES (@i::int)) AS v("Value")
+    FROM (VALUES (@i)) AS v("Value")
     WHERE v."Value" > p."Id") = 1
 """);
     }

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
@@ -44,7 +44,7 @@ WHERE length(b."ByteArray") >= 3 AND get_byte(b."ByteArray", 2) = 190
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE length(b."ByteArray") >= 1 AND get_byte(b."ByteArray", 0)::smallint = 222
+WHERE length(b."ByteArray") >= 1 AND get_byte(b."ByteArray", 0) = 222
 """);
     }
 
@@ -101,7 +101,7 @@ WHERE b."ByteArray" = @byteArrayParam
     }
 
     [ConditionalFact]
-    public virtual async Task Any()
+    public override async Task Any()
     {
         await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Any()));
 

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/CitextTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/CitextTranslationsTest.cs
@@ -66,7 +66,7 @@ LIMIT 2
 
 SELECT s."Id", s."CaseInsensitiveText"
 FROM "SomeEntities" AS s
-WHERE left(@param, length(s."CaseInsensitiveText"))::citext = s."CaseInsensitiveText"
+WHERE left(@param, length(s."CaseInsensitiveText")) = s."CaseInsensitiveText"
 LIMIT 2
 """);
     }
@@ -120,7 +120,7 @@ LIMIT 2
 
 SELECT s."Id", s."CaseInsensitiveText"
 FROM "SomeEntities" AS s
-WHERE right(@param, length(s."CaseInsensitiveText"))::citext = s."CaseInsensitiveText"
+WHERE right(@param, length(s."CaseInsensitiveText")) = s."CaseInsensitiveText"
 LIMIT 2
 """);
     }

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/MathTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/MathTranslationsNpgsqlTest.cs
@@ -426,7 +426,7 @@ WHERE b."Float" > 0 AND sqrt(b."Float") > 0
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE sign(b."Double")::int > 0
+WHERE sign(b."Double") > 0
 """);
     }
 
@@ -438,7 +438,7 @@ WHERE sign(b."Double")::int > 0
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE sign(b."Float")::int > 0
+WHERE sign(b."Float") > 0
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/MiscellaneousTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/MiscellaneousTranslationsNpgsqlTest.cs
@@ -109,64 +109,64 @@ WHERE random() >= 0.0 AND random() < 1.0
         await base.Convert_ToInt32();
 
 AssertSql(
-"""
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Bool"::int = 1
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Byte"::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Decimal"::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Double"::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Float"::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Short"::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE b."Int"::int = 12
+WHERE b."Int" = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Long"::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE b."Int"::text::int = 12
 """,
-                //
-                """
+    //
+    """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE b."Int"::int = 12
+WHERE b."Int" = 12
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/InstantTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/InstantTranslationsTest.cs
@@ -127,7 +127,7 @@ WHERE n."Instant" AT TIME ZONE @timeZone = TIMESTAMP '2018-04-20T12:31:33.666'
             """
 SELECT n."Id", n."DateInterval", n."Duration", n."Instant", n."InstantRange", n."Interval", n."LocalDate", n."LocalDate2", n."LocalDateRange", n."LocalDateTime", n."LocalTime", n."Long", n."OffsetTime", n."Period", n."TimeZoneId", n."ZonedDateTime"
 FROM "NodaTimeTypes" AS n
-WHERE n."Instant"::timestamptz = TIMESTAMPTZ '2018-04-20T10:31:33.666Z'
+WHERE n."Instant" = TIMESTAMPTZ '2018-04-20T10:31:33.666Z'
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/Temporal/DateOnlyTranslationsNpgsqlTest.cs
@@ -89,7 +89,7 @@ WHERE b."DateOnly" - DATE '0001-01-01' = 726780
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE CAST(b."DateOnly" + INTERVAL '3 years' AS date) = DATE '1993-11-10'
+WHERE b."DateOnly" + INTERVAL '3 years' = DATE '1993-11-10'
 """);
     }
 
@@ -101,7 +101,7 @@ WHERE CAST(b."DateOnly" + INTERVAL '3 years' AS date) = DATE '1993-11-10'
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE CAST(b."DateOnly" + INTERVAL '3 months' AS date) = DATE '1991-02-10'
+WHERE b."DateOnly" + INTERVAL '3 months' = DATE '1991-02-10'
 """);
     }
 
@@ -213,7 +213,7 @@ WHERE DATE '1990-11-10' + b."TimeOnly" = TIMESTAMP '1990-11-10T15:30:10'
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE CAST(b."DateOnly" + INTERVAL '1 years' AS date) + b."TimeOnly" = TIMESTAMP '2021-01-01T15:30:10'
+WHERE b."DateOnly" + INTERVAL '1 years' + b."TimeOnly" = TIMESTAMP '2021-01-01T15:30:10'
 """);
     }
 


### PR DESCRIPTION
Syncs to the latest EF Core daily build for preview.5.

## EF-side PRs that required changes

| PR | Change | Impact |
|---|---|---|
| [#38156](https://github.com/dotnet/efcore/pull/38156) | Strip no-op SQL CASTs | 22 SQL baseline rewrites + 2 type mapping bug fixes (see below) |
| [#38188](https://github.com/dotnet/efcore/pull/38188) | Rename `StructuredJsonPath.Ordinals` → `Indices` | Build fix in `NpgsqlUpdateSqlGenerator` |
| [#38168](https://github.com/dotnet/efcore/pull/38168) | Translate `Any()` over byte array | Added `override` on `ByteArrayTranslationsNpgsqlTest.Any()` |

## Type mapping bug fixes exposed by EF's new cast removal

### 1. `DateInterval.End`: wrong result type for `date - interval`

PostgreSQL returns `timestamp without time zone` for `date - interval`, but `NpgsqlSqlExpressionFactory.ApplyTypeMappings` always used the left operand's type mapping (`date`) for the result, ignoring the explicitly passed type mapping. Fixed by using `typeMapping ?? newLeft.TypeMapping`.

### 2. `= ANY(scalar_subquery)`: syntactic cast incorrectly modeled as type cast

We used `SqlUnaryExpression(Convert)` to force PostgreSQL's array-form `ANY()` (vs. subquery-form), but both the subquery and cast had the same `integer[]` store type. This isn't a type mapping bug — it's a syntactic disambiguation. Moved the cast emission to `NpgsqlQuerySqlGenerator.VisitArrayAny()`, which detects `ScalarSubqueryExpression` and appends `::storeType` directly in SQL generation.