### PR TITLE
Sync to EF 11.0.0-preview.5.26279.113

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
 
       - name: Test
-        run: dotnet test -c ${{ matrix.config }} -- --no-progress
+        run: dotnet test -c ${{ matrix.config }} --logger "GitHubActions;report-warnings=false"
         shell: bash
         env:
           # Disable SSL to avoid unnecessary handshake pressure in the Windows functional tests.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.5.26275.101</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.5.26275.101</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26275.101</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.5.26279.113</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.5.26279.113</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.5.26279.113</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.3</NpgsqlVersion>
   </PropertyGroup>
 
@@ -28,7 +28,6 @@
 
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="xunit.v3" Version="4.0.0-pre.108" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.core" Version="2.9.3" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -21,9 +21,6 @@
         <packageSource key="dotnet11">
             <package pattern="*" />
         </packageSource>
-        <packageSource key="dotnet-eng">
-            <package pattern="Microsoft.DotNet.*" />
-        </packageSource>
     </packageSourceMapping>
 
 </configuration>

--- a/global.json
+++ b/global.json
@@ -3,8 +3,5 @@
     "version": "11.0.100-preview.4.26210.111",
     "rollForward": "latestMinor",
     "allowPrerelease": true
-  },
-  "test": {
-    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,21 +5,14 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
 
     <!-- There's lots of use of internal EF Core APIs from the tests, suppress the analyzer warnings for those -->
-    <NoWarn>$(NoWarn);CS0618;xUnit1003;xUnit1004;xUnit1008;xUnit1013;xUnit1024;xUnit1051;EF1001</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TestRunnerName>XUnitV3</TestRunnerName>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --filter-not-trait category=failing --ignore-exit-code 8</TestingPlatformCommandLineArguments>
+    <NoWarn>$(NoWarn);xUnit1003;xUnit1004;xUnit1013;xUnit1024;EF1001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Npgsql" />
@@ -31,6 +24,7 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
     <Using Include="Microsoft.EntityFrameworkCore.TestUtilities" />
     <Using Include="Microsoft.EntityFrameworkCore.TestUtilities.Xunit" />
   </ItemGroup>

--- a/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BuiltInDataTypesNpgsqlTest.cs
@@ -719,7 +719,7 @@ WHERE m."TimeSpanAsTime" = @timeSpan
         Assert.Null(entity.Mood);
     }
 
