### PR TITLE
Sync to EF 11.0.0-preview.7.26324.112

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>11.0.0-preview.6</VersionPrefix>
+    <VersionPrefix>11.0.0-preview.7</VersionPrefix>
     <TargetFramework>net11.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,8 @@
   <Project>
   <PropertyGroup>
-    <EFCoreVersion>11.0.0-preview.6.26327.103</EFCoreVersion>
-    <MicrosoftExtensionsVersion>11.0.0-preview.6.26327.103</MicrosoftExtensionsVersion>
-    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.6.26327.103</MicrosoftExtensionsConfigurationVersion>
+    <EFCoreVersion>11.0.0-preview.7.26324.112</EFCoreVersion>
+    <MicrosoftExtensionsVersion>11.0.0-preview.7.26324.112</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsConfigurationVersion>11.0.0-preview.7.26324.112</MicrosoftExtensionsConfigurationVersion>
     <NpgsqlVersion>10.0.3</NpgsqlVersion>
     <XunitVersion>4.0.0-pre.128</XunitVersion>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.6.26313.102",
+    "version": "11.0.100-preview.6.26359.118",
     "allowPrerelease": true
   },
   "test": {


### PR DESCRIPTION
Updates EF Core and Microsoft.Extensions dependencies to `11.0.0-preview.7.26324.112`, and updates the provider version to `11.0.0-preview.7`.

## EF-side PRs requiring EFCore.PG updates

None. The provider builds and the full test suite pass without source or test changes.