### PR TITLE
Fix GIN index detection for views

### DIFF
--- a/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.PG/Query/Internal/NpgsqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -703,12 +703,12 @@ public class NpgsqlQueryableMethodTranslatingExpressionVisitor : RelationalQuery
                 return array switch
                 {
                     // For array columns which have a GIN index, we translate to array containment (with @>) which uses that index.
-                    ColumnExpression { Column: IColumn column }
-                        when column.Table.Indexes
-                            .Any(i =>
-                                i.Columns.Count > 0
-                                && i.Columns[0] == column
-                                && i.MappedIndexes.Any(mi => mi.GetMethod()?.Equals("GIN", StringComparison.OrdinalIgnoreCase) == true))
+                    ColumnExpression { Column: IColumnBase column }
+                        when column.PropertyMappings.Any(
+                            m => m.Property.GetContainingIndexes().Any(
+                                i => i.Properties.Count > 0
+                                    && i.Properties[0] == m.Property
+                                    && i.GetMethod()?.Equals("GIN", StringComparison.OrdinalIgnoreCase) == true))
                         => BuildSimplifiedShapedQuery(
                             source,
                             _sqlExpressionFactory.Contains(

--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -2760,7 +2760,8 @@ LIMIT 2
             onModelCreating: mb => mb.Entity<TestEntity>()
                 .ToView("TestView")
                 .HasIndex(e => e.Ints)
-                .HasMethod("GIN"));
+                .HasMethod("GIN"),
+            onConfiguring: b => b.ConfigureWarnings(w => w.Ignore(RelationalEventId.AllIndexPropertiesNotMappedToAnyTable)));
 
         await using var context = contextFactory.CreateDbContext();
 

--- a/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/PrimitiveCollectionsQueryNpgsqlTest.cs
@@ -2754,6 +2754,26 @@ LIMIT 2
     }
 
     [ConditionalFact]
+    public virtual async Task View_column_collection_Contains_with_GIN_index_uses_containment()
+    {
+        var contextFactory = await InitializeNonSharedTest<TestContext>(
+            onModelCreating: mb => mb.Entity<TestEntity>()
+                .ToView("TestView")
+                .HasIndex(e => e.Ints)
+                .HasMethod("GIN"));
+
+        await using var context = contextFactory.CreateDbContext();
+
+        Assert.Equal(
+            """
+SELECT t."Id", t."Ints"
+FROM "TestView" AS t
+WHERE t."Ints" @> ARRAY[4]::integer[]
+""",
+            context.Set<TestEntity>().Where(c => c.Ints!.Contains(4)).ToQueryString());
+    }
+
+    [ConditionalFact]
     public virtual async Task Column_collection_Contains_with_btree_index_does_not_use_containment()
     {
         var contextFactory = await InitializeNonSharedTest<TestContext>(


### PR DESCRIPTION
`ToView` mappings use view columns rather than table columns, so the index-aware array `Contains` translation did not find a modeled GIN index and fell back to `ANY`.

Inspect indexes through the column property's model metadata, which supports both table and view mappings while retaining the existing first-indexed-property and GIN-method requirements. Adds a focused `ToView` translation regression test.

Fixes #3829