-    [ActiveIssue("DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
+    [ConditionalFact(Skip = "DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_object_backed_data_types()
         => Task.CompletedTask;
 

--- a/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesNpgsqlTest.cs
@@ -1407,6 +1407,7 @@ WHERE c0."CustomerID" = s."CustomerID"
 """);
     }
 
+    [ConditionalTheory]
     public override async Task Update_with_cross_join_left_join_set_constant(bool async)
     {
         await base.Update_with_cross_join_left_join_set_constant(async);
@@ -1436,6 +1437,7 @@ WHERE c2."CustomerID" = s."CustomerID"
 """);
     }
 
+    [ConditionalTheory]
     public override async Task Update_with_cross_join_cross_apply_set_constant(bool async)
     {
         await base.Update_with_cross_join_cross_apply_set_constant(async);
@@ -1465,6 +1467,7 @@ WHERE c2."CustomerID" = s."CustomerID"
 """);
     }
 
+    [ConditionalTheory]
     public override async Task Update_with_cross_join_outer_apply_set_constant(bool async)
     {
         await base.Update_with_cross_join_outer_apply_set_constant(async);
@@ -1574,6 +1577,7 @@ WHERE c."CustomerID" LIKE 'F%'
 """);
     }
 
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public override async Task Update_with_two_inner_joins(bool async)
     {

--- a/test/EFCore.PG.FunctionalTests/ComputedColumnTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ComputedColumnTest.cs
@@ -134,9 +134,9 @@ public class ComputedColumnTest : IAsyncLifetime
 
     protected NpgsqlTestStore TestStore { get; private set; } = null!;
 
-    public async ValueTask InitializeAsync()
+    public async Task InitializeAsync()
         => TestStore = await NpgsqlTestStore.CreateInitializedAsync("ComputedColumnTest");
 
-    public async ValueTask DisposeAsync()
+    public async Task DisposeAsync()
         => await TestStore.DisposeAsync();
 }

--- a/test/EFCore.PG.FunctionalTests/ConnectionInterceptionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ConnectionInterceptionNpgsqlTest.cs
@@ -7,19 +7,19 @@ namespace Microsoft.EntityFrameworkCore;
 public abstract class ConnectionInterceptionNpgsqlTestBase(ConnectionInterceptionNpgsqlTestBase.InterceptionNpgsqlFixtureBase fixture)
     : ConnectionInterceptionTestBase(fixture)
 {
-    [ActiveIssue("#2368")]
+    [ConditionalTheory(Skip = "#2368")]
     public override Task Intercept_connection_creation_passively(bool async)
         => base.Intercept_connection_creation_passively(async);
 
-    [ActiveIssue("#2368")]
+    [ConditionalTheory(Skip = "#2368")]
     public override Task Intercept_connection_creation_with_multiple_interceptors(bool async)
         => base.Intercept_connection_creation_with_multiple_interceptors(async);
 
-    [ActiveIssue("#2368")]
+    [ConditionalTheory(Skip = "#2368")]
     public override Task Intercept_connection_to_override_connection_after_creation(bool async)
         => base.Intercept_connection_to_override_connection_after_creation(async);
 
-    [ActiveIssue("#2368")]
+    [ConditionalTheory(Skip = "#2368")]
     public override Task Intercept_connection_to_override_creation(bool async)
         => base.Intercept_connection_to_override_creation(async);
 

--- a/test/EFCore.PG.FunctionalTests/ConvertToProviderTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ConvertToProviderTypesNpgsqlTest.cs
@@ -49,7 +49,7 @@ public class ConvertToProviderTypesNpgsqlTest : ConvertToProviderTypesTestBase<
     //     }
     // }
 
-    [ActiveIssue("DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
+    [ConditionalFact(Skip = "DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_object_backed_data_types()
         => Task.CompletedTask;
 

--- a/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/CustomConvertersNpgsqlTest.cs
@@ -7,7 +7,7 @@ public class CustomConvertersNpgsqlTest(CustomConvertersNpgsqlTest.CustomConvert
     public override Task Can_insert_and_read_back_with_case_insensitive_string_key()
         => Task.CompletedTask;
 
-    [ActiveIssue("DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
+    [ConditionalFact(Skip = "DateTimeOffset with non-zero offset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_object_backed_data_types()
         => Task.CompletedTask;
 

--- a/test/EFCore.PG.FunctionalTests/JsonTypesNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/JsonTypesNpgsqlTest.cs
@@ -210,6 +210,7 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
         public List<DateOnly> DateOnly { get; set; } = null!;
     }
 
+    [ConditionalFact]
     public override Task Can_read_write_collection_of_nullable_DateOnly_JSON_values()
         => Can_read_and_write_JSON_value<NullableDateOnlyCollectionType, List<DateOnly?>>(
             nameof(NullableDateOnlyCollectionType.DateOnly),
@@ -461,6 +462,7 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
             new NpgsqlLogSequenceNumber(value),
             json);
 
+    [ConditionalFact]
     public override async Task Can_read_write_point()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
@@ -478,6 +480,7 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
             new Point(2, 4),
             """{"Prop":"POINT (2 4)"}""");
 
+    [ConditionalFact]
     public override async Task Can_read_write_point_with_M()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
@@ -508,6 +511,7 @@ public class JsonTypesNpgsqlTest(NonSharedFixture fixture) : JsonTypesRelational
             """{"Prop":"SRID=4326;POINT Z(1 2 3)"}""");
     }
 
+    [ConditionalFact]
     public override async Task Can_read_write_line_string()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);

--- a/test/EFCore.PG.FunctionalTests/LazyLoadProxyNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/LazyLoadProxyNpgsqlTest.cs
@@ -15,9 +15,10 @@ public class LazyLoadProxyNpgsqlTest : LazyLoadProxyRelationalTestBase<LazyLoadP
     public override void Can_serialize_proxies_to_JSON()
         => Assert.Throws<EqualException>(base.Can_serialize_proxies_to_JSON);
 
+    [ConditionalFact] // Requires MARS
     public override void Top_level_projection_track_entities_before_passing_to_client_method() { }
 
-    [ActiveIssue("Possibly requires MARS, investigate")]
+    [ConditionalTheory(Skip = "Possibly requires MARS, investigate")]
     public override void Lazy_load_one_to_one_reference_with_recursive_property(EntityState state)
         => base.Lazy_load_one_to_one_reference_with_recursive_property(state);
 

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsInfrastructureNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsInfrastructureNpgsqlTest.cs
@@ -29,23 +29,23 @@ public class MigrationsInfrastructureNpgsqlTest(MigrationsInfrastructureNpgsqlTe
     public override Task Can_generate_no_migration_script()
         => base.Can_generate_no_migration_script();
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
+    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_apply_all_migrations()
         => base.Can_apply_all_migrations();
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
+    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_apply_range_of_migrations()
         => base.Can_apply_range_of_migrations();
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
+    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_revert_all_migrations()
         => base.Can_revert_all_migrations();
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
+    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
     public override void Can_revert_one_migrations()
         => base.Can_revert_one_migrations();
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/33056")]
+    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/issues/33056")]
     public override Task Can_apply_all_migrations_async()
         => base.Can_apply_all_migrations_async();
 

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
@@ -3246,7 +3246,7 @@ CREATE COLLATION some_collation (LOCALE = 'en-u-ks-level1',
         AssertSql("""ALTER TABLE "Customers" ADD "Numbers" integer[] NOT NULL DEFAULT (ARRAY[1,2,3]);""");
     }
 
-    [ActiveIssue("issue #33038")]
+    [ConditionalFact(Skip = "issue #33038")]
     public override async Task Add_required_primitive_collection_with_custom_converter_to_existing_table()
     {
         await base.Add_required_primitive_collection_with_custom_converter_to_existing_table();
@@ -3337,7 +3337,7 @@ CREATE TABLE "Contacts" (
         AssertSql("""ALTER TABLE "Customers" ADD "Numbers" integer[] NOT NULL DEFAULT ARRAY[1,2,3]::integer[];""");
     }
 
-    [ActiveIssue("issue #33038")]
+    [ConditionalFact(Skip = "issue #33038")]
     public override async Task Add_required_primitve_collection_with_custom_converter_to_existing_table()
     {
         await base.Add_required_primitve_collection_with_custom_converter_to_existing_table();

--- a/test/EFCore.PG.FunctionalTests/Query/AdHocMiscellaneousQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/AdHocMiscellaneousQueryNpgsqlTest.cs
@@ -33,7 +33,7 @@ INSERT INTO "ZeroKey" VALUES (NULL)
     public override Task Subquery_first_member_compared_to_null(bool async)
         => Task.CompletedTask;
 
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/27995/files#r874038747")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/27995/files#r874038747")]
     public override Task StoreType_for_UDF_used(bool async)
         => base.StoreType_for_UDF_used(async);
 }

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonCollectionNpgsqlTest.cs
@@ -177,6 +177,7 @@ WHERE (CAST(r."AssociateCollection" #>> '{9999,Int}' AS integer)) = 8
 
     #region GroupBy
 
+    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/Navigations/NavigationsCollectionNpgsqlTest.cs
@@ -210,6 +210,7 @@ ORDER BY r."Id" NULLS FIRST, s."Id" NULLS FIRST
 
     #region GroupBy
 
+    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedJson/OwnedJsonCollectionNpgsqlTest.cs
@@ -191,6 +191,7 @@ WHERE (CAST(r."AssociateCollection" #>> '{9999,Int}' AS integer)) = 8
 
     #region GroupBy
 
+    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/OwnedNavigations/OwnedNavigationsCollectionNpgsqlTest.cs
@@ -213,6 +213,7 @@ ORDER BY r."Id" NULLS FIRST, s."RootEntityId" NULLS FIRST, s."Id" NULLS FIRST, s
 
     #region GroupBy
 
+    [ConditionalFact]
     public override async Task GroupBy()
     {
         await base.GroupBy();

--- a/test/EFCore.PG.FunctionalTests/Query/CompatibilityQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/CompatibilityQueryNpgsqlTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.EntityFrameworkCore.Query;
+namespace Microsoft.EntityFrameworkCore.Query;
 
 public class CompatibilityQueryNpgsqlTest : IClassFixture<CompatibilityQueryNpgsqlTest.CompatibilityQueryNpgsqlFixture>
 {
@@ -74,7 +74,7 @@ LIMIT 2
             return new CompatibilityContext(builder.Options);
         }
 
-        public virtual async ValueTask InitializeAsync()
+        public virtual async Task InitializeAsync()
         {
             _testStore = NpgsqlTestStoreFactory.Instance.GetOrCreate(StoreName);
             await _testStore.InitializeAsync(null, CreateContext, c => CompatibilityContext.SeedAsync((CompatibilityContext)c));
@@ -85,7 +85,7 @@ LIMIT 2
         {
         }
 
-        public virtual async ValueTask DisposeAsync()
+        public virtual async Task DisposeAsync()
             => await _testStore.DisposeAsync();
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsSharedTypeQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ComplexNavigationsSharedTypeQueryNpgsqlTest.cs
@@ -15,7 +15,7 @@ public class ComplexNavigationsSharedTypeQueryNpgsqlTest
         Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
     }
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/26353")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/26353")]
     public override Task Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy(bool async)
         => base.Subquery_with_Distinct_Skip_FirstOrDefault_without_OrderBy(async);
 
@@ -30,11 +30,11 @@ public class ComplexNavigationsSharedTypeQueryNpgsqlTest
                 "Microsoft.EntityFrameworkCore.Query.ComplexNavigationsQueryTestBase<Microsoft.EntityFrameworkCore.Query.ComplexNavigationsSharedTypeQueryNpgsqlFixture>",
                 "ClientMethodNullableInt"));
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/26104")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/26104")]
     public override Task GroupBy_aggregate_where_required_relationship(bool async)
         => base.GroupBy_aggregate_where_required_relationship(async);
 
-    [ActiveIssue("https://github.com/dotnet/efcore/issues/26104")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/issues/26104")]
     public override Task GroupBy_aggregate_where_required_relationship_2(bool async)
         => base.GroupBy_aggregate_where_required_relationship_2(async);
 }

--- a/test/EFCore.PG.FunctionalTests/Query/EntitySplittingQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/EntitySplittingQueryNpgsqlTest.cs
@@ -224,7 +224,7 @@ LEFT JOIN "OwnedReferenceExtras1" AS o0 ON e."Id" = o0."EntityOneId"
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing(bool async)
     {
         await base.Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing(async);
@@ -232,7 +232,7 @@ LEFT JOIN "OwnedReferenceExtras1" AS o0 ON e."Id" = o0."EntityOneId"
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing_custom_projection(bool async)
     {
         await base.Normal_entity_owning_a_split_reference_with_main_fragment_not_sharing_custom_projection(async);
@@ -240,7 +240,7 @@ LEFT JOIN "OwnedReferenceExtras1" AS o0 ON e."Id" = o0."EntityOneId"
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Normal_entity_owning_a_split_collection(bool async)
     {
         await base.Normal_entity_owning_a_split_collection(async);
@@ -291,7 +291,7 @@ ORDER BY e."Id" NULLS FIRST, o."EntityOneId" NULLS FIRST
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Split_entity_owning_a_split_reference_without_table_sharing(bool async)
     {
         await base.Split_entity_owning_a_split_reference_without_table_sharing(async);
@@ -299,7 +299,7 @@ ORDER BY e."Id" NULLS FIRST, o."EntityOneId" NULLS FIRST
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Split_entity_owning_a_split_collection(bool async)
     {
         await base.Split_entity_owning_a_split_collection(async);
@@ -334,7 +334,7 @@ LEFT JOIN "OwnedReferencePart3" AS o ON s."Id" = o."EntityOneId"
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Split_entity_owning_a_split_reference_with_table_sharing_6(bool async)
     {
         await base.Split_entity_owning_a_split_reference_with_table_sharing_6(async);
@@ -562,7 +562,7 @@ FROM "SiblingEntity" AS s
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tph_entity_owning_a_split_reference_on_base_without_table_sharing(bool async)
     {
         await base.Tph_entity_owning_a_split_reference_on_base_without_table_sharing(async);
@@ -570,7 +570,7 @@ FROM "SiblingEntity" AS s
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpt_entity_owning_a_split_reference_on_base_without_table_sharing(bool async)
     {
         await base.Tpt_entity_owning_a_split_reference_on_base_without_table_sharing(async);
@@ -604,7 +604,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."BaseEntityId" = o1."BaseEntityId"
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tph_entity_owning_a_split_reference_on_middle_without_table_sharing(bool async)
     {
         await base.Tph_entity_owning_a_split_reference_on_middle_without_table_sharing(async);
@@ -612,7 +612,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."BaseEntityId" = o1."BaseEntityId"
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpt_entity_owning_a_split_reference_on_middle_without_table_sharing(bool async)
     {
         await base.Tpt_entity_owning_a_split_reference_on_middle_without_table_sharing(async);
@@ -646,7 +646,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tph_entity_owning_a_split_reference_on_leaf_without_table_sharing(bool async)
     {
         await base.Tph_entity_owning_a_split_reference_on_leaf_without_table_sharing(async);
@@ -654,7 +654,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpt_entity_owning_a_split_reference_on_leaf_without_table_sharing(bool async)
     {
         await base.Tpt_entity_owning_a_split_reference_on_leaf_without_table_sharing(async);
@@ -662,7 +662,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpc_entity_owning_a_split_reference_on_leaf_without_table_sharing(bool async)
     {
         await base.Tpc_entity_owning_a_split_reference_on_leaf_without_table_sharing(async);
@@ -670,7 +670,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tph_entity_owning_a_split_collection_on_base(bool async)
     {
         await base.Tph_entity_owning_a_split_collection_on_base(async);
@@ -678,7 +678,7 @@ LEFT JOIN "OwnedReferencePart3" AS o1 ON o."MiddleEntityId" = o1."MiddleEntityId
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpt_entity_owning_a_split_collection_on_base(bool async)
     {
         await base.Tpt_entity_owning_a_split_collection_on_base(async);
@@ -716,7 +716,7 @@ ORDER BY u."Id" NULLS FIRST, s0."BaseEntityId" NULLS FIRST
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tph_entity_owning_a_split_collection_on_middle(bool async)
     {
         await base.Tph_entity_owning_a_split_collection_on_middle(async);
@@ -724,7 +724,7 @@ ORDER BY u."Id" NULLS FIRST, s0."BaseEntityId" NULLS FIRST
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpt_entity_owning_a_split_collection_on_middle(bool async)
     {
         await base.Tpt_entity_owning_a_split_collection_on_middle(async);
@@ -762,7 +762,7 @@ ORDER BY u."Id" NULLS FIRST, s0."MiddleEntityId" NULLS FIRST
 """);
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tph_entity_owning_a_split_collection_on_leaf(bool async)
     {
         await base.Tph_entity_owning_a_split_collection_on_leaf(async);
@@ -770,7 +770,7 @@ ORDER BY u."Id" NULLS FIRST, s0."MiddleEntityId" NULLS FIRST
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpt_entity_owning_a_split_collection_on_leaf(bool async)
     {
         await base.Tpt_entity_owning_a_split_collection_on_leaf(async);
@@ -778,7 +778,7 @@ ORDER BY u."Id" NULLS FIRST, s0."MiddleEntityId" NULLS FIRST
         AssertSql();
     }
 
-    [ActiveIssue("Issue29075")]
+    [ConditionalTheory(Skip = "Issue29075")]
     public override async Task Tpc_entity_owning_a_split_collection_on_leaf(bool async)
     {
         await base.Tpc_entity_owning_a_split_collection_on_leaf(async);

--- a/test/EFCore.PG.FunctionalTests/Query/FromSqlQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/FromSqlQueryNpgsqlTest.cs
@@ -7,11 +7,11 @@ namespace Microsoft.EntityFrameworkCore.Query;
 public class FromSqlQueryNpgsqlTest(NorthwindQueryNpgsqlFixture<NoopModelCustomizer> fixture)
     : FromSqlQueryTestBase<NorthwindQueryNpgsqlFixture<NoopModelCustomizer>>(fixture)
 {
-    [ActiveIssue("https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
+    [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
     public override Task Bad_data_error_handling_invalid_cast(bool async)
         => base.Bad_data_error_handling_invalid_cast(async);
 
-    [ActiveIssue("https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
+    [ConditionalTheory(Skip = "https://github.com/aspnet/EntityFramework/issues/{6563,20364}")]
     public override Task Bad_data_error_handling_invalid_cast_projection(bool async)
         => base.Bad_data_error_handling_invalid_cast_projection(async);
 
@@ -66,6 +66,7 @@ public class FromSqlQueryNpgsqlTest(NorthwindQueryNpgsqlFixture<NoopModelCustomi
         Assert.Single(actual);
     }
 
+    [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public override async Task FromSql_queryable_multiple_composed_with_parameters_and_closure_parameters_interpolated(bool async)
     {

--- a/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPCInheritanceQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Inheritance/TPCInheritanceQueryNpgsqlTest.cs
@@ -78,8 +78,11 @@ ORDER BY e1."Id" NULLS FIRST
 """);
     }
 
+    // Seed data for the fixture manually inserts entities with IDs 1, 2; then this test attempts to insert another one with an auto-generated ID,
+    // but the PG sequence wasn't updated so produces 1, resulting in a conflict. The test should be consistent in either using either
+    // auto-generated IDs or not across the board.
     public override Task Can_insert_update_delete()
-        => base.Can_insert_update_delete();
+        => Assert.ThrowsAsync<DbUpdateException>(base.Can_insert_update_delete);
 
     public override async Task Can_query_all_animals(bool async)
     {

--- a/test/EFCore.PG.FunctionalTests/Query/LegacyTimestampQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/LegacyTimestampQueryTest.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations.Schema;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal;
 
 #if DEBUG
@@ -110,10 +110,10 @@ WHERE now() AT TIME ZONE 'UTC' <> @myDatetime
                 NpgsqlTypeMappingSource.LegacyTimestampBehavior = true;
             }
 
-            public override ValueTask DisposeAsync()
+            public override Task DisposeAsync()
             {
                 NpgsqlTypeMappingSource.LegacyTimestampBehavior = false;
-                return ValueTask.CompletedTask;
+                return Task.CompletedTask;
             }
 
             protected override async Task SeedAsync(TimestampQueryContext context)

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindDbFunctionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindDbFunctionsQueryNpgsqlTest.cs
@@ -127,7 +127,7 @@ WHERE c."ContactName" NOT ILIKE '%M%' OR c."ContactName" IS NULL
     #region Collation
 
     [MinimumPostgresVersion(12, 0)]
-    [SkipOnPlatform(TestPlatforms.Windows, "ICU non-deterministic doesn't seem to work on Windows?")]
+    [PlatformSkipCondition(TestUtilities.Xunit.TestPlatform.Windows, SkipReason = "ICU non-deterministic doesn't seem to work on Windows?")]
     public override async Task Collate_case_insensitive(bool async)
     {
         await base.Collate_case_insensitive(async);

--- a/test/EFCore.PG.FunctionalTests/Query/NorthwindGroupByQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/NorthwindGroupByQueryNpgsqlTest.cs
@@ -2031,7 +2031,7 @@ ORDER BY o0."CustomerID" NULLS FIRST
 """);
     }
 
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/28410")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/28410")]
     public override async Task Select_nested_collection_with_groupby(bool async)
     {
         await base.Select_nested_collection_with_groupby(async);

--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -2657,6 +2657,7 @@ WHERE NOT (p."Int" = ANY (@ints) AND p."Int" = ANY (@ints) IS NOT NULL)
 """);
     }
 
+    [ConditionalFact]
     public override async Task Multidimensional_array_is_not_supported()
     {
         // Multidimensional arrays are supported in PostgreSQL (via the regular array type); the EFCore.PG maps .NET

--- a/test/EFCore.PG.FunctionalTests/Query/SqlQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/SqlQueryNpgsqlTest.cs
@@ -360,7 +360,7 @@ FROM (
 """);
     }
 
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
     public override async Task SqlQueryRaw_annotations_do_not_affect_successive_calls(bool async)
     {
         await base.SqlQueryRaw_annotations_do_not_affect_successive_calls(async);
@@ -460,7 +460,7 @@ SELECT * FROM "Customers" WHERE "CustomerID" = @somename
 """);
     }
 
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
     public override async Task SqlQuery_parameterization_issue_12213(bool async)
     {
         await base.SqlQuery_parameterization_issue_12213(async);
@@ -672,11 +672,11 @@ WHERE m."ContactName" LIKE '%z%'
     }
 
 #pragma warning disable xUnit1026
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
     public override Task Bad_data_error_handling_invalid_cast(bool async)
         => Task.CompletedTask;
 
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/30384")]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/efcore/pull/30384")]
     public override Task Bad_data_error_handling_invalid_cast_projection(bool async)
         => Task.CompletedTask;
 #pragma warning restore xUnit1026

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/ByteArrayTranslationsNpgsqlTest.cs
@@ -100,6 +100,7 @@ WHERE b."ByteArray" = @byteArrayParam
 """);
     }
 
+    [ConditionalFact]
     public override async Task Any()
     {
         await AssertQuery(ss => ss.Set<BasicTypesEntity>().Where(e => e.ByteArray.Any()));

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/MathTranslationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/MathTranslationsNpgsqlTest.cs
@@ -427,11 +427,6 @@ WHERE b."Float" > 0 AND sqrt(b."Float") > 0
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE sign(b."Double")::int > 0
-""",
-            //
-            """
-SELECT sign(b."Double")::int
-FROM "BasicTypesEntities" AS b
 """);
     }
 
@@ -444,11 +439,6 @@ FROM "BasicTypesEntities" AS b
 SELECT b."Id", b."Bool", b."Byte", b."ByteArray", b."DateOnly", b."DateTime", b."DateTimeOffset", b."Decimal", b."Double", b."Enum", b."FlagsEnum", b."Float", b."Guid", b."Int", b."Long", b."Short", b."String", b."TimeOnly", b."TimeSpan"
 FROM "BasicTypesEntities" AS b
 WHERE sign(b."Float")::int > 0
-""",
-            //
-            """
-SELECT sign(b."Float")::int
-FROM "BasicTypesEntities" AS b
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/UdfDbFunctionNpgsqlTests.cs
@@ -584,7 +584,7 @@ LIMIT 2
     #endregion
 
 #if RELEASE
-    [ActiveIssue("https://github.com/dotnet/efcore/pull/30388")]
+    [ConditionalFact(Skip = "https://github.com/dotnet/efcore/pull/30388")]
     public override void Scalar_Function_with_nullable_value_return_type_throws() {}
 #endif
 

--- a/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Scaffolding/NpgsqlDatabaseModelFactoryTest.cs
@@ -2214,7 +2214,7 @@ CREATE EXTENSION postgis;
         public new NpgsqlTestStore TestStore
             => (NpgsqlTestStore)base.TestStore;
 
-        public override async ValueTask InitializeAsync()
+        public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
             await TestStore.ExecuteNonQueryAsync("CREATE SCHEMA IF NOT EXISTS db2");

--- a/test/EFCore.PG.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EFCore.PG.FunctionalTests/SequenceEndToEndTest.cs
@@ -391,9 +391,9 @@ public class SequenceEndToEndTest : IAsyncLifetime
 
     protected NpgsqlTestStore TestStore { get; private set; } = null!;
 
-    public async ValueTask InitializeAsync()
+    public async Task InitializeAsync()
         => TestStore = await NpgsqlTestStore.CreateInitializedAsync("SequenceEndToEndTest");
 
-    public async ValueTask DisposeAsync()
+    public async Task DisposeAsync()
         => await TestStore.DisposeAsync();
 }

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/MinimumPostgresVersionAttribute.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/MinimumPostgresVersionAttribute.cs
@@ -1,16 +1,13 @@
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
-public sealed class MinimumPostgresVersionAttribute(int major, int minor) : Attribute, global::Xunit.v3.ITraitAttribute
+public sealed class MinimumPostgresVersionAttribute(int major, int minor) : Attribute, ITestCondition
 {
     private readonly Version _version = new(major, minor);
 
-    private bool IsMet
-        => TestEnvironment.PostgresVersion >= _version;
+    public ValueTask<bool> IsMetAsync()
+        => new(TestEnvironment.PostgresVersion >= _version);
 
     public string SkipReason
         => $"Requires PostgreSQL version {_version} or later.";
-
-    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits()
-        => IsMet ? [] : [new("category", "failing")];
 }

--- a/test/EFCore.PG.FunctionalTests/TestUtilities/RequiresPostgisAttribute.cs
+++ b/test/EFCore.PG.FunctionalTests/TestUtilities/RequiresPostgisAttribute.cs
@@ -1,17 +1,13 @@
-﻿using System.Globalization;
+using System.Globalization;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
-public sealed class RequiresPostgisAttribute : Attribute, global::Xunit.v3.ITraitAttribute
+public sealed class RequiresPostgisAttribute : Attribute, ITestCondition
 {
-    private static bool IsMet
-        => TestEnvironment.IsPostgisAvailable
-            || Environment.GetEnvironmentVariable("NPGSQL_TEST_POSTGIS")?.ToLower(CultureInfo.InvariantCulture) is "1" or "true";
+    public ValueTask<bool> IsMetAsync()
+        => new(TestEnvironment.IsPostgisAvailable || Environment.GetEnvironmentVariable("NPGSQL_TEST_POSTGIS")?.ToLower(CultureInfo.InvariantCulture) is "1" or "true");
 
     public string SkipReason
         => "PostGIS isn't installed, skipping";
-
-    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits()
-        => IsMet ? [] : [new("category", "failing")];
 }

--- a/test/EFCore.PG.FunctionalTests/Update/JsonUpdateNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Update/JsonUpdateNpgsqlTest.cs
@@ -1255,6 +1255,7 @@ LIMIT 2
 """);
     }
 
+    [ConditionalFact]
     public override async Task Edit_single_property_with_converter_string_True_False_to_bool()
     {
         await base.Edit_single_property_with_converter_string_True_False_to_bool();
@@ -1276,6 +1277,7 @@ LIMIT 2
 """);
     }
 
+    [ConditionalFact]
     public override async Task Edit_single_property_with_converter_string_Y_N_to_bool()
     {
         await base.Edit_single_property_with_converter_string_Y_N_to_bool();

--- a/test/EFCore.PG.FunctionalTests/ValueConvertersEndToEndNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/ValueConvertersEndToEndNpgsqlTest.cs
@@ -3,7 +3,7 @@ namespace Microsoft.EntityFrameworkCore;
 public class ValueConvertersEndToEndNpgsqlTest(ValueConvertersEndToEndNpgsqlTest.ValueConvertersEndToEndNpgsqlFixture fixture)
     : ValueConvertersEndToEndTestBase<ValueConvertersEndToEndNpgsqlTest.ValueConvertersEndToEndNpgsqlFixture>(fixture)
 {
-    [ActiveIssue("DateTime and DateTimeOffset, https://github.com/dotnet/efcore/issues/26068")]
+    [ConditionalTheory(Skip = "DateTime and DateTimeOffset, https://github.com/dotnet/efcore/issues/26068")]
     public override Task Can_insert_and_read_back_with_conversions(int[] valueOrder)
         => base.Can_insert_and_read_back_with_conversions(valueOrder);
 


### PR DESCRIPTION
Syncs EFCore.PG to the latest EF Core daily build on the preview.5 line: **11.0.0-preview.5.26275.101 → 11.0.0-preview.5.26279.113**.

## What changed

The main fallout is that EF Core's test infrastructure was reverted from **xunit v3 back to xunit v2** on the preview.5 line. The `Microsoft.EntityFrameworkCore.Specification.Tests` package dependencies changed accordingly:

| | 26275.101 | 26279.113 |
|---|---|---|
| xunit | `xunit.v3.assert` / `xunit.v3.extensibility.core` 4.0.0-pre.108 | `xunit.assert` / `xunit.core` 2.9.3 |
| extensions | `Microsoft.DotNet.XUnitV3Extensions` | `xunit.runner.visualstudio` 4.0.0-pre.4 |

This required reverting the xunit-v3 / Microsoft.Testing.Platform migration that was introduced in the previous sync (commit 3ddc83c0, "Sync to EF 11.0.0-preview.5.26275.101"), while preserving the genuine EF API/test fallout from that commit. Concretely:

- **Framework config** reverted to xunit v2: removed the `xunit.v3` package, the MTP runner wiring in `test/Directory.Build.props` (`UseMicrosoftTestingPlatformRunner`, `OutputType=Exe`, `TestRunnerName=XUnitV3`, `TestingPlatformCommandLineArguments`), the `Microsoft.Testing.Platform` runner in `global.json`, the `dotnet-eng` package-source mapping in `NuGet.config`, and restored the classic `dotnet test` invocation in `build.yml`.
- **Test code** reverted from xunit v3 idioms back to v2: `[ActiveIssue(...)]` → `[ConditionalFact/Theory(Skip = ...)]`, `[SkipOnPlatform(TestPlatforms.X, ...)]` → `[PlatformSkipCondition(...)]`, `IAsyncLifetime` overrides `ValueTask` → `Task`, and the `RequiresPostgis` / `MinimumPostgresVersion` attributes back to `ITestCondition`.
- **Test baselines** adjusted to match the target build: `MathTranslationsNpgsqlTest.Sign`/`Sign_float` now assert a single query, and `TPCInheritanceQueryNpgsqlTest.Can_insert_update_delete` again asserts the PG seed/sequence conflict.

## EF-side changes

EF Core's product source is essentially unchanged between these two daily builds — the relevant change is the test-infrastructure downgrade from xunit v3 to xunit v2 on the `release/11.0-preview5` line (`main` remains on xunit v3 via dotnet/efcore#38277). The change flows through the dotnet/dotnet VMR, so there is no single dotnet/efcore product PR to attribute it to.

## Validation

- Full solution builds clean (Release, 0 warnings/errors).
- Unit tests: **491 passed**, 6 skipped, 0 failed.
- Functional tests against PostgreSQL: **27830 passed**, 274 skipped, **0 failed**.
