### PR TITLE
Fix JSON null type mapping on hotfix

### DIFF
--- a/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -1443,7 +1443,7 @@ public class NpgsqlQueryableMethodTranslatingExpressionVisitor : RelationalQuery
     private SqlExpression JsonNull(RelationalTypeMapping jsonTypeMapping)
         => new SqlUnaryExpression(
             ExpressionType.Convert,
-            _sqlExpressionFactory.Constant("null"),
+            _sqlExpressionFactory.Constant("null", _typeMappingSource.FindMapping(typeof(string))),
             jsonTypeMapping.ClrType,
             jsonTypeMapping);
 

--- a/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonBulkUpdateNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Associations/ComplexJson/ComplexJsonBulkUpdateNpgsqlTest.cs
@@ -49,7 +49,7 @@ WHERE r."Name" = @deletableEntity_Name
 @p='?'
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{String}', to_jsonb(@p))
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{String}', to_jsonb(@p))
 """);
     }
 
@@ -60,7 +60,7 @@ SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{String}', to_js
         AssertExecuteUpdateSql(
             """
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{String}', to_jsonb('{ Some other/JSON:like text though it [isn''t]: ממש ממש לאéèéè }'::text))
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{String}', to_jsonb('{ Some other/JSON:like text though it [isn''t]: ממש ממש לאéèéè }'::text))
 WHERE (r."RequiredAssociate" ->> 'String') = '{ this may/look:like JSON but it [isn''t]: ממש ממש לאéèéè }'
 """);
     }
@@ -74,7 +74,7 @@ WHERE (r."RequiredAssociate" ->> 'String') = '{ this may/look:like JSON but it [
 @p='?'
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{RequiredNestedAssociate,String}', to_jsonb(@p))
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{RequiredNestedAssociate,String}', to_jsonb(@p))
 """);
     }
 
@@ -87,7 +87,7 @@ SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{RequiredNestedA
 @p='?'
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{String}', to_jsonb(@p))
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{String}', to_jsonb(@p))
 """);
     }
 
@@ -131,7 +131,7 @@ SET "RequiredAssociate" = @complex_type_p
 @complex_type_p='?' (DbType = Object)
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{RequiredNestedAssociate}', @complex_type_p)
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{RequiredNestedAssociate}', @complex_type_p)
 """);
     }
 
@@ -258,7 +258,7 @@ SET "AssociateCollection" = @complex_type_p
 @complex_type_p='?' (DbType = Object)
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{NestedCollection}', @complex_type_p)
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{NestedCollection}', @complex_type_p)
 """);
     }
 
@@ -280,7 +280,7 @@ SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{NestedCollection}',
         AssertExecuteUpdateSql(
             """
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{NestedCollection}', r."OptionalAssociate" -> 'NestedCollection')
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{NestedCollection}', COALESCE(r."OptionalAssociate" -> 'NestedCollection', 'null'::jsonb))
 WHERE (r."OptionalAssociate") IS NOT NULL
 """);
     }
@@ -323,7 +323,7 @@ SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{Ints}', '[1,2,4]')
 @ints='?' (DbType = Object)
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{Ints}', @ints)
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{Ints}', @ints)
 """);
     }
 
@@ -347,7 +347,7 @@ SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{OptionalNestedAssoc
 @p='?' (DbType = Int32)
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{Ints,1}', to_jsonb(@p))
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{Ints,1}', to_jsonb(@p))
 WHERE jsonb_array_length(r."RequiredAssociate" -> 'Ints') >= 2
 """);
     }
@@ -366,7 +366,7 @@ WHERE jsonb_array_length(r."RequiredAssociate" -> 'Ints') >= 2
 @p1='?' (DbType = Int32)
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(jsonb_set_lax(r."RequiredAssociate", '{String}', to_jsonb(@p)), '{Int}', to_jsonb(@p1))
+SET "RequiredAssociate" = jsonb_set(jsonb_set(r."RequiredAssociate", '{String}', to_jsonb(@p)), '{Int}', to_jsonb(@p1))
 """);
     }
 
