### PR TITLE
Sync to EF 11.0.0-preview.5.26261.101

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.5.26251.112</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.5.26251.112</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26251.112</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.5.26261.101</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 
@@ -31,7 +31,7 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.core" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0-pre.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
   </ItemGroup>


### PR DESCRIPTION
Updates EF Core dependency from `11.0.0-preview.5.26251.112` to `11.0.0-preview.5.26261.101`.

## Changes

- Bumped EF Core packages to `11.0.0-preview.5.26261.101`
- Updated `xunit.runner.visualstudio` from `3.1.5` to `4.0.0-pre.4` (required by new EF Core dependency on `Microsoft.EntityFrameworkCore.Specification.Tests`)

## Test Results

All 28,612 tests pass (0 failures, 279 skipped).