### PR TITLE
Add ValueComparer for JSON DOM types using DeepEquals

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlJsonTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlJsonTypeMapping.cs
@@ -13,6 +13,9 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
 /// </summary>
 public class NpgsqlJsonTypeMapping : NpgsqlTypeMapping
 {
+    private static readonly JsonDocumentComparer JsonDocumentComparerInstance = new();
+    private static readonly JsonElementComparer JsonElementComparerInstance = new();
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -29,11 +32,14 @@ public class NpgsqlJsonTypeMapping : NpgsqlTypeMapping
     /// </summary>
     public NpgsqlJsonTypeMapping(string storeType, Type clrType, CoreTypeMapping? elementTypeMapping = null)
         : base(
-            storeType,
-            clrType,
-            storeType == "jsonb" ? NpgsqlDbType.Jsonb : NpgsqlDbType.Json,
-            jsonValueReaderWriter: clrType == typeof(string) ? JsonStringReaderWriter.Instance : null,
-            elementTypeMapping: elementTypeMapping)
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    clrType,
+                    comparer: GetComparer(clrType),
+                    jsonValueReaderWriter: clrType == typeof(string) ? JsonStringReaderWriter.Instance : null,
+                    elementMapping: elementTypeMapping),
+                storeType),
+            storeType == "jsonb" ? NpgsqlDbType.Jsonb : NpgsqlDbType.Json)
     {
         if (storeType != "json" && storeType != "jsonb")
         {
@@ -135,4 +141,33 @@ public class NpgsqlJsonTypeMapping : NpgsqlTypeMapping
 
     private static readonly MethodInfo ParseMethod =
         typeof(JsonDocument).GetMethod(nameof(JsonDocument.Parse), [typeof(string), typeof(JsonDocumentOptions)])!;
+
+    private static ValueComparer? GetComparer(Type clrType)
+    {
+        if (clrType == typeof(JsonDocument))
+        {
+            return JsonDocumentComparerInstance;
+        }
+
+        if (clrType == typeof(JsonElement))
+        {
+            return JsonElementComparerInstance;
+        }
+
+        return null;
+    }
+
+    private sealed class JsonDocumentComparer() : ValueComparer<JsonDocument>(
+        (a, b) => a == null ? b == null : b != null && JsonElement.DeepEquals(a.RootElement, b.RootElement),
+        o => o.GetHashCode(),
+        // Disposing the original JsonDocument will throw when it's later compared against the snapshot
+        o => o);
+
+    private sealed class JsonElementComparer() : ValueComparer<JsonElement>(
+        (a, b) => a.ValueKind == JsonValueKind.Undefined
+            ? b.ValueKind == JsonValueKind.Undefined
+            : b.ValueKind != JsonValueKind.Undefined && JsonElement.DeepEquals(a, b),
+        // JsonElement.GetHashCode() has inefficient runtime-provided implementation
+        o => 0,
+        o => o);
 }

--- a/test/EFCore.PG.FunctionalTests/Query/JsonDomChangeTrackingTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/JsonDomChangeTrackingTest.cs
@@ -1,0 +1,266 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+
+namespace Microsoft.EntityFrameworkCore.Query;
+
+public class JsonDomChangeTrackingTest : IClassFixture<JsonDomChangeTrackingTest.JsonDomChangeTrackingFixture>
+{
+    private JsonDomChangeTrackingFixture Fixture { get; }
+
+    public JsonDomChangeTrackingTest(JsonDomChangeTrackingFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        Fixture = fixture;
+        Fixture.TestSqlLoggerFactory.Clear();
+        Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+    }
+
+    [Theory]
+    [InlineData("""{"Name":"John","Age":25}""", true)]
+    [InlineData("""{"Age":25.00,"Name":"Joe"}""", false)]
+    public async Task SaveChanges_jsonb_document(string json, bool isModified)
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.CreateExecutionStrategy().ExecuteAsync(
+            ctx, async context =>
+            {
+                await using var transaction = await context.Database.BeginTransactionAsync();
+
+                var entity = await context.JsonbEntities.SingleAsync(e => e.Id == 1);
+                entity.CustomerDocument = JsonDocument.Parse(json);
+                Fixture.TestSqlLoggerFactory.Clear();
+                await context.SaveChangesAsync();
+
+                if (isModified)
+                {
+                    AssertSql(
+                        """
+@p1='1'
+@p0='System.Text.Json.JsonDocument' (DbType = Object)
+
+UPDATE "JsonbEntities" SET "CustomerDocument" = @p0
+WHERE "Id" = @p1;
+""");
+                }
+                else
+                {
+                    AssertEmptySql();
+                }
+            });
+    }
+
+    [Theory]
+    [InlineData("""{"Name":"Joe","Age":26}""", true)]
+    [InlineData("""{"Age":25.00,"Name":"Joe"}""", false)]
+    public async Task SaveChanges_json_document(string json, bool isModified)
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.CreateExecutionStrategy().ExecuteAsync(
+            ctx, async context =>
+            {
+                await using var transaction = await context.Database.BeginTransactionAsync();
+
+                var entity = await context.JsonEntities.SingleAsync(e => e.Id == 1);
+                entity.CustomerDocument = JsonDocument.Parse(json);
+                Fixture.TestSqlLoggerFactory.Clear();
+                await context.SaveChangesAsync();
+
+                if (isModified)
+                {
+                    AssertSql(
+                        """
+@p1='1'
+@p0='System.Text.Json.JsonDocument' (DbType = Object)
+
+UPDATE "JsonEntities" SET "CustomerDocument" = @p0
+WHERE "Id" = @p1;
+""");
+                }
+                else
+                {
+                    AssertEmptySql();
+                }
+            });
+    }
+
+    [Theory]
+    [InlineData("""{"Name":"John","Age":25}""", true)]
+    [InlineData("""{"Age":25.00,"Name":"Joe"}""", false)]
+    public async Task SaveChanges_jsonb_element(string json, bool isModified)
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.CreateExecutionStrategy().ExecuteAsync(
+            ctx, async context =>
+            {
+                await using var transaction = await context.Database.BeginTransactionAsync();
+
+                var entity = await context.JsonbEntities.SingleAsync(e => e.Id == 1);
+                entity.CustomerElement = JsonElement.Parse(json);
+                Fixture.TestSqlLoggerFactory.Clear();
+                await context.SaveChangesAsync();
+
+                if (isModified)
+                {
+                    AssertSql(
+                        """
+@p1='1'
+@p0='{"Name":"John","Age":25}' (DbType = Object)
+
+UPDATE "JsonbEntities" SET "CustomerElement" = @p0
+WHERE "Id" = @p1;
+""");
+                }
+                else
+                {
+                    AssertEmptySql();
+                }
+            });
+    }
+
+    [Theory]
+    [InlineData("""{"Name":"Joe","Age":26}""", true)]
+    [InlineData("""{"Age":25.00,"Name":"Joe"}""", false)]
+    public async Task SaveChanges_json_element(string json, bool isModified)
+    {
+        await using var ctx = CreateContext();
+        await ctx.Database.CreateExecutionStrategy().ExecuteAsync(
+            ctx, async context =>
+            {
+                await using var transaction = await context.Database.BeginTransactionAsync();
+
+                var entity = await context.JsonEntities.SingleAsync(e => e.Id == 1);
+                entity.CustomerElement = JsonElement.Parse(json);
+                Fixture.TestSqlLoggerFactory.Clear();
+                await context.SaveChangesAsync();
+
+                if (isModified)
+                {
+                    AssertSql(
+                        """
+@p1='1'
+@p0='{"Name":"Joe","Age":26}' (DbType = Object)
+
+UPDATE "JsonEntities" SET "CustomerElement" = @p0
+WHERE "Id" = @p1;
+""");
+                }
+                else
+                {
+                    AssertEmptySql();
+                }
+            });
+    }
+
+    [Fact]
+    public async Task DetectChanges_jsonb_undefined_element_no_throw()
+    {
+        await using var ctx = CreateContext();
+
+        var entity = await ctx.JsonbEntities.SingleAsync(e => e.Id == 1);
+        entity.CustomerElement = new JsonElement();
+        ctx.JsonbEntities.Add(
+            new JsonbEntity
+            {
+                Id = 2,
+                CustomerElement = new JsonElement(),
+                CustomerDocument = null
+            });
+
+        ctx.ChangeTracker.DetectChanges();
+    }
+
+    [Fact]
+    public async Task DetectChanges_json_undefined_element_no_throw()
+    {
+        await using var ctx = CreateContext();
+
+        var entity = await ctx.JsonEntities.SingleAsync(e => e.Id == 1);
+        entity.CustomerElement = new JsonElement();
+        ctx.JsonEntities.Add(
+            new JsonEntity
+            {
+                Id = 2,
+                CustomerElement = new JsonElement(),
+                CustomerDocument = null
+            });
+
+        ctx.ChangeTracker.DetectChanges();
+    }
+
+    #region Support
+
+    protected JsonDomChangeTrackingContext CreateContext()
+        => Fixture.CreateContext();
+
+    private void AssertSql(params string[] expected)
+        => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+    private void AssertEmptySql()
+        => Assert.Empty(Fixture.TestSqlLoggerFactory.SqlStatements);
+
+    public class JsonDomChangeTrackingContext(DbContextOptions options) : PoolableDbContext(options)
+    {
+        public DbSet<JsonbEntity> JsonbEntities { get; set; }
+        public DbSet<JsonEntity> JsonEntities { get; set; }
+
+        public static async Task SeedAsync(JsonDomChangeTrackingContext context)
+        {
+            var customer = CreateCustomer();
+
+            context.JsonbEntities.Add(
+                new JsonbEntity
+                {
+                    Id = 1,
+                    CustomerDocument = customer,
+                    CustomerElement = customer.RootElement
+                });
+            context.JsonEntities.Add(
+                new JsonEntity
+                {
+                    Id = 1,
+                    CustomerDocument = customer,
+                    CustomerElement = customer.RootElement
+                });
+
+            await context.SaveChangesAsync();
+
+            static JsonDocument CreateCustomer()
+                => JsonDocument.Parse("""{"Name":"Joe","Age":25}""");
+        }
+    }
+
+    public class JsonbEntity
+    {
+        public required int Id { get; set; }
+
+        public required JsonDocument? CustomerDocument { get; set; }
+        public required JsonElement CustomerElement { get; set; }
+    }
+
+    public class JsonEntity
+    {
+        public required int Id { get; set; }
+
+        [Column(TypeName = "json")]
+        public required JsonDocument? CustomerDocument { get; set; }
+
+        [Column(TypeName = "json")]
+        public required JsonElement CustomerElement { get; set; }
+    }
+
+    public class JsonDomChangeTrackingFixture : SharedStoreFixtureBase<JsonDomChangeTrackingContext>
+    {
+        protected override string StoreName
+            => "JsonDomChangeTrackingTest";
+
+        protected override ITestStoreFactory TestStoreFactory
+            => NpgsqlTestStoreFactory.Instance;
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ListLoggerFactory;
+
+        protected override Task SeedAsync(JsonDomChangeTrackingContext context)
+            => JsonDomChangeTrackingContext.SeedAsync(context);
+    }
+
+    #endregion
+}

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingTest.cs
@@ -943,6 +943,15 @@ public class NpgsqlTypeMappingTest
         var snapshot = (JsonDocument)comparer.Snapshot(source);
         Assert.Same(source, snapshot);
         Assert.True(comparer.Equals(source, snapshot));
