### PR TITLE
Fix ST_Extent box2d cast being removed by EF simplifier

### DIFF
--- a/src/EFCore.PG.NTS/Query/ExpressionTranslators/Internal/NpgsqlNetTopologySuiteAggregateMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.PG.NTS/Query/ExpressionTranslators/Internal/NpgsqlNetTopologySuiteAggregateMethodCallTranslatorPlugin.cs
@@ -122,7 +122,10 @@ public class NpgsqlNetTopologySuiteAggregateMethodTranslator : IAggregateMethodC
         if (method == EnvelopeCombineMethod)
         {
             // ST_Extent returns a PostGIS box2d, which isn't a geometry and has no binary output function.
-            // Convert it to a geometry first.
+            // We need to cast the result to geometry. The aggregate function must use 'box2d' as the store type
+            // so that the cast to geometry is not stripped as a no-op by EF's SqlExpressionSimplifyingExpressionVisitor.
+            var geometryMapping = GetMapping();
+
             return _sqlExpressionFactory.Convert(
                 _sqlExpressionFactory.AggregateFunction(
                     "ST_Extent",
@@ -131,8 +134,8 @@ public class NpgsqlNetTopologySuiteAggregateMethodTranslator : IAggregateMethodC
                     nullable: true,
                     argumentsPropagateNullability: [false],
                     typeof(Geometry),
-                    GetMapping()),
-                typeof(Geometry), GetMapping());
+                    geometryMapping?.WithStoreTypeAndSize("box2d", null)),
+                typeof(Geometry), geometryMapping);
         }
 
         if (method == UnionMethod || method == GeometryCombineMethod)


### PR DESCRIPTION
`ST_Extent` returns `box2d` in PostgreSQL, but the aggregate expression was assigned the `geometry` type mapping. EF's `SqlExpressionSimplifyingExpressionVisitor` (added in the latest sync) strips `Convert` nodes when the operand and cast have the same store type. Since both had `geometry`, the `::geometry` cast was removed, leaving the raw `box2d` result which has no binary output function in Npgsql.

Fix: give the `ST_Extent` aggregate a `box2d` store type (via `WithStoreTypeAndSize`), so the cast from `box2d` to `geometry` is recognized as a real type conversion and preserved.

Same root cause as the type mapping fixes in #3827.