### PR TITLE
Fix tsvector columns over JSON-mapped navigations/complex properties

### DIFF
--- a/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
+++ b/src/EFCore.PG/Metadata/Internal/NpgsqlAnnotationProvider.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 
@@ -112,7 +113,13 @@ public class NpgsqlAnnotationProvider : RelationalAnnotationProvider
             yield return new Annotation(
                 NpgsqlAnnotationNames.TsVectorProperties,
                 valueGeneratedProperty.GetTsVectorProperties()!
-                    .Select(p2 => valueGeneratedProperty.DeclaringType.FindProperty(p2)!.GetColumnName(tableIdentifier))
+                    .Select(p2 => valueGeneratedProperty.DeclaringType.FindProperty(p2)?.GetColumnName(tableIdentifier)
+                        ?? (valueGeneratedProperty.DeclaringType as IReadOnlyEntityType)?.FindNavigation(p2)?.TargetEntityType
+                        .GetContainerColumnName(tableIdentifier)
+                        ?? valueGeneratedProperty.DeclaringType.FindComplexProperty(p2)?.ComplexType.GetContainerColumnName(tableIdentifier)
+                        ?? throw new InvalidOperationException(
+                            NpgsqlStrings.TsVectorIncludedPropertyNotFound(valueGeneratedProperty.DeclaringType.DisplayName(), p2))
+                    )
                     .ToArray());
         }
 

--- a/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.Designer.cs
@@ -229,6 +229,14 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.Internal
                 GetString("WithoutOverlapsRequiresRangeType", nameof(keyOrIndexName), nameof(entityType), nameof(property), nameof(propertyType)),
                 keyOrIndexName, entityType, property, propertyType);
 
+        /// <summary>
+        ///     Could not find property, navigation or complex property '{property}' on entity type '{entityType}' for generated tsvector column
+        /// </summary>
+        public static string TsVectorIncludedPropertyNotFound(object? entityType, object? property)
+            => string.Format(
+                GetString("TsVectorIncludedPropertyNotFound", nameof(entityType), nameof(property)),
+                entityType, property);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name)!;

--- a/src/EFCore.PG/Properties/NpgsqlStrings.resx
+++ b/src/EFCore.PG/Properties/NpgsqlStrings.resx
@@ -268,4 +268,7 @@
   <data name="WithoutOverlapsRequiresRangeType" xml:space="preserve">
     <value>WITHOUT OVERLAPS on {keyOrIndexName} in entity type '{entityType}' requires the last column to be a PostgreSQL range type (e.g. daterange, tsrange, tstzrange), but property '{property}' has type '{propertyType}'.</value>
   </data>
+  <data name="TsVectorIncludedPropertyNotFound" xml:space="preserve">
+    <value>Could not find property, navigation or complex property '{property}' on entity type '{entityType}' for generated tsvector column</value>
+  </data>
 </root>

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
@@ -3194,6 +3194,28 @@ CREATE COLLATION some_collation (LOCALE = 'en-u-ks-level1',
     }
 
     [Fact]
