### PR TITLE
Fix CreateParameter for collection shape mismatch with element value converters

### DIFF
--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayTypeMapping.cs
@@ -232,22 +232,25 @@ public class NpgsqlArrayTypeMapping<TCollection, TConcreteCollection, TElement> 
     {
         // In queries which compose non-server-correlated LINQ operators over an array parameter (e.g. Where(b => ids.Skip(1)...) we
         // get an enumerable parameter value that isn't an array/list - but those aren't supported at the Npgsql ADO level.
-        // Detect this here and evaluate the enumerable to get a fully materialized List.
-        // Note that when we have a value converter (e.g. for HashSet), we don't want to convert it to a List, since the value converter
-        // expects the original type.
+        // Detect this here and evaluate the enumerable to get a fully materialized TConcreteCollection (array or List).
+        // Note that when we have a value converter (e.g. for HashSet), we don't want to convert values that already match
+        // the converter's model type, since the value converter expects that original type.
+        // However, if the value's collection shape differs from the converter model type (e.g. List<MyId> vs MyId[] after
+        // type mapping inference for Intersect().Any() → &&), normalize to TConcreteCollection so Sanitize succeeds.
         // TODO: Make Npgsql support IList<> instead of only arrays and List<>
-        if (value is not null && Converter is null && !value.GetType().IsArrayOrGenericList())
+        if (value is not null
+            && ((Converter is null && !value.GetType().IsArrayOrGenericList())
+                || (Converter is not null && !Converter.ModelClrType.IsInstanceOfType(value))))
         {
-            switch (value)
+            var castedElements = value switch
             {
-                case IEnumerable<TElement> elements:
-                    value = elements.ToList();
-                    break;
+                IEnumerable<TElement> elements => elements,
+                IEnumerable elements => elements.Cast<TElement>(),
+                _ => throw new InvalidOperationException(
+                    $"Cannot create a parameter for {GetType().Name} from value of type '{value.GetType().Name}'")
+            };
 
-                case IEnumerable elements:
-                    value = elements.Cast<TElement>().ToList();
-                    break;
-            }
+            value = typeof(TConcreteCollection).IsArray ? castedElements.ToArray() : castedElements.ToList();
         }
 
         var param = base.CreateParameter(command, name, value, nullable, direction);

--- a/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayTypeMapping.cs
+++ b/src/EFCore.PG/Storage/Internal/Mapping/NpgsqlArrayTypeMapping.cs
@@ -181,6 +181,50 @@ public class NpgsqlArrayTypeMapping<TCollection, TConcreteCollection, TElement> 
             storeType);
     }
 
+    private IEnumerable<TElement> AsElementEnumerable(object value)
+        => value switch
+        {
+            IEnumerable<TElement> elements => elements,
+            IEnumerable elements => elements.Cast<TElement>(),
+            _ => throw new InvalidOperationException(
+                $"Cannot create a parameter for {GetType().Name} from value of type '{value.GetType().Name}'")
+        };
+
+    private static TConcreteCollection CreateInstance(int? count)
+        => (count, typeof(TConcreteCollection)) switch
+        {
+            ({ } c, var type) when type.GetConstructor([typeof(int)]) is { } ctorWithSize
+                => (TConcreteCollection)ctorWithSize.Invoke([c]),
+            var (_, type) when type.GetConstructor([]) is { } ctor
+                => (TConcreteCollection)ctor.Invoke(null),
+            var (_, type) => throw new InvalidOperationException(
+                $"Type {type.Name} cannot be instantiated as it does not have a public parameterless constructor")
+        };
+
+    private static object Materialize(IEnumerable<TElement> elements)
+    {
+        if (typeof(TConcreteCollection).IsArray)
+        {
+            return elements.ToArray();
+        }
+
+        var count = elements.TryGetNonEnumeratedCount(out var c) ? c : (int?)null;
+        var collection = CreateInstance(count);
+
+        if (collection is not ICollection<TElement> destination)
+        {
+            throw new InvalidOperationException(
+                $"Type {typeof(TConcreteCollection).Name} cannot be populated (no ICollection<{typeof(TElement).Name}>).");
+        }
+
+        foreach (var element in elements)
+        {
+            destination.Add(element);
+        }
+
+        return collection;
+    }
+
     /// <summary>
     ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
     ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
