### PR TITLE
Add EnableLegacyUuidBehaviour switch to preserve v4 UUID generation

### DIFF
--- a/src/EFCore.PG/ValueGeneration/Internal/NpgsqlValueGeneratorSelector.cs
+++ b/src/EFCore.PG/ValueGeneration/Internal/NpgsqlValueGeneratorSelector.cs
@@ -11,6 +11,12 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal;
 /// </summary>
 public class NpgsqlValueGeneratorSelector : RelationalValueGeneratorSelector
 {
+#if DEBUG
+    internal static bool LegacyUuidBehaviour;
+#else
+    internal static readonly bool LegacyUuidBehaviour;
+#endif
+
     private readonly INpgsqlSequenceValueGeneratorFactory _sequenceFactory;
     private readonly INpgsqlRelationalConnection _connection;
     private readonly IRawSqlCommandBuilder _rawSqlCommandBuilder;
@@ -34,6 +40,8 @@ public class NpgsqlValueGeneratorSelector : RelationalValueGeneratorSelector
         _connection = connection;
         _rawSqlCommandBuilder = rawSqlCommandBuilder;
         _commandLogger = commandLogger;
+
+        LegacyUuidBehaviour = AppContext.TryGetSwitch("Npgsql.EnableLegacyUuidBehaviour", out var enabled) && enabled;
     }
 
     /// <summary>
@@ -104,7 +112,9 @@ public class NpgsqlValueGeneratorSelector : RelationalValueGeneratorSelector
         => property.ClrType.UnwrapNullableType() switch
         {
             var t when t == typeof(Guid) && property.ValueGenerated is not ValueGenerated.Never && property.GetDefaultValueSql() is null
-                => new NpgsqlSequentialGuidValueGenerator(),
+                => LegacyUuidBehaviour
+                    ? new NpgsqlSequentialLegacyGuidValueGenerator()
+                    : new NpgsqlSequentialGuidValueGenerator(),
 
             var t when t == typeof(string) && property.ValueGenerated is not ValueGenerated.Never && property.GetDefaultValueSql() is null
                 => new NpgsqlSequentialStringValueGenerator(),

--- a/src/EFCore.PG/ValueGeneration/NpgsqlSequentialLegacyGuidValueGenerator.cs
+++ b/src/EFCore.PG/ValueGeneration/NpgsqlSequentialLegacyGuidValueGenerator.cs
@@ -1,0 +1,25 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration;
+
+/// <summary>
+///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+///     directly from your code. This API may change or be removed in future releases.
+/// </summary>
+public class NpgsqlSequentialLegacyGuidValueGenerator : ValueGenerator<Guid>
+{
+    /// <summary>
+    ///     Gets a value to be assigned to a property.
+    /// </summary>
+    /// <param name="entry">The change tracking entry of the entity for which the value is being generated.</param>
+    /// <returns>The value to be assigned to a property.</returns>
+    public override Guid Next(EntityEntry entry)
+        => Guid.NewGuid();
+
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public override bool GeneratesTemporaryValues => false;
+}

--- a/test/EFCore.PG.Tests/NpgsqlValueGeneratorSelectorTest.cs
+++ b/test/EFCore.PG.Tests/NpgsqlValueGeneratorSelectorTest.cs
@@ -175,6 +175,40 @@ public class NpgsqlValueGeneratorSelectorTest
         Assert.IsType<NpgsqlSequenceHiLoValueGenerator<int>>(generator);
     }
 
+    [ConditionalFact]
+    public void Returns_legacy_guid_generator_when_legacy_uuid_behaviour_enabled()
+    {
+        var previous = NpgsqlValueGeneratorSelector.LegacyUuidBehaviour;
+
+        try
+        {
+            NpgsqlValueGeneratorSelector.LegacyUuidBehaviour = true;
+
+            var builder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+            builder.Entity<AnEntity>(
+                b =>
+                {
+                    b.Property(e => e.Guid).ValueGeneratedOnAdd();
+                    b.HasKey(e => e.Guid);
+                });
+
+            var model = builder.FinalizeModel();
+            var entityType = model.FindEntityType(typeof(AnEntity));
+
+            var selector = NpgsqlTestHelpers.Instance.CreateContextServices(model)
+                .GetRequiredService<IValueGeneratorSelector>();
+
+            var property = entityType.FindProperty("Guid")!;
+
+            Assert.True(selector.TrySelect(property, property.DeclaringType, out var generator));
+            Assert.IsType<NpgsqlSequentialLegacyGuidValueGenerator>(generator);
+        }
+        finally
+        {
+            NpgsqlValueGeneratorSelector.LegacyUuidBehaviour = previous;
+        }
+    }
+
     private class AnEntity
     {
         // ReSharper disable UnusedMember.Local


### PR DESCRIPTION
If a system requires uuid version to remain as it has, upgrading npgsql to >= 9.x.x will cause "breaking changes", there is no mechanism to allow the uuid generator to be overwritten to keep the behaviour as it previously was, this adds a switch under Npgsql.EnableLegacyUuidBehaviour to enable v4 uuid generation, instead of the default v7