### PR TITLE
Handle absent LIKE escape expressions explicitly

### DIFF
--- a/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
+++ b/src/EFCore.PG/Query/NpgsqlSqlExpressionFactory.cs
@@ -721,7 +721,7 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
             ApplyTypeMapping(likeExpression.Match, inferredTypeMapping),
             ApplyTypeMapping(likeExpression.Pattern, inferredTypeMapping),
             // The escape character must not inherit the match or pattern's value converter (#3888).
-            ApplyDefaultTypeMapping(likeExpression.EscapeChar),
+            likeExpression.EscapeChar is null ? null : ApplyDefaultTypeMapping(likeExpression.EscapeChar),
             _boolTypeMapping);
     }
 
@@ -734,7 +734,7 @@ public class NpgsqlSqlExpressionFactory : SqlExpressionFactory
             ApplyTypeMapping(ilikeExpression.Match, inferredTypeMapping),
             ApplyTypeMapping(ilikeExpression.Pattern, inferredTypeMapping),
             // The escape character must not inherit the match or pattern's value converter (#3888).
-            ApplyDefaultTypeMapping(ilikeExpression.EscapeChar),
+            ilikeExpression.EscapeChar is null ? null : ApplyDefaultTypeMapping(ilikeExpression.EscapeChar),
             _boolTypeMapping);
     }
 


### PR DESCRIPTION
Follow-up to #3889: LIKE and ILIKE escape expressions are optional, so preserve `null` explicitly before applying the independent default string type mapping.

This makes the optional escape behavior clear and avoids relying on `ApplyDefaultTypeMapping` accepting a null expression.

Tests:
- `NorthwindDbFunctionsQueryNpgsqlTest` (41 tests)

Fixes: #3888