@@ -232,25 +276,19 @@ public class NpgsqlArrayTypeMapping<TCollection, TConcreteCollection, TElement> 
     {
         // In queries which compose non-server-correlated LINQ operators over an array parameter (e.g. Where(b => ids.Skip(1)...) we
         // get an enumerable parameter value that isn't an array/list - but those aren't supported at the Npgsql ADO level.
-        // Detect this here and evaluate the enumerable to get a fully materialized TConcreteCollection (array or List).
+        // Detect this here and evaluate the enumerable to get a fully materialized List.
         // Note that when we have a value converter (e.g. for HashSet), we don't want to convert values that already match
         // the converter's model type, since the value converter expects that original type.
-        // However, if the value's collection shape differs from the converter model type (e.g. List<MyId> vs MyId[] after
+        // However, if the value's collection shape differs from the converter model type (e.g. List<T> vs T[] after
         // type mapping inference for Intersect().Any() → &&), normalize to TConcreteCollection so Sanitize succeeds.
         // TODO: Make Npgsql support IList<> instead of only arrays and List<>
-        if (value is not null
-            && ((Converter is null && !value.GetType().IsArrayOrGenericList())
-                || (Converter is not null && !Converter.ModelClrType.IsInstanceOfType(value))))
+        if (value is not null && Converter is null && !value.GetType().IsArrayOrGenericList())
         {
-            var castedElements = value switch
-            {
-                IEnumerable<TElement> elements => elements,
-                IEnumerable elements => elements.Cast<TElement>(),
-                _ => throw new InvalidOperationException(
-                    $"Cannot create a parameter for {GetType().Name} from value of type '{value.GetType().Name}'")
-            };
-
-            value = typeof(TConcreteCollection).IsArray ? castedElements.ToArray() : castedElements.ToList();
+            value = AsElementEnumerable(value).ToList();
+        }
+        else if (value is not null && Converter is not null && !Converter.ModelClrType.IsInstanceOfType(value))
+        {
+            value = Materialize(AsElementEnumerable(value));
         }
 
         var param = base.CreateParameter(command, name, value, nullable, direction);

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
@@ -927,6 +927,49 @@ WHERE s."ValueConvertedArrayOfEnum" && @toFindArray
 """);
     }
 
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_hash_set_over_value_converted_array()
+    {
+        HashSet<SomeEnum> toFindHashSet = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedArrayOfEnum.Intersect(toFindHashSet).Any()));
+
+        AssertSql(
+            """
+@toFindHashSet={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedArrayOfEnum" && @toFindHashSet
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_non_collection_enumerable_over_value_converted_array()
+    {
+        var toFindEnumerable = new List<SomeEnum>
+        {
+            SomeEnum.One,
+            SomeEnum.Three,
+            SomeEnum.Eight
+        }.Where(_ => true);
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedArrayOfEnum.Intersect(toFindEnumerable).Any()));
+
+        AssertSql(
+            """
+@toFindEnumerable={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedArrayOfEnum" && @toFindEnumerable
+""");
+    }
+
     #endregion
 
     #region Other translations

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayArrayQueryTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.EntityFrameworkCore.TestModels.Array;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Internal;
 
@@ -866,6 +867,67 @@ WHERE ARRAY[5,6]::integer[] <@ s."IntArray"
     }
 
     #endregion Any/All
+
+    #region Intersect
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_list_over_value_converted_array()
+    {
+        List<SomeEnum> toFindList = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedArrayOfEnum.Intersect(toFindList).Any()));
+
+        AssertSql(
+            """
+@toFindList={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedArrayOfEnum" && @toFindList
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_immutable_list_over_value_converted_array()
+    {
+        ImmutableList<SomeEnum> toFindImmutableList = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedArrayOfEnum.Intersect(toFindImmutableList).Any()));
+
+        AssertSql(
+            """
+@toFindImmutableList={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedArrayOfEnum" && @toFindImmutableList
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_array_over_value_converted_array()
+    {
+        SomeEnum[] toFindArray = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedArrayOfEnum.Intersect(toFindArray).Any()));
+
+        AssertSql(
+            """
+@toFindArray={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedArrayOfEnum" && @toFindArray
+""");
+    }
+
+    #endregion
 
     #region Other translations
 

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayListQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayListQueryTest.cs
@@ -933,6 +933,49 @@ WHERE s."ValueConvertedListOfEnum" && @toFindList
 """);
     }
 
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_hash_set_over_value_converted_list()
+    {
+        HashSet<SomeEnum> toFindHashSet = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedListOfEnum.Intersect(toFindHashSet).Any()));
+
+        AssertSql(
+            """
+@toFindHashSet={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedListOfEnum" && @toFindHashSet
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_non_collection_enumerable_over_value_converted_list()
+    {
+        var toFindEnumerable = new List<SomeEnum>
+        {
+            SomeEnum.One,
+            SomeEnum.Three,
+            SomeEnum.Eight
+        }.Where(_ => true);
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedListOfEnum.Intersect(toFindEnumerable).Any()));
+
+        AssertSql(
+            """
+@toFindEnumerable={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedListOfEnum" && @toFindEnumerable
+""");
+    }
+
     #endregion
 
     #region Other translations