+        Assert.True(comparer.Equals(source, JsonDocument.Parse(json)));
+        json = """{"Age":25.0,"Name":"Joe"}""";
+        source = JsonDocument.Parse(json);
+        Assert.True(comparer.Equals(source, snapshot));
+        json = """{"Name":"Joe","Age":26}""";
+        source = JsonDocument.Parse(json);
+        Assert.False(comparer.Equals(source, snapshot));
+        Assert.False(comparer.Equals(source, null));
+        Assert.True(comparer.Equals(null, null));
     }
 
     [Fact]
@@ -954,7 +963,15 @@ public class NpgsqlTypeMappingTest
         var comparer = GetMapping(typeof(JsonElement)).Comparer;
         var snapshot = (JsonElement)comparer.Snapshot(source);
         Assert.True(comparer.Equals(source, snapshot));
-        Assert.False(comparer.Equals(source, JsonDocument.Parse(json).RootElement));
+        Assert.True(comparer.Equals(source, JsonDocument.Parse(json).RootElement));
+        json = """{"Age":25.0,"Name":"Joe"}""";
+        source = JsonDocument.Parse(json).RootElement;
+        Assert.True(comparer.Equals(source, snapshot));
+        json = """{"Name":"Joe","Age":26}""";
+        source = JsonDocument.Parse(json).RootElement;
+        Assert.False(comparer.Equals(source, snapshot));
+        Assert.False(comparer.Equals(source, new JsonElement()));
+        Assert.True(comparer.Equals(new JsonElement(), new JsonElement()));
     }
 
     private static readonly Customer SampleCustomer = new()


### PR DESCRIPTION
The change tracker currently uses shallow comparison when detecting changes to JSON DOM properties (JsonDocument and JsonElement). If the JSON content itself hasn't actually changed, but a new object instance was created, this results in unnecessary saves to the database.

This PR adds ValueComparers for JsonDocument and JsonElement based on DeepEquals.

Trade-offs:
- For performance, the snapshot stores the original JsonDocument/JsonElement instance rather than a deep copy. If the original JsonDocument has since been disposed, comparing against the snapshot will throw.
- Key order doesn't matter for jsonb, but does for json. DeepEquals follows jsonb's semantics either way.
- JsonElement.GetHashCode() is inefficient, so JsonElementComparer always returns 0 as its hash.
- JsonDocumentComparer's GetHashCode() is reference-based while Equals compares by content, breaking the Equals/GetHashCode contract — same trade-off as HstoreMutableComparer for Dictionary<string, string>.

As a very rough estimate of the potential performance gain, I benchmarked saving 1 million JsonDocuments to the database, recreating the objects each time without actually changing their content:
- ~24 sec with the old comparer (unconditional save)
- ~0,7 sec with the new comparer (save skipped — no actual change detected)

Relates to #3314