@@ -380,8 +380,8 @@ SET "RequiredAssociate" = jsonb_set_lax(jsonb_set_lax(r."RequiredAssociate", '{S
 
 UPDATE "RootEntity" AS r
 SET "Name" = r."Name" || 'Modified',
-    "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{String}', r."OptionalAssociate" -> 'String'),
-    "OptionalAssociate" = jsonb_set_lax(r."OptionalAssociate", '{RequiredNestedAssociate,String}', to_jsonb(@p))
+    "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{String}', COALESCE(r."OptionalAssociate" -> 'String', 'null'::jsonb)),
+    "OptionalAssociate" = jsonb_set(r."OptionalAssociate", '{RequiredNestedAssociate,String}', to_jsonb(@p))
 WHERE (r."OptionalAssociate") IS NOT NULL
 """);
     }
@@ -395,8 +395,8 @@ WHERE (r."OptionalAssociate") IS NOT NULL
 @p='?'
 
 UPDATE "RootEntity" AS r
-SET "RequiredAssociate" = jsonb_set_lax(r."RequiredAssociate", '{String}', r."OptionalAssociate" -> 'String'),
-    "OptionalAssociate" = jsonb_set_lax(r."OptionalAssociate", '{String}', to_jsonb(@p))
+SET "RequiredAssociate" = jsonb_set(r."RequiredAssociate", '{String}', COALESCE(r."OptionalAssociate" -> 'String', 'null'::jsonb)),
+    "OptionalAssociate" = jsonb_set(r."OptionalAssociate", '{String}', to_jsonb(@p))
 WHERE (r."OptionalAssociate") IS NOT NULL
 """);
     }

--- a/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlBoolTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlBoolTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='False'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(FALSE::boolean))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(FALSE::boolean))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlByteArrayTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlByteArrayTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='0x04050607'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encode(@Fixture_OtherValue, 'base64')))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(encode(@Fixture_OtherValue, 'base64')))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encod
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encode(BYTEA E'\\x04050607', 'base64')))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(encode(BYTEA E'\\x04050607', 'base64')))
 """);
     }
 
@@ -80,7 +80,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encod
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encode(decode(j."JsonContainer" ->> 'OtherValue', 'base64'), 'base64')))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(to_jsonb(encode(decode(j."JsonContainer" ->> 'OtherValue', 'base64'), 'base64')), 'null'::jsonb))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encod
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(encode(j."OtherValue", 'base64')))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(to_jsonb(encode(j."OtherValue", 'base64')), 'null'::jsonb))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlGuidTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlGuidTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='ae192c36-9004-49b2-b785-8be10d169627'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb('ae192c36-9004-49b2-b785-8be10d169627'::uuid))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb('ae192c36-9004-49b2-b785-8be10d169627'::uuid))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlStringTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Miscellaneous/NpgsqlStringTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='bar'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb('bar'::text))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb('bar'::text))
 """);
     }
 
@@ -80,7 +80,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb('bar'
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', j."JsonContainer" -> 'OtherValue')
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(j."JsonContainer" -> 'OtherValue', 'null'::jsonb))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', j."JsonContain
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(to_jsonb(j."OtherValue"), 'null'::jsonb))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Networking/NpgsqlInetTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Networking/NpgsqlInetTypeTest.cs
@@ -60,7 +60,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='192.168.1.2' (DbType = Object)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -71,7 +71,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(INET '192.168.1.2'::inet))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(INET '192.168.1.2'::inet))
 """);
     }
 
@@ -82,7 +82,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(INET 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', j."JsonContainer" -> 'OtherValue')
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(j."JsonContainer" -> 'OtherValue', 'null'::jsonb))
 """);
     }
 
@@ -93,7 +93,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', j."JsonContain
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(to_jsonb(j."OtherValue"), 'null'::jsonb))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Networking/NpgsqlMacaddrTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Networking/NpgsqlMacaddrTypeTest.cs
@@ -60,7 +60,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='001422012346' (DbType = Object)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -71,7 +71,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(MACADDR '001422012346'::macaddr))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(MACADDR '001422012346'::macaddr))
 """);
     }
 
@@ -82,7 +82,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(MACAD
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', j."JsonContainer" -> 'OtherValue')
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(j."JsonContainer" -> 'OtherValue', 'null'::jsonb))
 """);
     }
 
