### PR TITLE
Fix Windows test connection cleanup flakiness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
         run: dotnet test -c ${{ matrix.config }} --logger "GitHubActions;report-warnings=false"
         shell: bash
         env:
+          # Disable SSL to avoid unnecessary handshake pressure in the Windows functional tests.
           Test__Npgsql__DefaultConnection: Server=localhost;Username=npgsql_tests;Password=npgsql_tests;SSL Mode=Disable
 
       - id: analyze_tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         run: dotnet test -c ${{ matrix.config }} --logger "GitHubActions;report-warnings=false"
         shell: bash
         env:
-          Test__Npgsql__DefaultConnection: Server=localhost;Username=npgsql_tests;Password=npgsql_tests
+          Test__Npgsql__DefaultConnection: Server=localhost;Username=npgsql_tests;Password=npgsql_tests;SSL Mode=Disable
 
       - id: analyze_tag
         name: Analyze tag

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/NpgsqlTestStore.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/NpgsqlTestStore.cs
@@ -341,8 +341,7 @@ SELECT pg_terminate_backend (pg_stat_activity.pid)
         }
         finally
         {
-            if (connection.State == ConnectionState.Closed
-                && connection.State != ConnectionState.Closed)
+            if (connection.State != ConnectionState.Closed)
             {
                 connection.Close();
             }
@@ -389,8 +388,7 @@ SELECT pg_terminate_backend (pg_stat_activity.pid)
         }
         finally
         {
-            if (connection.State == ConnectionState.Closed
-                && connection.State != ConnectionState.Closed)
+            if (connection.State != ConnectionState.Closed)
             {
                 await connection.CloseAsync();
             }


### PR DESCRIPTION
Fixes a likely source of Windows CI flakiness by closing `NpgsqlTestStore` helper-opened connections after command execution.

Also disables SSL in the CI test connection string to avoid unnecessary SSL negotiation/handshake pressure in the functional test suite.

Validation:
- `dotnet build --configuration Debug --no-restore`

Note: the targeted functional test could not run locally because Docker/testcontainers is unavailable in this workspace.