### PR TITLE
Sync to EF 11.0.0-preview.5.26275.101

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
 
       - name: Test
-        run: dotnet test -c ${{ matrix.config }} --logger "GitHubActions;report-warnings=false"
+        run: dotnet test -c ${{ matrix.config }} -- --no-progress
         shell: bash
         env:
           # Disable SSL to avoid unnecessary handshake pressure in the Windows functional tests.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.5.26267.102</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.5.26267.102</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26267.102</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.5.26275.101</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.5.26275.101</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26275.101</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.0</NpgsqlVersion>
   </PropertyGroup>
 
@@ -28,6 +28,7 @@
 
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0-pre.108" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.core" Version="2.9.3" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -21,6 +21,9 @@
         <packageSource key="dotnet11">
             <package pattern="*" />
         </packageSource>
+        <packageSource key="dotnet-eng">
+            <package pattern="Microsoft.DotNet.*" />
+        </packageSource>
     </packageSourceMapping>
 
 </configuration>

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "11.0.100-preview.4.26210.111",
     "rollForward": "latestMinor",
     "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMathTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlMathTranslator.cs
@@ -18,6 +18,7 @@ public class NpgsqlMathTranslator(
     IModel model) : IMethodCallTranslator
 {
     private readonly RelationalTypeMapping _intTypeMapping = typeMappingSource.FindMapping(typeof(int), model)!;
+    private readonly RelationalTypeMapping _doubleTypeMapping = typeMappingSource.FindMapping(typeof(double), model)!;
     private readonly RelationalTypeMapping _decimalTypeMapping = typeMappingSource.FindMapping(typeof(decimal), model)!;
 
     /// <inheritdoc />
@@ -226,7 +227,8 @@ public class NpgsqlMathTranslator(
                     [argument],
                     nullable: true,
                     argumentsPropagateNullability: TrueArrays[1],
-                    method.ReturnType),
+                    argument.Type == typeof(decimal) ? typeof(decimal) : typeof(double),
+                    argument.Type == typeof(decimal) ? argument.TypeMapping : _doubleTypeMapping),
                 typeof(int),
                 _intTypeMapping);
     }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,7 +8,7 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
 
     <!-- There's lots of use of internal EF Core APIs from the tests, suppress the analyzer warnings for those -->
-    <NoWarn>$(NoWarn);CS0618;xUnit1003;xUnit1004;xUnit1013;xUnit1024;xUnit1051;EF1001</NoWarn>
+    <NoWarn>$(NoWarn);CS0618;xUnit1003;xUnit1004;xUnit1008;xUnit1013;xUnit1024;xUnit1051;EF1001</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,14 +5,21 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
 
     <!-- There's lots of use of internal EF Core APIs from the tests, suppress the analyzer warnings for those -->
-    <NoWarn>$(NoWarn);xUnit1003;xUnit1004;xUnit1013;xUnit1024;EF1001</NoWarn>
+    <NoWarn>$(NoWarn);CS0618;xUnit1003;xUnit1004;xUnit1013;xUnit1024;xUnit1051;EF1001</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TestRunnerName>XUnitV3</TestRunnerName>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --filter-not-trait category=failing --ignore-exit-code 8</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Npgsql" />
@@ -24,7 +31,6 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
     <Using Include="Microsoft.EntityFrameworkCore.TestUtilities" />
     <Using Include="Microsoft.EntityFrameworkCore.TestUtilities.Xunit" />
   </ItemGroup>

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Net.NetworkInformation;
 
@@ -719,7 +719,7 @@ WHERE m."TimeSpanAsTime" = @timeSpan
         Assert.Null(entity.Mood);
     }
 
