### PR TITLE
Add generic date_trunc translation

### DIFF
--- a/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMethodCallTranslatorPlugin.cs
@@ -111,11 +111,13 @@ public class NpgsqlNodaTimeMethodCallTranslator(
         SqlExpression value,
         SqlExpression timeZone)
     {
-        if (returnType != typeof(LocalDateTime)
-            && returnType != typeof(Instant)
-            && returnType != typeof(ZonedDateTime)
-            && returnType != typeof(Period)
-            && returnType != typeof(Duration))
+        var type = Nullable.GetUnderlyingType(returnType) ?? returnType;
+
+        if (type != typeof(LocalDateTime)
+            && type != typeof(Instant)
+            && type != typeof(ZonedDateTime)
+            && type != typeof(Period)
+            && type != typeof(Duration))
         {
             return null;
         }

--- a/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMethodCallTranslatorPlugin.cs
@@ -52,7 +52,7 @@ public class NpgsqlNodaTimeMethodCallTranslator(
     private readonly IRelationalTypeMappingSource _typeMappingSource = typeMappingSource;
     private readonly NpgsqlSqlExpressionFactory _sqlExpressionFactory = sqlExpressionFactory;
 
-    private static readonly bool[][] TrueArrays = [[], [true], [true, true]];
+    private static readonly bool[][] TrueArrays = [[], [true], [true, true], [true, true, true]];
 
 #pragma warning disable EF1001
     /// <inheritdoc />
@@ -63,7 +63,8 @@ public class NpgsqlNodaTimeMethodCallTranslator(
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
     {
         var translated =
-            TranslateInstant(instance, method, arguments)
+            TranslateDbFunctions(method, arguments)
+            ?? TranslateInstant(instance, method, arguments)
             ?? TranslateZonedDateTime(instance, method, arguments)
             ?? TranslateLocalDateTime(instance, method, arguments)
             ?? TranslateLocalDate(instance, method, arguments)
@@ -84,6 +85,55 @@ public class NpgsqlNodaTimeMethodCallTranslator(
         }
 
         return null;
+    }
+
+    private SqlExpression? TranslateDbFunctions(
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments)
+    {
+        if (method.DeclaringType != typeof(NpgsqlDbFunctionsExtensions))
+        {
+            return null;
+        }
+
+        return method.Name switch
+        {
+            nameof(NpgsqlDbFunctionsExtensions.DateTrunc) when arguments is [_, var field, var value, var timeZone]
+                => TranslateDateTrunc(method.ReturnType, field, value, timeZone),
+
+            _ => null
+        };
+    }
+
+    private SqlExpression? TranslateDateTrunc(
+        Type returnType,
+        SqlExpression field,
+        SqlExpression value,
+        SqlExpression timeZone)
+    {
+        if (returnType != typeof(LocalDateTime)
+            && returnType != typeof(Instant)
+            && returnType != typeof(ZonedDateTime)
+            && returnType != typeof(Period)
+            && returnType != typeof(Duration))
+        {
+            return null;
+        }
+
+        var fieldArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(field);
+        var valueArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(value);
+        var hasTimeZone = timeZone is not SqlConstantExpression { Value: null };
+        var arguments = hasTimeZone
+            ? [fieldArgument, valueArgument, _sqlExpressionFactory.ApplyDefaultTypeMapping(timeZone)]
+            : new[] { fieldArgument, valueArgument };
+
+        return _sqlExpressionFactory.Function(
+            "date_trunc",
+            arguments,
+            nullable: true,
+            argumentsPropagateNullability: TrueArrays[arguments.Length],
+            returnType,
+            valueArgument.TypeMapping);
     }
 
     private SqlExpression? TranslateInstant(

--- a/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.PG.NodaTime/Query/Internal/NpgsqlNodaTimeMethodCallTranslatorPlugin.cs
@@ -123,6 +123,12 @@ public class NpgsqlNodaTimeMethodCallTranslator(
         var fieldArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(field);
         var valueArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(value);
         var hasTimeZone = timeZone is not SqlConstantExpression { Value: null };
+
+        if (hasTimeZone && valueArgument.TypeMapping is not (TimestampTzInstantMapping or TimestampTzZonedDateTimeMapping))
+        {
+            return null;
+        }
+
         var arguments = hasTimeZone
             ? [fieldArgument, valueArgument, _sqlExpressionFactory.ApplyDefaultTypeMapping(timeZone)]
             : new[] { fieldArgument, valueArgument };

--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDbFunctionsExtensions.cs
@@ -143,6 +143,23 @@ public static class NpgsqlDbFunctionsExtensions
         => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(Distance)));
 
     /// <summary>
+    ///     Truncates <paramref name="value" /> to the specified precision.
+    ///     Corresponds to the PostgreSQL <c>date_trunc</c> function.
+    /// </summary>
+    /// <param name="_">The <see cref="DbFunctions" /> instance.</param>
+    /// <param name="field">
+    ///     The precision to truncate to, such as <c>microseconds</c>, <c>milliseconds</c>, <c>second</c>, <c>minute</c>, <c>hour</c>,
+    ///     <c>day</c>, <c>week</c>, <c>month</c>, <c>quarter</c>, <c>year</c>, <c>decade</c>, <c>century</c> or <c>millennium</c>.
+    /// </param>
+    /// <param name="value">The timestamp or interval to truncate.</param>
+    /// <param name="timeZone">
+    ///     The time zone in which to perform the truncation. Supported only for values mapped to <c>timestamp with time zone</c>.
+    /// </param>
+    /// <see href="https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC" />
+    public static T DateTrunc<T>(this DbFunctions _, string field, T value, string? timeZone = null)
+        => throw new InvalidOperationException(CoreStrings.FunctionOnClient(nameof(DateTrunc)));
+
+    /// <summary>
     ///     Converts string to date according to the given format.
     /// </summary>
     /// <param name="_">The <see cref="DbFunctions"/> instance.</param>

--- a/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDbFunctionsExtensions.cs
+++ b/src/EFCore.PG/Extensions/DbFunctionsExtensions/NpgsqlDbFunctionsExtensions.cs
@@ -154,6 +154,7 @@ public static class NpgsqlDbFunctionsExtensions
     /// <param name="value">The timestamp or interval to truncate.</param>
     /// <param name="timeZone">
     ///     The time zone in which to perform the truncation. Supported only for values mapped to <c>timestamp with time zone</c>.
+    ///     Requires PostgreSQL 12 or later.
     /// </param>
     /// <see href="https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC" />
     public static T DateTrunc<T>(this DbFunctions _, string field, T value, string? timeZone = null)

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
@@ -59,7 +59,9 @@ public class NpgsqlDateTimeMethodTranslator(
         SqlExpression value,
         SqlExpression timeZone)
     {
-        if (returnType != typeof(DateTime) && returnType != typeof(DateTimeOffset) && returnType != typeof(TimeSpan))
+        var type = Nullable.GetUnderlyingType(returnType) ?? returnType;
+
+        if (type != typeof(DateTime) && type != typeof(DateTimeOffset) && type != typeof(TimeSpan))
         {
             return null;
         }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
@@ -68,7 +68,7 @@ public class NpgsqlDateTimeMethodTranslator(
         var valueArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(value);
         var hasTimeZone = timeZone is not SqlConstantExpression { Value: null };
 
-        if (hasTimeZone && returnType == typeof(TimeSpan))
+        if (hasTimeZone && valueArgument.TypeMapping is not NpgsqlTimestampTzTypeMapping)
         {
             return null;
         }

--- a/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
+++ b/src/EFCore.PG/Query/ExpressionTranslators/Internal/NpgsqlDateTimeMethodTranslator.cs
@@ -1,5 +1,6 @@
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
+using static Npgsql.EntityFrameworkCore.PostgreSQL.Utilities.Statics;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Query.ExpressionTranslators.Internal;
 
@@ -27,11 +28,63 @@ public class NpgsqlDateTimeMethodTranslator(
         MethodInfo method,
         IReadOnlyList<SqlExpression> arguments,
         IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-        => TranslateDateTime(instance, method, arguments)
+        => TranslateDbFunctions(method, arguments)
+           ?? TranslateDateTime(instance, method, arguments)
            ?? TranslateDateOnly(instance, method, arguments)
            ?? TranslateTimeOnly(instance, method, arguments)
            ?? TranslateTimeZoneInfo(method, arguments)
            ?? TranslateDatePart(instance, method, arguments);
+
+    private SqlExpression? TranslateDbFunctions(
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments)
+    {
+        if (method.DeclaringType != typeof(NpgsqlDbFunctionsExtensions))
+        {
+            return null;
+        }
+
+        return method.Name switch
+        {
+            nameof(NpgsqlDbFunctionsExtensions.DateTrunc) when arguments is [_, var field, var value, var timeZone]
+                => TranslateDateTrunc(method.ReturnType, field, value, timeZone),
+
+            _ => null
+        };
+    }
+
+    private SqlExpression? TranslateDateTrunc(
+        Type returnType,
+        SqlExpression field,
+        SqlExpression value,
+        SqlExpression timeZone)
+    {
+        if (returnType != typeof(DateTime) && returnType != typeof(DateTimeOffset) && returnType != typeof(TimeSpan))
+        {
+            return null;
+        }
+
+        var fieldArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(field);
+        var valueArgument = _sqlExpressionFactory.ApplyDefaultTypeMapping(value);
+        var hasTimeZone = timeZone is not SqlConstantExpression { Value: null };
+
+        if (hasTimeZone && returnType == typeof(TimeSpan))
+        {
+            return null;
+        }
+
+        var arguments = hasTimeZone
+            ? [fieldArgument, valueArgument, _sqlExpressionFactory.ApplyDefaultTypeMapping(timeZone)]
+            : new[] { fieldArgument, valueArgument };
+
+        return _sqlExpressionFactory.Function(
+            "date_trunc",
+            arguments,
+            nullable: true,
+            argumentsPropagateNullability: TrueArrays[arguments.Length],
+            returnType,
+            valueArgument.TypeMapping);
+    }
 
     private SqlExpression? TranslateDatePart(
         SqlExpression? instance,

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/DurationTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/DurationTranslationsTest.cs
@@ -156,6 +156,20 @@ WHERE floor(date_part('second', n."Duration"))::int = 8
 """);
     }
 
+    [ConditionalFact] // #3831
+    public async Task DateTrunc()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<NodaTimeTypes>().Select(t => EF.Functions.DateTrunc("day", t.Duration)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', n."Duration")
+FROM "NodaTimeTypes" AS n
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public async Task GroupBy_Property_Select_Sum_over_Duration(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/DurationTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/DurationTranslationsTest.cs
@@ -170,6 +170,17 @@ FROM "NodaTimeTypes" AS n
 """);
     }
 
+    [ConditionalFact] // #3831
+    public Task DateTrunc_with_timezone_is_not_translated()
+    {
+        using var ctx = CreateContext();
+
+        return AssertTranslationFailed(
+            () => ctx.Set<NodaTimeTypes>()
+                .Where(t => EF.Functions.DateTrunc("day", t.Duration, "Europe/Berlin") == Duration.Zero)
+                .ToListAsync());
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public async Task GroupBy_Property_Select_Sum_over_Duration(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/InstantTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/InstantTranslationsTest.cs
@@ -84,6 +84,7 @@ WHERE CAST(n."Instant" AT TIME ZONE 'Europe/Berlin' AS date) = DATE '2018-04-20'
     }
 
     [ConditionalFact] // #3831
+    [MinimumPostgresVersion(12, 0)]
     public async Task DateTrunc_with_timezone()
     {
         await using var ctx = CreateContext();

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/InstantTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/InstantTranslationsTest.cs
@@ -83,6 +83,34 @@ WHERE CAST(n."Instant" AT TIME ZONE 'Europe/Berlin' AS date) = DATE '2018-04-20'
 """);
     }
 
+    [ConditionalFact] // #3831
+    public async Task DateTrunc_with_timezone()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<NodaTimeTypes>().Select(t => EF.Functions.DateTrunc("day", t.Instant, "Europe/Berlin")).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', n."Instant", 'Europe/Berlin')
+FROM "NodaTimeTypes" AS n
+""");
+    }
+
+    [ConditionalFact] // #3831
+    public async Task DateTrunc_without_timezone()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<NodaTimeTypes>().Select(t => EF.Functions.DateTrunc("day", t.Instant)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', n."Instant")
+FROM "NodaTimeTypes" AS n
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public async Task InZone_parameter_LocalDateTime(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/LocalDateTimeTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/LocalDateTimeTranslationsTest.cs
@@ -156,6 +156,20 @@ WHERE n."LocalDateTime"::date = DATE '2018-04-20'
 """);
     }
 
+    [ConditionalFact] // #3831
+    public async Task DateTrunc()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<NodaTimeTypes>().Select(t => EF.Functions.DateTrunc("day", t.LocalDateTime)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', n."LocalDateTime")
+FROM "NodaTimeTypes" AS n
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public async Task Time(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/LocalDateTimeTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/LocalDateTimeTranslationsTest.cs
@@ -170,6 +170,17 @@ FROM "NodaTimeTypes" AS n
 """);
     }
 
+    [ConditionalFact] // #3831
+    public Task DateTrunc_with_timezone_is_not_translated()
+    {
+        using var ctx = CreateContext();
+
+        return AssertTranslationFailed(
+            () => ctx.Set<NodaTimeTypes>()
+                .Where(t => EF.Functions.DateTrunc("day", t.LocalDateTime, "Europe/Berlin") == default)
+                .ToListAsync());
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public async Task Time(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/PeriodTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/PeriodTranslationsTest.cs
@@ -122,6 +122,17 @@ FROM "NodaTimeTypes" AS n
 """);
     }
 
+    [ConditionalFact] // #3831
+    public Task DateTrunc_with_timezone_is_not_translated()
+    {
+        using var ctx = CreateContext();
+
+        return AssertTranslationFailed(
+            () => ctx.Set<NodaTimeTypes>()
+                .Where(t => EF.Functions.DateTrunc("day", t.Period, "Europe/Berlin") == Period.Zero)
+                .ToListAsync());
+    }
+
     // PostgreSQL does not support extracting weeks from intervals
     [ConditionalFact]
     public Task Weeks_is_not_translated()

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/PeriodTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/PeriodTranslationsTest.cs
@@ -108,6 +108,20 @@ WHERE floor(date_part('second', n."Period"))::int = 23
 """);
     }
 
+    [ConditionalFact] // #3831
+    public async Task DateTrunc()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<NodaTimeTypes>().Select(t => EF.Functions.DateTrunc("day", t.Period)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', n."Period")
+FROM "NodaTimeTypes" AS n
+""");
+    }
+
     // PostgreSQL does not support extracting weeks from intervals
     [ConditionalFact]
     public Task Weeks_is_not_translated()

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/ZonedDateTimeTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/NodaTime/ZonedDateTimeTranslationsTest.cs
@@ -156,6 +156,20 @@ WHERE CAST(n."ZonedDateTime" AT TIME ZONE 'UTC' AS date) = DATE '2018-04-20'
 """);
     }
 
+    [ConditionalFact] // #3831
+    public async Task DateTrunc_without_timezone()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<NodaTimeTypes>().Select(t => EF.Functions.DateTrunc("day", t.ZonedDateTime)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', n."ZonedDateTime")
+FROM "NodaTimeTypes" AS n
+""");
+    }
+
     [ConditionalTheory]
     [MemberData(nameof(IsAsyncData))]
     public async Task DayOfWeek(bool async)

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/TimestampTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/TimestampTranslationsTest.cs
@@ -469,6 +469,62 @@ FROM "Entities" AS e
         }
     }
 
+    [ConditionalFact] // #3831
+    public async Task DateTime_DateTrunc()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<Entity>().Select(e => EF.Functions.DateTrunc("day", e.TimestampDateTime)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', e."TimestampDateTime")
+FROM "Entities" AS e
+""");
+    }
+
+    [ConditionalFact] // #3831
+    public async Task DateTimeOffset_DateTrunc_with_timezone()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<Entity>().Select(e => EF.Functions.DateTrunc("day", e.TimestampDateTimeOffset, "Europe/Berlin")).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', e."TimestampDateTimeOffset", 'Europe/Berlin')
+FROM "Entities" AS e
+""");
+    }
+
+    [ConditionalFact] // #3831
+    public async Task DateTimeOffset_DateTrunc_without_timezone()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<Entity>().Select(e => EF.Functions.DateTrunc("day", e.TimestampDateTimeOffset)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('day', e."TimestampDateTimeOffset")
+FROM "Entities" AS e
+""");
+    }
+
+    [ConditionalFact] // #3831
+    public async Task TimeSpan_DateTrunc()
+    {
+        await using var ctx = CreateContext();
+
+        _ = await ctx.Set<Entity>().Select(e => EF.Functions.DateTrunc("hour", e.TimestamptzDateTime - e.TimestamptzDateTime)).ToListAsync();
+
+        AssertSql(
+            """
+SELECT date_trunc('hour', e."TimestamptzDateTime" - e."TimestamptzDateTime")
+FROM "Entities" AS e
+""");
+    }
+
     #endregion DateTimeOffset
 
     #region DateTime constructors

--- a/test/EFCore.PG.FunctionalTests/Query/Translations/TimestampTranslationsTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/Translations/TimestampTranslationsTest.cs
@@ -484,6 +484,7 @@ FROM "Entities" AS e
     }
 
     [ConditionalFact] // #3831
