### PR TITLE
Sync to EF 11.0.0-preview.5.26267.102

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.5.26261.101</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.5.26267.102</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.5.26267.102</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26267.102</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Sync EF Core and Microsoft.Extensions dependencies to `11.0.0-preview.5.26267.102`.

## EF-side PRs requiring EFCore.PG updates

None; this sync only required the package version bump.

## Validation

- `dotnet restore && dotnet build --no-restore` passed.
- `dotnet test test\EFCore.PG.Tests --no-build` passed: 495 passed, 6 skipped.
- `dotnet test --no-build` could not complete functional tests in this environment because no `Test__Npgsql__DefaultConnection` is configured and Docker is not running (`Failed to connect to Docker endpoint at npipe://./pipe/docker_engine`).