### PR TITLE
Fix deprecated GitHub Actions outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,10 +133,10 @@ jobs:
         run: |
           if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
               echo "Release tag detected"
-              echo "::set-output name=is_release::true"
+              echo "is_release=true" >> "$GITHUB_OUTPUT"
               if [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+.*- ]]; then
                   echo "Prerelease tag detected"
-                  echo "::set-output name=is_prerelease::true"
+                  echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
               fi
           fi
 


### PR DESCRIPTION
GitHub Actions warns that the `set-output` command is deprecated. Replace the tag-analysis step's deprecated workflow commands with `$GITHUB_OUTPUT` environment-file writes while preserving the existing release and prerelease job outputs.