+    [MinimumPostgresVersion(12, 0)]
     public async Task DateTimeOffset_DateTrunc_with_timezone()
     {
         await using var ctx = CreateContext();
@@ -495,6 +496,17 @@ FROM "Entities" AS e
 SELECT date_trunc('day', e."TimestampDateTimeOffset", 'Europe/Berlin')
 FROM "Entities" AS e
 """);
+    }
+
+    [ConditionalFact] // #3831
+    public async Task DateTime_DateTrunc_with_timezone_is_not_translated()
+    {
+        await using var ctx = CreateContext();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ctx.Set<Entity>()
+                .Where(e => EF.Functions.DateTrunc("day", e.TimestampDateTime, "Europe/Berlin") == DateTime.Today)
+                .ToListAsync());
     }
 
     [ConditionalFact] // #3831
@@ -523,6 +535,17 @@ FROM "Entities" AS e
 SELECT date_trunc('hour', e."TimestamptzDateTime" - e."TimestamptzDateTime")
 FROM "Entities" AS e
 """);
+    }
+
+    [ConditionalFact] // #3831
+    public async Task TimeSpan_DateTrunc_with_timezone_is_not_translated()
+    {
+        await using var ctx = CreateContext();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ctx.Set<Entity>()
+                .Where(e => EF.Functions.DateTrunc("hour", e.TimestamptzDateTime - e.TimestamptzDateTime, "Europe/Berlin") == TimeSpan.Zero)
+                .ToListAsync());
     }
 
     #endregion DateTimeOffset


### PR DESCRIPTION
Adds a generic `EF.Functions.DateTrunc<T>()` API so LINQ queries can express PostgreSQL `date_trunc` directly for timestamp and interval values. This covers BCL `DateTime`, `DateTimeOffset`, and `TimeSpan`, and lets the NodaTime plugin translate the same generic API for `LocalDateTime`, `Instant`, `ZonedDateTime`, `Period`, and `Duration`.

The translation emits the 2-argument PostgreSQL overload when `timeZone` is omitted, and the 3-argument overload when a timezone is supplied. This avoids accidentally translating omitted optional arguments as `NULL` timezone arguments.

Validation:
- `dotnet build test/EFCore.PG.FunctionalTests/EFCore.PG.FunctionalTests.csproj --no-restore --verbosity minimal`
- `dotnet test test/EFCore.PG.FunctionalTests/EFCore.PG.FunctionalTests.csproj --filter DateTrunc --no-build --verbosity minimal`

Closes #3831