+    public virtual async Task Add_column_generated_tsvector_over_json_owned_navigation()
+    {
+        await Test(
+            builder =>
+            {
+                builder.Entity("People").OwnsOne("JsonOwned", "JsonOwned").ToJson();
+            },
+            _ => { },
+            builder => builder.Entity("People").Property<NpgsqlTsVector>("SearchColumn")
+                .IsGeneratedTsVectorColumn("english", "JsonOwned"),
+            model =>
+            {
+                var table = Assert.Single(model.Tables);
+                var column = Assert.Single(table.Columns, c => c.Name == "SearchColumn");
+                Assert.Equal("tsvector", column.StoreType);
+            });
+
+        AssertSql(
+            """ALTER TABLE "People" ADD "SearchColumn" tsvector GENERATED ALWAYS AS (jsonb_to_tsvector('english', coalesce("JsonOwned", '{}'), '"all"')) STORED;""");
+    }
+
+    [Fact]
     public virtual async Task Alter_column_generated_tsvector_change_config()
     {
         await Test(

--- a/test/EFCore.PG.Tests/Migrations/NpgsqlAnnotationProviderTest.cs
+++ b/test/EFCore.PG.Tests/Migrations/NpgsqlAnnotationProviderTest.cs
@@ -1,0 +1,178 @@
+﻿using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.Migrations;
+
+public class NpgsqlAnnotationProviderTest
+{
+    [Fact]
+    public void ForColumn_resolves_tsvector_properties_over_json_navigation()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<Blog>(
+            eb =>
+            {
+                eb.OwnsOne(b => b.Owned).ToJson();
+                eb.Property(b => b.SearchVector)
+                    .IsGeneratedTsVectorColumn("english", nameof(Blog.Owned));
+            });
+
+        CheckTsVectorProperties(modelBuilder, ["Owned"]);
+    }
+
+    [Fact]
+    public void ForColumn_resolves_tsvector_properties_over_renamed_json_navigation()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<Blog>(
+            eb =>
+            {
+                eb.OwnsOne(b => b.Owned).ToJson("owned_renamed");
+                eb.Property(b => b.SearchVector)
+                    .IsGeneratedTsVectorColumn("english", nameof(Blog.Owned));
+            });
+
+        CheckTsVectorProperties(modelBuilder, ["owned_renamed"]);
+    }
+
+    [Fact]
+    public void ForColumn_resolves_tsvector_properties_over_json_complex_property()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<Blog>().ComplexProperty(b => b.Owned).ToJson();
+        modelBuilder.Entity<Blog>().Property(b => b.SearchVector).IsGeneratedTsVectorColumn("english", nameof(Blog.Owned));
+
+        CheckTsVectorProperties(modelBuilder, ["Owned"]);
+    }
+
+    [Fact]
+    public void ForColumn_resolves_tsvector_properties_over_renamed_json_complex_property()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<Blog>().ComplexProperty(b => b.Owned).ToJson("owned_renamed");
+        modelBuilder.Entity<Blog>().Property(b => b.SearchVector).IsGeneratedTsVectorColumn("english", nameof(Blog.Owned));
+
+        CheckTsVectorProperties(modelBuilder, ["owned_renamed"]);
+    }
+
+    [Fact]
+    public void ForColumn_resolves_tsvector_properties_over_mixed_text_jsonb_and_json_navigation()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity(
+            "Blogs", eb =>
+            {
+                eb.Property<int>("Id");
+                eb.Property<string>("Text");
+                eb.Property<string>("Jsonb").HasColumnType("jsonb");
+                eb.OwnsOne("Owned", "Owned").ToJson();
+                eb.Property<NpgsqlTsVector>("SearchVector")
+                    .IsGeneratedTsVectorColumn("english", "Text", "Jsonb", "Owned");
+            });
+
+        CheckTsVectorProperties(modelBuilder, ["Text", "Jsonb", "Owned"]);
+    }
+
+    [Fact]
+    public void ForColumn_resolves_tsvector_properties_when_declared_on_complex_type()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity<BlogWithComplexProperty>(
+            eb =>
+            {
+                eb.ComplexProperty(b => b.ComplexProperty, cb =>
+                {
+                    cb.Property(cp => cp.Something).IsRequired();
+                    // using [nameof(ComplexProperty.Something)] leads to an exception, see #3892
+                    cb.Property(cp => cp.SearchVector).Metadata.SetTsVectorProperties(new string[] { nameof(ComplexProperty.Something) });
+                });
+            });
+
+        CheckTsVectorProperties(modelBuilder, ["ComplexProperty_Something"], searchVectorName: "ComplexProperty_SearchVector");
+    }
+
+    [Fact]
+    public void ForColumn_throws_when_included_navigation_is_not_mapped_to_json()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity(
+            "Blogs", eb =>
+            {
+                eb.Property<int>("Id");
+                eb.OwnsOne("Owned", "Owned");
+                eb.Property<NpgsqlTsVector>("SearchVector")
+                    .IsGeneratedTsVectorColumn("english", "Owned");
+            });
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            var model = modelBuilder.FinalizeModel(designTime: true);
+            model.GetRelationalModel();
+        });
+        Assert.Equal(
+            "Could not find property, navigation or complex property 'Owned' on entity type 'Blogs (Dictionary<string, object>)' for generated tsvector column",
+            exception.Message);
+    }
+
+    [Fact]
+    public void ForColumn_throws_when_included_name_does_not_resolve()
+    {
+        var modelBuilder = NpgsqlTestHelpers.Instance.CreateConventionBuilder();
+
+        modelBuilder.Entity(
+            "Blogs", eb =>
+            {
+                eb.Property<int>("Id");
+                eb.OwnsOne("Owned", "Owned");
+                eb.Property<NpgsqlTsVector>("SearchVector")
+                    .IsGeneratedTsVectorColumn("english", "Owne");
+            });
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            var model = modelBuilder.FinalizeModel(designTime: true);
+            model.GetRelationalModel();
+        });
+        Assert.Equal(
+            "Could not find property, navigation or complex property 'Owne' on entity type 'Blogs (Dictionary<string, object>)' for generated tsvector column",
+            exception.Message);
+    }
+
+    private class Blog
+    {
+        public int Id { get; set; }
+        public Owned Owned { get; set; }
+        public NpgsqlTsVector SearchVector { get; set; }
+    }
+
+    private class Owned { public string Something { get; set; } }
+
+    private class BlogWithComplexProperty
+    {
+        public int Id { get; set; }
+        public ComplexProperty ComplexProperty { get; set; }
+    }
+
+    private class ComplexProperty
+    {
+        public string Something { get; set; }
+        public NpgsqlTsVector SearchVector { get; set; }
+    }
+
+    private void CheckTsVectorProperties(TestHelpers.TestModelBuilder modelBuilder, IReadOnlyCollection<string> expectedProperties,
+        string searchVectorName = "SearchVector")
+    {
+        var model = modelBuilder.FinalizeModel(designTime: true);
+        var relationalModel = model.GetRelationalModel();
+
+        var column = Assert.Single(relationalModel.Tables.Single().Columns, c => c.Name == searchVectorName);
+        var tsVectorProperties = (IReadOnlyCollection<string>)column.FindAnnotation(NpgsqlAnnotationNames.TsVectorProperties)!.Value!;
+        Assert.Equal(expectedProperties, tsVectorProperties);
+    }
+}


### PR DESCRIPTION
When a property is configured as a generated tsvector column that includes a navigation or complex property mapped to JSON via `ToJson()`, `NpgsqlAnnotationProvider` only resolved included names as regular properties, throwing a `NullReferenceException` instead of finding the underlying JSON container column.

Resolution now also checks navigations and complex properties declared on the same type, resolving them to their JSON container column (including renamed columns) and reporting a clear error for names that don't resolve to a property, navigation, or complex property. Adds unit and functional regression tests covering navigation- and complex-property-based JSON tsvector columns, including renamed and mixed scenarios.

Fixes #3075