### PR TITLE
Fix: spelling of occurred in sync-to-latest-ef skill

### DIFF
--- a/.agents/skills/sync-to-latest-ef/SKILL.md
+++ b/.agents/skills/sync-to-latest-ef/SKILL.md
@@ -20,7 +20,7 @@ We're going to sync the EF Core PostgreSQL provider (EFCore.PG) in this repo to 
 
 Build EFCore.PG and resolve any errors that are reported.
 
-The EF Core source code can be found in https://github.com/dotnet/efcore - you can explore that repo to understand what changes happened there from the last version the EFCore.PG used to the version we're upgrading towards. Focus especially on changes that occured before the current daily build referenced by EFCore.PG (before your change), since everything is still working correctly with it.
+The EF Core source code can be found in https://github.com/dotnet/efcore - you can explore that repo to understand what changes happened there from the last version the EFCore.PG used to the version we're upgrading towards. Focus especially on changes that occurred before the current daily build referenced by EFCore.PG (before your change), since everything is still working correctly with it.
 
 Generally try to align EFCore.PG to whatever practices and patterns are in use within EF Core itself.
 


### PR DESCRIPTION
## Summary

Corrects a misspelling in `.agents/skills/sync-to-latest-ef/SKILL.md` (`occured` → `occurred`).

This skill tells agents which EF Core changes to inspect when syncing the provider. The misspelling is in a sentence that describes the time window to search, so it is worth matching the rest of the file (`a rename occurred`, `commits that occurred`).

Docs-only, no code changes.