--- a/test/EFCore.PG.FunctionalTests/Query/ArrayListQueryTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Query/ArrayListQueryTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.EntityFrameworkCore.TestModels.Array;
 
 namespace Microsoft.EntityFrameworkCore.Query;
@@ -872,6 +873,67 @@ WHERE ARRAY[5,6]::integer[] <@ s."IntList"
     }
 
     #endregion Any/All
+
+    #region Intersect
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_array_over_value_converted_list()
+    {
+        SomeEnum[] toFindArray = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedListOfEnum.Intersect(toFindArray).Any()));
+
+        AssertSql(
+            """
+@toFindArray={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedListOfEnum" && @toFindArray
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_immutable_list_over_value_converted_list()
+    {
+        ImmutableList<SomeEnum> toFindImmutableList = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedListOfEnum.Intersect(toFindImmutableList).Any()));
+
+        AssertSql(
+            """
+@toFindImmutableList={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedListOfEnum" && @toFindImmutableList
+""");
+    }
+
+    [ConditionalFact]
+    public virtual async Task Intersect_parameter_list_over_value_converted_list()
+    {
+        List<SomeEnum> toFindList = [SomeEnum.One, SomeEnum.Three, SomeEnum.Eight];
+
+        await AssertQuery(ss => ss.Set<ArrayEntity>().Where(e => e.ValueConvertedListOfEnum.Intersect(toFindList).Any()));
+
+        AssertSql(
+            """
+@toFindList={ 'One'
+'Three'
+'Eight' } (DbType = Object)
+
+SELECT s."Id", s."ArrayContainerEntityId", s."ArrayOfStringConvertedToDelimitedString", s."Byte", s."ByteArray", s."Bytea", s."EnumConvertedToInt", s."EnumConvertedToString", s."IList", s."IntArray", s."IntList", s."ListOfStringConvertedToDelimitedString", s."NonNullableText", s."NullableEnumConvertedToString", s."NullableEnumConvertedToStringWithNonNullableLambda", s."NullableIntArray", s."NullableIntList", s."NullableStringArray", s."NullableStringList", s."NullableText", s."StringArray", s."StringList", s."ValueConvertedArrayOfEnum", s."ValueConvertedListOfEnum", s."Varchar10", s."Varchar15"
+FROM "SomeEntities" AS s
+WHERE s."ValueConvertedListOfEnum" && @toFindList
+""");
+    }
+
+    #endregion
 
     #region Other translations
 

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Text.Json;
@@ -262,6 +263,48 @@ public class NpgsqlTypeMappingSourceTest
     [Fact]
     public void Array_over_type_mapping_with_value_converter_by_store_type()
         => Array_over_type_mapping_with_value_converter(CreateTypeMappingSource().FindMapping("ltree[]"), typeof(List<LTree>));
+
+    [Theory]
+    [InlineData(typeof(LTree[]))]
+    [InlineData(typeof(List<LTree>))]
+    public void CreateParameter_with_value_converter_accepts_list(Type mappingType)
+    {
+        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
+        Assert.NotNull(mapping.Converter);
+        var parameter = mapping.CreateParameter(
+            new NpgsqlCommand(),
+            "p",
+            new List<LTree> { new("foo"), new("bar") });
+        Assert.Equal(["foo", "bar"], Assert.IsType<string[]>(parameter.Value));
+    }
+
+    [Theory]
+    [InlineData(typeof(LTree[]))]
+    [InlineData(typeof(List<LTree>))]
+    public void CreateParameter_with_value_converter_accepts_immutable_list(Type mappingType)
+    {
+        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
+        Assert.NotNull(mapping.Converter);
+        var parameter = mapping.CreateParameter(
+            new NpgsqlCommand(),
+            "p",
+            ImmutableList.Create(new LTree("foo"), new LTree("bar")));
+        Assert.Equal(["foo", "bar"], Assert.IsType<string[]>(parameter.Value));
+    }
+
+    [Theory]
+    [InlineData(typeof(LTree[]))]
+    [InlineData(typeof(List<LTree>))]
+    public void CreateParameter_with_value_converter_accepts_array(Type mappingType)
+    {
+        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
+        Assert.NotNull(mapping.Converter);
+        var parameter = mapping.CreateParameter(
+            new NpgsqlCommand(),
+            "p",
+            new LTree[] { new("foo"), new("bar") });
+        Assert.Equal(["foo", "bar"], Assert.IsType<string[]>(parameter.Value));
+    }
 
     private void Array_over_type_mapping_with_value_converter(CoreTypeMapping mapping, Type expectedType)
     {

--- a/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
+++ b/test/EFCore.PG.Tests/Storage/NpgsqlTypeMappingSourceTest.cs
@@ -265,45 +265,79 @@ public class NpgsqlTypeMappingSourceTest
         => Array_over_type_mapping_with_value_converter(CreateTypeMappingSource().FindMapping("ltree[]"), typeof(List<LTree>));
 
     [Theory]
-    [InlineData(typeof(LTree[]))]
-    [InlineData(typeof(List<LTree>))]
-    public void CreateParameter_with_value_converter_accepts_list(Type mappingType)
-    {
-        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
-        Assert.NotNull(mapping.Converter);
-        var parameter = mapping.CreateParameter(
-            new NpgsqlCommand(),
-            "p",
-            new List<LTree> { new("foo"), new("bar") });
-        Assert.Equal(["foo", "bar"], Assert.IsType<string[]>(parameter.Value));
-    }
+    [InlineData(typeof(LTree[]), typeof(List<LTree>))]
+    [InlineData(typeof(List<LTree>), typeof(List<LTree>))]
+    [InlineData(typeof(HashSet<LTree>), typeof(List<LTree>))]
+    [InlineData(typeof(LTree[]), typeof(HashSet<LTree>))]
+    [InlineData(typeof(List<LTree>), typeof(HashSet<LTree>))]
+    [InlineData(typeof(HashSet<LTree>), typeof(HashSet<LTree>))]
+    public void CreateParameter_with_value_converter_accepts_mutable_collections(Type mappingType, Type valueType)
+        => CreateParameter_with_value_converter(
+            mappingType, Activator.CreateInstance(valueType, new LTree[] { new("foo"), new("bar") }));
 
     [Theory]
     [InlineData(typeof(LTree[]))]
     [InlineData(typeof(List<LTree>))]
+    [InlineData(typeof(HashSet<LTree>))]
     public void CreateParameter_with_value_converter_accepts_immutable_list(Type mappingType)
-    {
-        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
-        Assert.NotNull(mapping.Converter);
-        var parameter = mapping.CreateParameter(
-            new NpgsqlCommand(),
-            "p",
-            ImmutableList.Create(new LTree("foo"), new LTree("bar")));
-        Assert.Equal(["foo", "bar"], Assert.IsType<string[]>(parameter.Value));
-    }
+        => CreateParameter_with_value_converter(mappingType, ImmutableList.Create(new LTree("foo"), new LTree("bar")));
 
     [Theory]
     [InlineData(typeof(LTree[]))]
     [InlineData(typeof(List<LTree>))]
+    [InlineData(typeof(HashSet<LTree>))]
     public void CreateParameter_with_value_converter_accepts_array(Type mappingType)
+        => CreateParameter_with_value_converter(mappingType, new LTree[] { new("foo"), new("bar") });
+
+    [Theory]
+    [InlineData(typeof(LTree[]))]
+    [InlineData(typeof(List<LTree>))]
+    [InlineData(typeof(HashSet<LTree>))]
+    public void CreateParameter_with_value_converter_accepts_non_collection_enumerable(Type mappingType)
+        => CreateParameter_with_value_converter(
+            mappingType, new List<LTree> { new("foo"), new("bar") }.Where(_ => true));
+
+    [Theory]
+    [InlineData(typeof(int[]), typeof(List<int>))]
+    [InlineData(typeof(List<int>), typeof(List<int>))]
+    [InlineData(typeof(HashSet<int>), typeof(List<int>))]
+    [InlineData(typeof(int[]), typeof(HashSet<int>))]
+    [InlineData(typeof(List<int>), typeof(HashSet<int>))]
+    [InlineData(typeof(HashSet<int>), typeof(HashSet<int>))]
+    public void CreateParameter_without_converter_accepts_mutable_collections(Type mappingType, Type valueType)
+        => CreateParameter_without_converter(
+            mappingType, Activator.CreateInstance(valueType, new[] { 1, 2 }));
+
+    [Theory]
+    [InlineData(typeof(int[]))]
+    [InlineData(typeof(List<int>))]
+    [InlineData(typeof(HashSet<int>))]
+    public void CreateParameter_without_converter_accepts_immutable_list(Type mappingType)
+        => CreateParameter_without_converter(mappingType, ImmutableList.Create(new[] { 1, 2 }));
+
+    [Theory]
+    [InlineData(typeof(int[]))]
+    [InlineData(typeof(List<int>))]
+    [InlineData(typeof(HashSet<int>))]
+    public void CreateParameter_without_converter_accepts_array(Type mappingType)
     {
         var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
+        Assert.Null(mapping.Converter);
+        var parameter = mapping.CreateParameter(new NpgsqlCommand(), "p", new[] { 1, 2 });
+        Assert.Equal(new[] { 1, 2 }, Assert.IsType<int[]>(parameter.Value));
+    }
+
+    [Fact]
+    public void CreateParameter_with_shape_only_converter_accepts_non_ilist_collection()
+    {
+        var mapping = CreateTypeMappingSource().FindMapping(typeof(IList<int>))!;
         Assert.NotNull(mapping.Converter);
-        var parameter = mapping.CreateParameter(
-            new NpgsqlCommand(),
-            "p",
-            new LTree[] { new("foo"), new("bar") });
-        Assert.Equal(["foo", "bar"], Assert.IsType<string[]>(parameter.Value));
+        Assert.Same(typeof(IList<int>), mapping.Converter.ModelClrType);
+        Assert.Same(typeof(int[]), mapping.Converter.ProviderClrType);
+        Assert.Null(mapping.ElementTypeMapping!.Converter);
+
+        var parameter = mapping.CreateParameter(new NpgsqlCommand(), "p", new HashSet<int> { 1, 2 });
+        Assert.Equivalent(new[] { 1, 2 }, Assert.IsType<int[]>(parameter.Value), strict: true);
     }
 
     private void Array_over_type_mapping_with_value_converter(CoreTypeMapping mapping, Type expectedType)
@@ -329,6 +363,22 @@ public class NpgsqlTypeMappingSourceTest
                     : new List<LTree> { new("foo"), new("bar") }),
             s => Assert.Equal("foo", s),
             s => Assert.Equal("bar", s));
+    }
+
+    private void CreateParameter_with_value_converter(Type mappingType, object value)
+    {
+        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
+        Assert.NotNull(mapping.Converter);
+        var parameter = mapping.CreateParameter(new NpgsqlCommand(), "p", value);
+        Assert.Equivalent(new[] { "foo", "bar" }, Assert.IsType<string[]>(parameter.Value), strict: true);
+    }
+
+    private void CreateParameter_without_converter(Type mappingType, object value)
+    {
+        var mapping = CreateTypeMappingSource().FindMapping(mappingType)!;
+        Assert.Null(mapping.Converter);
+        var parameter = mapping.CreateParameter(new NpgsqlCommand(), "p", value);
+        Assert.Equivalent(new[] { 1, 2 }, Assert.IsType<List<int>>(parameter.Value), strict: true);
     }
 
     #endregion Array


### PR DESCRIPTION
When a primitive collection has an element value converter and a parameter uses a different collection shape (e.g. List<T> vs T[]), type mapping inference for Intersect(...).Any() → && can apply the column mapping to that parameter. CreateParameter skipped materialization whenever a converter was present, so Sanitize threw InvalidCastException (IConvertible).

Normalize mismatched values to TConcreteCollection before Sanitize, without rewriting values that already match the converter model type. There is no extra materialization on existing paths — only the new mismatch cases take that branch; existing tests do not.

Fixes #3805