### PR TITLE
Run CI setup steps in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,17 +54,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v5
-        with:
-          global-json-file: global.json
-
-      - name: Build
-        run: dotnet build --configuration Debug
-        shell: bash
-
       - name: Start PostgreSQL ${{ matrix.pg_major }} (Linux)
+        id: setup-postgresql-linux
         if: startsWith(matrix.os, 'ubuntu')
+        background: true
         run: |
           # First uninstall any PostgreSQL installed on the image
           dpkg-query -W --showformat='${Package}\n' 'postgresql-*' | xargs sudo dpkg -P postgresql
@@ -85,7 +78,9 @@ jobs:
           sudo -u postgres psql -c "CREATE USER npgsql_tests SUPERUSER PASSWORD 'npgsql_tests'"
 
       - name: Start PostgreSQL ${{ matrix.pg_major }} (Windows)
+        id: setup-postgresql-windows
         if: startsWith(matrix.os, 'windows')
+        background: true
         run: |
           # Find EnterpriseDB version number
           EDB_VERSION=$(pwsh -c "
@@ -112,6 +107,18 @@ jobs:
           pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests SUPERUSER LOGIN PASSWORD 'npgsql_tests'"
           pgsql/bin/psql -U postgres -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
         shell: bash
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Build
+        run: dotnet build --configuration Debug
+        shell: bash
+
+      - name: Wait for PostgreSQL setup
+        wait-all: true
 
       - name: Test
         run: dotnet test -c ${{ matrix.config }} --filter-not-trait category=failing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,14 +114,14 @@ jobs:
           global-json-file: global.json
 
       - name: Build
-        run: dotnet build --configuration Debug
+        run: dotnet build --configuration ${{ matrix.config }}
         shell: bash
 
       - name: Wait for PostgreSQL setup
         wait-all: true
 
       - name: Test
-        run: dotnet test -c ${{ matrix.config }} --filter-not-trait category=failing
+        run: dotnet test -c ${{ matrix.config }} --no-build --filter-not-trait category=failing
         shell: bash
         env:
           # Disable SSL to avoid unnecessary handshake pressure in the Windows functional tests.


### PR DESCRIPTION
CI currently installs PostgreSQL only after the .NET SDK setup and build complete, making the build job wait on independent setup work. This changes the build job to use GitHub Actions native parallel step support so PostgreSQL setup can run concurrently with .NET setup and the project build.

The Linux and Windows PostgreSQL setup steps now run with `background: true`, and the workflow waits with `wait-all: true` before running tests. This keeps the tests gated on a ready database while preserving separate step logs and avoiding shell-level background/PID handling.