@@ -93,7 +93,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', j."JsonContain
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', COALESCE(to_jsonb(j."OtherValue"), 'null'::jsonb))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlDecimalTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlDecimalTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='30'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(30.0::numeric))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(30.0::numeric))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlDoubleTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlDoubleTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='30'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(30.0::double precision))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(30.0::double precision))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlFloatTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlFloatTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='30'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(30::real))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(30::real))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlIntTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlIntTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='2147483647'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(2147483647::int))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(2147483647::int))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlLongTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlLongTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='9223372036854775807'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(9223372036854775807::bigint))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(9223372036854775807::bigint))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlShortTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Numeric/NpgsqlShortTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='32767'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(32767::smallint))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(32767::smallint))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateOnlyTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateOnlyTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='05/03/2022' (DbType = Date)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(DATE '2022-05-03'::date))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(DATE '2022-05-03'::date))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateTimeOffsetTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateTimeOffsetTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='2020-01-05T13:30:45.0000000+00:00' (DbType = DateTime)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(TIMESTAMPTZ '2020-01-05T13:30:45+00:00'::timestamptz))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(TIMESTAMPTZ '2020-01-05T13:30:45+00:00'::timestamptz))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateTimeUnspecifiedTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateTimeUnspecifiedTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='2022-05-03T00:00:00.0000000'
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(TIMESTAMP '2022-05-03T00:00:00'::timestamp))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(TIMESTAMP '2022-05-03T00:00:00'::timestamp))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateTimeUtcTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlDateTimeUtcTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='2022-05-03T00:00:00.0000000Z' (DbType = DateTime)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(TIMESTAMPTZ '2022-05-03T00:00:00Z'::timestamptz))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(TIMESTAMPTZ '2022-05-03T00:00:00Z'::timestamptz))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlTimeOnlyTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlTimeOnlyTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='14:00' (DbType = Time)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(TIME '14:00:00'::time without time zone))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(TIME '14:00:00'::time without time zone))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 

--- a/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlTimeSpanTypeTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Types/Temporal/NpgsqlTimeSpanTypeTest.cs
@@ -58,7 +58,7 @@ WHERE "Id" = @p1;
 @Fixture_OtherValue='14:00:00' (DbType = Object)
 
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(@Fixture_OtherValue))
 """);
     }
 
@@ -69,7 +69,7 @@ SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(@Fixt
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(INTERVAL '14:00:00'::interval))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(INTERVAL '14:00:00'::interval))
 """);
     }
 
@@ -91,7 +91,7 @@ SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', j."JsonContainer" 
         AssertSql(
             """
 UPDATE "JsonTypeEntity" AS j
-SET "JsonContainer" = jsonb_set_lax(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
+SET "JsonContainer" = jsonb_set(j."JsonContainer", '{Value}', to_jsonb(j."OtherValue"))
 """);
     }
 


### PR DESCRIPTION
The hotfix backport of #3855 fails CI because EF10's type-mapping postprocessor rejects the unmapped string literal used as the operand for the generated JSON null cast.

This assigns the literal operand its string type mapping before converting it to the JSON mapping, preserving the existing SQL shape while keeping the expression tree fully typed.

Tests:
-   EFCore.PG -> /Users/roji/.copilot/repos/copilot-worktrees/efcore.pg/roji-cautious-train/src/EFCore.PG/bin/Release/net10.0/Npgsql.EntityFrameworkCore.PostgreSQL.dll
  EFCore.PG.NTS -> /Users/roji/.copilot/repos/copilot-worktrees/efcore.pg/roji-cautious-train/src/EFCore.PG.NTS/bin/Release/net10.0/Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite.dll
  EFCore.PG.NodaTime -> /Users/roji/.copilot/repos/copilot-worktrees/efcore.pg/roji-cautious-train/src/EFCore.PG.NodaTime/bin/Release/net10.0/Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime.dll
  EFCore.PG.FunctionalTests -> /Users/roji/.copilot/repos/copilot-worktrees/efcore.pg/roji-cautious-train/test/EFCore.PG.FunctionalTests/bin/Release/net10.0/Npgsql.EntityFrameworkCore.PostgreSQL.FunctionalTests.dll
  EFCore.PG.Tests -> /Users/roji/.copilot/repos/copilot-worktrees/efcore.pg/roji-cautious-train/test/EFCore.PG.Tests/bin/Release/net10.0/Npgsql.EntityFrameworkCore.PostgreSQL.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:17.87
- 