-    [ConditionalFact(Skip = "DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
+    [ActiveIssue("DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_object_backed_data_types()
         => Task.CompletedTask;
 

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
@@ -1407,7 +1407,6 @@ WHERE c0."CustomerID" = s."CustomerID"
 """);
     }
 
-    [ConditionalTheory]
     public override async Task Update_with_cross_join_left_join_set_constant(bool async)
     {
         await base.Update_with_cross_join_left_join_set_constant(async);
@@ -1437,7 +1436,6 @@ WHERE c2."CustomerID" = s."CustomerID"
 """);
     }
 
-    [ConditionalTheory]
     public override async Task Update_with_cross_join_cross_apply_set_constant(bool async)
     {
         await base.Update_with_cross_join_cross_apply_set_constant(async);
@@ -1467,7 +1465,6 @@ WHERE c2."CustomerID" = s."CustomerID"
 """);
     }
 
-    [ConditionalTheory]
     public override async Task Update_with_cross_join_outer_apply_set_constant(bool async)
     {
         await base.Update_with_cross_join_outer_apply_set_constant(async);
@@ -1577,7 +1574,6 @@ WHERE c."CustomerID" LIKE 'F%'
 """);
     }
 
-    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public override async Task Update_with_two_inner_joins(bool async)
     {

--- a/test/EFCore.PG.FunctionalTests/ComputedColumnTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ComputedColumnTest.cs
@@ -134,9 +134,9 @@ public class ComputedColumnTest : IAsyncLifetime
 
     protected NpgsqlTestStore TestStore { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
         => TestStore = await NpgsqlTestStore.CreateInitializedAsync("ComputedColumnTest");
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
         => await TestStore.DisposeAsync();
 }

--- a/test/EFCore.PG.FunctionalTests/ConnectionInterceptionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ConnectionInterceptionNpgsqlTest.cs
@@ -7,19 +7,19 @@ namespace Microsoft.EntityFrameworkCore;
 public abstract class ConnectionInterceptionNpgsqlTestBase(ConnectionInterceptionNpgsqlTestBase.InterceptionNpgsqlFixtureBase fixture)
     : ConnectionInterceptionTestBase(fixture)
 {
-    [ConditionalTheory(Skip = "#2368")]
+    [ActiveIssue("#2368")]
     public override Task Intercept_connection_creation_passively(bool async)
         => base.Intercept_connection_creation_passively(async);
 
-    [ConditionalTheory(Skip = "#2368")]
+    [ActiveIssue("#2368")]
     public override Task Intercept_connection_creation_with_multiple_interceptors(bool async)
         => base.Intercept_connection_creation_with_multiple_interceptors(async);
 
-    [ConditionalTheory(Skip = "#2368")]
+    [ActiveIssue("#2368")]
     public override Task Intercept_connection_to_override_connection_after_creation(bool async)
         => base.Intercept_connection_to_override_connection_after_creation(async);
 
-    [ConditionalTheory(Skip = "#2368")]
+    [ActiveIssue("#2368")]
     public override Task Intercept_connection_to_override_creation(bool async)
         => base.Intercept_connection_to_override_creation(async);
 

--- a/test/EFCore.PG.FunctionalTests/ConvertToProviderTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ConvertToProviderTypesNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.EntityFrameworkCore;
+namespace Microsoft.EntityFrameworkCore;
 
 public class ConvertToProviderTypesNpgsqlTest : ConvertToProviderTypesTestBase<
     ConvertToProviderTypesNpgsqlTest.ConvertToProviderTypesNpgsqlFixture>
@@ -49,7 +49,7 @@ public class ConvertToProviderTypesNpgsqlTest : ConvertToProviderTypesTestBase<
     //     }
     // }
 
-    [ConditionalFact(Skip = "DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
+    [ActiveIssue("DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_object_backed_data_types()
         => Task.CompletedTask;
 

--- a/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.EntityFrameworkCore;
+namespace Microsoft.EntityFrameworkCore;
 
 public class CustomConvertersNpgsqlTest(CustomConvertersNpgsqlTest.CustomConvertersNpgsqlFixture fixture)
     : CustomConvertersTestBase<CustomConvertersNpgsqlTest.CustomConvertersNpgsqlFixture>(fixture)
@@ -7,7 +7,7 @@ public class CustomConvertersNpgsqlTest(CustomConvertersNpgsqlTest.CustomConvert
     public override Task Can_insert_and_read_back_with_case_insensitive_string_key()
         => Task.CompletedTask;
 
-    [ConditionalFact(Skip = "DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
+    [ActiveIssue("DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_object_backed_data_types()
         => Task.CompletedTask;
 

--- a/test/EFCore.PG.FunctionalTests/JsonTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/JsonTypesNpgsqlTest.cs
@@ -210,7 +210,6 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
         public List<DateOnly> DateOnly { get; set; } = null!;
     }
 
-    [ConditionalFact]
     public override Task Can_read_write_collection_of_nullable_DateOnly_JSON_values()
         => Can_read_and_write_JSON_value<NullableDateOnlyCollectionType, List<DateOnly?>>(
             nameof(NullableDateOnlyCollectionType.DateOnly),
@@ -462,7 +461,6 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
             new NpgsqlLogSequenceNumber(value),
             json);
 
-    [ConditionalFact]
     public override async Task Can_read_write_point()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
@@ -480,7 +478,6 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
             new Point(2, 4),
             """{"Prop":"POINT (2 4)"}""");
 
-    [ConditionalFact]
     public override async Task Can_read_write_point_with_M()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
@@ -511,7 +508,6 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
             """{"Prop":"SRID=4326;POINT Z(1 2 3)"}""");
     }
 
-    [ConditionalFact]
     public override async Task Can_read_write_line_string()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);

--- a/test/EFCore.PG.FunctionalTests/LazyLoadProxyNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/LazyLoadProxyNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using Xunit.Sdk;
+using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore;
 
@@ -15,10 +15,9 @@ public class LazyLoadProxyNpgsqlTest : LazyLoadProxyRelationalTestBase<LazyLoadP
     public override void Can_serialize_proxies_to_JSON()
         => Assert.Throws<EqualException>(base.Can_serialize_proxies_to_JSON);
 
-    [ConditionalFact] // Requires MARS
     public override void Top_level_projection_track_entities_before_passing_to_client_method() { }
 
-    [ConditionalTheory(Skip = "Possibly requires MARS, investigate")]
+    [ActiveIssue("Possibly requires MARS, investigate")]
     public override void Lazy_load_one_to_one_reference_with_recursive_property(EntityState state)
         => base.Lazy_load_one_to_one_reference_with_recursive_property(state);
 

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsInfrastructureNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsInfrastructureNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations;
@@ -29,23 +29,23 @@ public class MigrationsInfrastructureNpgsqlTest(MigrationsInfrastructureNpgsqlTe
     public override Task Can_generate_no_migration_script()
         => base.Can_generate_no_migration_script();
 
-    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_apply_all_migrations()
         => base.Can_apply_all_migrations();
 
-    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_apply_range_of_migrations()
         => base.Can_apply_range_of_migrations();
 
-    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_revert_all_migrations()
         => base.Can_revert_all_migrations();
 
-    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_revert_one_migrations()
         => base.Can_revert_one_migrations();
 
-    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
     public override Task Can_apply_all_migrations_async()
         => base.Can_apply_all_migrations_async();
 

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Scaffolding.Internal;
@@ -3246,7 +3246,7 @@ CREATE COLLATION some_collation (LOCALE = 'en-u-ks-level1',
         AssertSql("""ALTER TABLE "Customers" ADD "Numbers" integer[] NOT NULL DEFAULT (ARRAY[1,2,3]);""");
     }
 
-    [ConditionalFact(Skip = "issue #33038")]
+    [ActiveIssue("issue #33038")]
     public override async Task Add_required_primitive_collection_with_custom_converter_to_existing_table()
     {
         await base.Add_required_primitive_collection_with_custom_converter_to_existing_table();
@@ -3337,7 +3337,7 @@ CREATE TABLE "Contacts" (
         AssertSql("""ALTER TABLE "Customers" ADD "Numbers" integer[] NOT NULL DEFAULT ARRAY[1,2,3]::integer[];""");
     }
 
-    [ConditionalFact(Skip = "issue #33038")]
+    [ActiveIssue("issue #33038")]
     public override async Task Add_required_primitve_collection_with_custom_converter_to_existing_table()
     {
         await base.Add_required_primitve_collection_with_custom_converter_to_existing_table();

--- a/test/EFCore.PG.FunctionalTests/Query/AdHocMiscellaneousQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/AdHocMiscellaneousQueryNpgsqlTest.cs
@@ -33,7 +33,7 @@ INSERT INTO "ZeroKey" VALUES (NULL)
     public override Task Subquery_first_member_compared_to_null(bool async)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/27995/files#r874038747")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/27995/files#r874038747")]
     public override Task StoreType_for_UDF_used(bool async)
         => base.StoreType_for_UDF_used(async);
 }

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionNpgsqlTest.cs
@@ -177,7 +177,6 @@ WHERE (CAST(r."AssociateCollection" #>> '{9999,Int}' AS integer)) = 8
 
     #region GroupBy
 
-    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionNpgsqlTest.cs
@@ -210,7 +210,6 @@ ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST
 
     #region GroupBy
 
-    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionNpgsqlTest.cs
@@ -191,7 +191,6 @@ WHERE (CAST(r."AssociateCollection" #>> '{9999,Int}' AS integer)) = 8
 
     #region GroupBy
 
-    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionNpgsqlTest.cs
@@ -213,7 +213,6 @@ ORDER BY r."Id" NULLS FIRST, s."RootEntityId" NULLS FIRST, s."Id" NULLS FIRST, s
 
     #region GroupBy
 
-    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/CompatibilityQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/CompatibilityQueryNpgsqlTest.cs
@@ -74,7 +74,7 @@ LIMIT 2
             return new CompatibilityContext(builder.Options);
         }
 
-        public virtual async Task InitializeAsync()
+        public virtual async ValueTask InitializeAsync()
         {
             _testStore = NpgsqlTestStoreFactory.Instance.GetOrCreate(StoreName);
             await _testStore.InitializeAsync(null, CreateContext, c => CompatibilityContext.SeedAsync((CompatibilityContext)c));
@@ -85,7 +85,7 @@ LIMIT 2
         {
         }
 
-        public virtual async Task DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
             => await _testStore.DisposeAsync();
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsSharedTypeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsSharedTypeQueryNpgsqlTest.cs
@@ -15,7 +15,7 @@ public class ComplexNavigationsSharedTypeQueryNpgsqlTest
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/26353")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/26353")]
     public override Task Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy(bool async)
         => base.Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy(async);
 
@@ -30,11 +30,11 @@ public class ComplexNavigationsSharedTypeQueryNpgsqlTest
                 "Microsoft.EntityFrameworkCore.Query.ComplexNavigationsQueryTestBase<Microsoft.EntityFrameworkCore.Query.ComplexNavigationsSharedTypeQueryNpgsqlFixture>",
                 "ClientMethodNullableInt"));
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/26104")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/26104")]
     public override Task GroupBy_aggregate_where_required_relationship(bool async)
         => base.GroupBy_aggregate_where_required_relationship(async);
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/26104")]
+    [ActiveIssue("https://github.com/dotnet/efcore/issues/26104")]
     public override Task GroupBy_aggregate_where_required_relationship_2(bool async)
         => base.GroupBy_aggregate_where_required_relationship_2(async);
 }

--- a/test/EFCore.PG.FunctionalTests/Query/EntitySplittingQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/EntitySplittingQueryNpgsqlTest.cs
@@ -224,7 +224,7 @@ LEFT JOIN "OwnedReferenceExtras1" AS o0 ON e."Id" = o0."EntityOneId"
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing(bool async)
     {
         await base.Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing(async);
@@ -232,7 +232,7 @@ LEFT JOIN "OwnedReferenceExtras1" AS o0 ON e."Id" = o0."EntityOneId"
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing_custom_projection(bool async)
     {
         await base.Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing_custom_projection(async);
@@ -240,7 +240,7 @@ LEFT JOIN "OwnedReferenceExtras1" AS o0 ON e."Id" = o0."EntityOneId"
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Normal_entity_owning_a_split_collection(bool async)
     {
         await base.Normal_entity_owning_a_split_collection(async);
@@ -291,7 +291,7 @@ ORDER BY e."Id" NULLS FIRST, o."EntityOneId" NULLS FIRST
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Split_entity_owning_a_split_reference_without_table_sharing(bool async)
     {
         await base.Split_entity_owning_a_split_reference_without_table_sharing(async);
@@ -299,7 +299,7 @@ ORDER BY e."Id" NULLS FIRST, o."EntityOneId" NULLS FIRST
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Split_entity_owning_a_split_collection(bool async)
     {
         await base.Split_entity_owning_a_split_collection(async);
@@ -334,7 +334,7 @@ LEFT JOIN "OwnedReferencePart3" AS o ON s."Id" = o."EntityOneId"
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Split_entity_owning_a_split_reference_with_table_sharing_6(bool async)
     {
         await base.Split_entity_owning_a_split_reference_with_table_sharing_6(async);
@@ -562,7 +562,7 @@ FROM "SiblingEntity" AS s
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tph_entity_owning_a_split_reference_on_base_without_table_sharing(bool async)
     {
         await base.Tph_entity_owning_a_split_reference_on_base_without_table_sharing(async);
@@ -570,7 +570,7 @@ FROM "SiblingEntity" AS s
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpt_entity_owning_a_split_reference_on_base_without_table_sharing(bool async)
     {
         await base.Tpt_entity_owning_a_split_reference_on_base_without_table_sharing(async);
@@ -604,7 +604,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."BaseEntityId" = o1."BaseEntityId"
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tph_entity_owning_a_split_reference_on_middle_without_table_sharing(bool async)
     {
         await base.Tph_entity_owning_a_split_reference_on_middle_without_table_sharing(async);
@@ -612,7 +612,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."BaseEntityId" = o1."BaseEntityId"
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpt_entity_owning_a_split_reference_on_middle_without_table_sharing(bool async)
     {
         await base.Tpt_entity_owning_a_split_reference_on_middle_without_table_sharing(async);
@@ -646,7 +646,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tph_entity_owning_a_split_reference_on_leaf_without_table_sharing(bool async)
     {
         await base.Tph_entity_owning_a_split_reference_on_leaf_without_table_sharing(async);
@@ -654,7 +654,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpt_entity_owning_a_split_reference_on_leaf_without_table_sharing(bool async)
     {
         await base.Tpt_entity_owning_a_split_reference_on_leaf_without_table_sharing(async);
@@ -662,7 +662,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpc_entity_owning_a_split_reference_on_leaf_without_table_sharing(bool async)
     {
         await base.Tpc_entity_owning_a_split_reference_on_leaf_without_table_sharing(async);
@@ -670,7 +670,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tph_entity_owning_a_split_collection_on_base(bool async)
     {
         await base.Tph_entity_owning_a_split_collection_on_base(async);
@@ -678,7 +678,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpt_entity_owning_a_split_collection_on_base(bool async)
     {
         await base.Tpt_entity_owning_a_split_collection_on_base(async);
@@ -716,7 +716,7 @@ ORDER BY u."Id" NULLS FIRST, s0."BaseEntityId" NULLS FIRST
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tph_entity_owning_a_split_collection_on_middle(bool async)
     {
         await base.Tph_entity_owning_a_split_collection_on_middle(async);
@@ -724,7 +724,7 @@ ORDER BY u."Id" NULLS FIRST, s0."BaseEntityId" NULLS FIRST
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpt_entity_owning_a_split_collection_on_middle(bool async)
     {
         await base.Tpt_entity_owning_a_split_collection_on_middle(async);
@@ -762,7 +762,7 @@ ORDER BY u."Id" NULLS FIRST, s0."MiddleEntityId" NULLS FIRST
 """);
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tph_entity_owning_a_split_collection_on_leaf(bool async)
     {
         await base.Tph_entity_owning_a_split_collection_on_leaf(async);
@@ -770,7 +770,7 @@ ORDER BY u."Id" NULLS FIRST, s0."MiddleEntityId" NULLS FIRST
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpt_entity_owning_a_split_collection_on_leaf(bool async)
     {
         await base.Tpt_entity_owning_a_split_collection_on_leaf(async);
@@ -778,7 +778,7 @@ ORDER BY u."Id" NULLS FIRST, s0."MiddleEntityId" NULLS FIRST
         AssertSql();
     }
 
-    [ConditionalTheory(Skip = "Issue29075")]
+    [ActiveIssue("Issue29075")]
     public override async Task Tpc_entity_owning_a_split_collection_on_leaf(bool async)
     {
         await base.Tpc_entity_owning_a_split_collection_on_leaf(async);

--- a/test/EFCore.PG.FunctionalTests/Query/FromSqlQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FromSqlQueryNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Xunit.Sdk;
 
@@ -7,11 +7,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public class FromSqlQueryNpgsqlTest(NorthwindQueryNpgsqlFixture<NoopModelCustomizer> fixture)
     : FromSqlQueryTestBase<NorthwindQueryNpgsqlFixture<NoopModelCustomizer>>(fixture)
 {
-    [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
+    [ActiveIssue("https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
     public override Task Bad_data_error_handling_invalid_cast(bool async)
         => base.Bad_data_error_handling_invalid_cast(async);
 
-    [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
+    [ActiveIssue("https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
     public override Task Bad_data_error_handling_invalid_cast_projection(bool async)
         => base.Bad_data_error_handling_invalid_cast_projection(async);
 
@@ -66,7 +66,6 @@ public class FromSqlQueryNpgsqlTest(NorthwindQueryNpgsqlFixture<NoopModelCustomi
         Assert.Single(actual);
     }
 
-    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated(bool async)
     {

--- a/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPCInheritanceQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPCInheritanceQueryNpgsqlTest.cs
@@ -78,11 +78,8 @@ ORDER BY e1."Id" NULLS FIRST
 """);
     }
 
-    // Seed data for the fixture manually inserts entities with IDs 1, 2; then this test attempts to insert another one with an auto-generated ID,
-    // but the PG sequence wasn't updated so produces 1, resulting in a conflict. The test should be consistent in either using either
-    // auto-generated IDs or not across the board.
     public override Task Can_insert_update_delete()
-        => Assert.ThrowsAsync<DbUpdateException>(base.Can_insert_update_delete);
+        => base.Can_insert_update_delete();
 
     public override async Task Can_query_all_animals(bool async)
     {

--- a/test/EFCore.PG.FunctionalTests/Query/LegacyTimestampQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/LegacyTimestampQueryTest.cs
@@ -110,10 +110,10 @@ WHERE now() AT TIME ZONE 'UTC' <> @myDatetime
                 NpgsqlTypeMappingSource.LegacyTimestampBehavior = true;
             }
 
-            public override Task DisposeAsync()
+            public override ValueTask DisposeAsync()
             {
                 NpgsqlTypeMappingSource.LegacyTimestampBehavior = false;
-                return Task.CompletedTask;
+                return ValueTask.CompletedTask;
             }
 
             protected override async Task SeedAsync(TimestampQueryContext context)

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindDbFunctionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindDbFunctionsQueryNpgsqlTest.cs
@@ -127,7 +127,7 @@ WHERE c."ContactName" NOT ILIKE '%M%' OR c."ContactName" IS NULL
     #region Collation
 
     [MinimumPostgresVersion(12, 0)]
-    [PlatformSkipCondition(TestUtilities.Xunit.TestPlatform.Windows, SkipReason = "ICU non-deterministic doesn't seem to work on Windows?")]
+    [SkipOnPlatform(TestPlatforms.Windows, "ICU non-deterministic doesn't seem to work on Windows?")]
     public override async Task Collate_case_insensitive(bool async)
     {
         await base.Collate_case_insensitive(async);

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindGroupByQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindGroupByQueryNpgsqlTest.cs
@@ -2031,7 +2031,7 @@ ORDER BY o0."CustomerID" NULLS FIRST
 """);
     }
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/28410")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/28410")]
     public override async Task Select_nested_collection_with_groupby(bool async)
     {
         await base.Select_nested_collection_with_groupby(async);

--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -2657,7 +2657,6 @@ WHERE NOT (p."Int" = ANY (@ints) AND p."Int" = ANY (@ints) IS NOT NULL)
 """);
     }
 
-    [ConditionalFact]
     public override async Task Multidimensional_array_is_not_supported()
     {
         // Multidimensional arrays are supported in PostgreSQL (via the regular array type); the EFCore.PG maps .NET

--- a/test/EFCore.PG.FunctionalTests/Query/SqlQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SqlQueryNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using Xunit.Sdk;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -360,7 +360,7 @@ FROM (
 """);
     }
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
     public override async Task SqlQueryRaw_annotations_do_not_affect_successive_calls(bool async)
     {
         await base.SqlQueryRaw_annotations_do_not_affect_successive_calls(async);
@@ -460,7 +460,7 @@ SELECT * FROM "Customers" WHERE "CustomerID" = @somename
 """);
     }
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
     public override async Task SqlQuery_parameterization_issue_12213(bool async)
     {
         await base.SqlQuery_parameterization_issue_12213(async);
@@ -672,11 +672,11 @@ WHERE m."ContactName" LIKE '%z%'
     }
 
 #pragma warning disable xUnit1026
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
     public override Task Bad_data_error_handling_invalid_cast(bool async)
         => Task.CompletedTask;
 
-    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
     public override Task Bad_data_error_handling_invalid_cast_projection(bool async)
         => Task.CompletedTask;
 #pragma warning restore xUnit1026

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
@@ -100,7 +100,6 @@ WHERE b."ByteArray" = @byteArrayParam
 """);
     }
 
-    [ConditionalFact]
     public override async Task Any()
     {
         await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Any()));

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/MathTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/MathTranslationsNpgsqlTest.cs
@@ -426,7 +426,12 @@ WHERE b."Float" > 0 AND sqrt(b."Float") > 0
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE sign(b."Double") > 0
+WHERE sign(b."Double")::int > 0
+""",
+            //
+            """
+SELECT sign(b."Double")::int
+FROM "BasicTypesEntities" AS b
 """);
     }
 
@@ -438,7 +443,12 @@ WHERE sign(b."Double") > 0
             """
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
-WHERE sign(b."Float") > 0
+WHERE sign(b."Float")::int > 0
+""",
+            //
+            """
+SELECT sign(b."Float")::int
+FROM "BasicTypesEntities" AS b
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.EntityFrameworkCore.Query;
+namespace Microsoft.EntityFrameworkCore.Query;
 
 #nullable disable
 
@@ -584,7 +584,7 @@ LIMIT 2
     #endregion
 
 #if RELEASE
-    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/pull/30388")]
+    [ActiveIssue("https://github.com/dotnet/efcore/pull/30388")]
     public override void Scalar_Function_with_nullable_value_return_type_throws() {}
 #endif
 

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -2214,7 +2214,7 @@ CREATE EXTENSION postgis;
         public new NpgsqlTestStore TestStore
             => (NpgsqlTestStore)base.TestStore;
 
-        public override async Task InitializeAsync()
+        public override async ValueTask InitializeAsync()
         {
             await base.InitializeAsync();
             await TestStore.ExecuteNonQueryAsync("CREATE SCHEMA IF NOT EXISTS db2");

--- a/test/EFCore.PG.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EFCore.PG.FunctionalTests/SequenceEndToEndTest.cs
@@ -391,9 +391,9 @@ public class SequenceEndToEndTest : IAsyncLifetime
 
     protected NpgsqlTestStore TestStore { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
         => TestStore = await NpgsqlTestStore.CreateInitializedAsync("SequenceEndToEndTest");
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
         => await TestStore.DisposeAsync();
 }

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/MinimumPostgresVersionAttribute.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/MinimumPostgresVersionAttribute.cs
@@ -1,13 +1,16 @@
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
-public sealed class MinimumPostgresVersionAttribute(int major, int minor) : Attribute, ITestCondition
+public sealed class MinimumPostgresVersionAttribute(int major, int minor) : Attribute, global::Xunit.v3.ITraitAttribute
 {
     private readonly Version _version = new(major, minor);
 
-    public ValueTask<bool> IsMetAsync()
-        => new(TestEnvironment.PostgresVersion >= _version);
+    private bool IsMet
+        => TestEnvironment.PostgresVersion >= _version;
 
     public string SkipReason
         => $"Requires PostgreSQL version {_version} or later.";
+
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits()
+        => IsMet ? [] : [new("category", "failing")];
 }

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/RequiresPostgisAttribute.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/RequiresPostgisAttribute.cs
@@ -3,11 +3,15 @@
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
-public sealed class RequiresPostgisAttribute : Attribute, ITestCondition
+public sealed class RequiresPostgisAttribute : Attribute, global::Xunit.v3.ITraitAttribute
 {
-    public ValueTask<bool> IsMetAsync()
-        => new(TestEnvironment.IsPostgisAvailable || Environment.GetEnvironmentVariable("NPGSQL_TEST_POSTGIS")?.ToLower(CultureInfo.InvariantCulture) is "1" or "true");
+    private static bool IsMet
+        => TestEnvironment.IsPostgisAvailable
+            || Environment.GetEnvironmentVariable("NPGSQL_TEST_POSTGIS")?.ToLower(CultureInfo.InvariantCulture) is "1" or "true";
 
     public string SkipReason
         => "PostGIS isn't installed, skipping";
+
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits()
+        => IsMet ? [] : [new("category", "failing")];
 }

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -53,7 +53,8 @@ public static class TestEnvironment
             };
         }
 
-        Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+        CultureInfo.DefaultThreadCurrentCulture = Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+        CultureInfo.DefaultThreadCurrentUICulture = Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
     }
 
     private static Version? _postgresVersion;

--- a/test/EFCore.PG.FunctionalTests/Update/JsonUpdateNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Update/JsonUpdateNpgsqlTest.cs
@@ -1255,7 +1255,6 @@ LIMIT 2
 """);
     }
 
-    [ConditionalFact]
     public override async Task Edit_single_property_with_converter_string_True_False_to_bool()
     {
         await base.Edit_single_property_with_converter_string_True_False_to_bool();
@@ -1277,7 +1276,6 @@ LIMIT 2
 """);
     }
 
-    [ConditionalFact]
     public override async Task Edit_single_property_with_converter_string_Y_N_to_bool()
     {
         await base.Edit_single_property_with_converter_string_Y_N_to_bool();

--- a/test/EFCore.PG.FunctionalTests/ValueConvertersEndToEndNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ValueConvertersEndToEndNpgsqlTest.cs
@@ -3,7 +3,7 @@ namespace Microsoft.EntityFrameworkCore;
 public class ValueConvertersEndToEndNpgsqlTest(ValueConvertersEndToEndNpgsqlTest.ValueConvertersEndToEndNpgsqlFixture fixture)
     : ValueConvertersEndToEndTestBase<ValueConvertersEndToEndNpgsqlTest.ValueConvertersEndToEndNpgsqlFixture>(fixture)
 {
-    [ConditionalTheory(Skip = "DateTime and DateTimeOffset, https://github.com/dotnet/efcore/issues/26068")]
+    [ActiveIssue("DateTime and DateTimeOffset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_with_conversions(int[] valueOrder)
         => base.Can_insert_and_read_back_with_conversions(valueOrder);
 


### PR DESCRIPTION
## Summary

- Sync EF Core and Microsoft.Extensions dependencies to `11.0.0-preview.5.26275.101`.
- Update test infrastructure for EF's xUnit v3 migration, including Microsoft.Testing.Platform opt-in and xUnit v3 conditional trait handling.
- Add package source mapping for the new `Microsoft.DotNet.XUnitV3Extensions` dependency from `dotnet-eng`.
- Adjust provider/test fallout from the sync: preserve test culture across xUnit v3 worker threads, avoid duplicate inherited fact/theory attributes on overrides, and cast translated `Math.Sign` results correctly.

## EF-side PRs requiring EFCore.PG updates

- dotnet/efcore@ec063d100f6461f2a8418ba1435be24dab009b94 - Upgrade to XUnit v3
- dotnet/efcore#38314 - Update dependencies from build 315684

## Validation

- `dotnet build --no-restore` passed.
- `dotnet test --no-build -- --no-progress` passed against local PostgreSQL (`Server=localhost;Username=npgsql_tests;Password=npgsql_tests`): 28,654 passed, 222 skipped.