### PR TITLE
Support DROP INDEX CONCURRENTLY

### DIFF
--- a/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
+++ b/src/EFCore.PG/Migrations/Internal/NpgsqlMigrationsAnnotationProvider.cs
@@ -31,4 +31,19 @@ public class NpgsqlMigrationsAnnotationProvider : MigrationsAnnotationProvider
     /// </summary>
     public override IEnumerable<IAnnotation> ForRemove(IRelationalModel model)
         => model.Model.GetAnnotations().Where(NpgsqlAnnotationHelper.IsRelationalModelAnnotation);
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override IEnumerable<IAnnotation> ForRemove(ITableIndex index)
+    {
+        // Model validation ensures that these facets are the same on all mapped indexes
+        if (index.MappedIndexes.First().IsCreatedConcurrently() is { } isCreatedConcurrently)
+        {
+            yield return new Annotation(NpgsqlAnnotationNames.CreatedConcurrently, isCreatedConcurrently);
+        }
+    }
 }

--- a/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
+++ b/src/EFCore.PG/Migrations/NpgsqlMigrationsSqlGenerator.cs
@@ -1491,14 +1491,21 @@ public class NpgsqlMigrationsSqlGenerator : MigrationsSqlGenerator
         Check.NotNull(operation, nameof(operation));
         Check.NotNull(builder, nameof(builder));
 
-        builder
-            .Append("DROP INDEX ")
-            .Append(DelimitIdentifier(operation.Name, operation.Schema));
+        builder.Append("DROP INDEX ");
+
+        var concurrently = operation[NpgsqlAnnotationNames.CreatedConcurrently] as bool? == true;
+        if (concurrently)
+        {
+            builder.Append("CONCURRENTLY ");
+        }
+
+        builder.Append(DelimitIdentifier(operation.Name, operation.Schema));
 
         if (terminate)
         {
             builder.AppendLine(";");
-            EndStatement(builder);
+            // Concurrent indexes cannot be dropped within a transaction
+            EndStatement(builder, suppressTransaction: concurrently);
         }
     }
 

--- a/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/MigrationsNpgsqlTest.cs
@@ -2020,6 +2020,24 @@ DROP SEQUENCE "People_Id_old_seq";
     }
 
     [Fact]
+    public virtual async Task Drop_index_concurrently()
+    {
+        await Test(
+            builder => builder.Entity(
+                "People", e =>
+                {
+                    e.Property<int>("Id");
+                    e.Property<int>("Age");
+                }),
+            builder => builder.Entity("People").HasIndex("Age")
+                .IsCreatedConcurrently(),
+            _ => { },
+            asserter: null); // No scaffolding for IsCreatedConcurrently
+
+        AssertSql("""DROP INDEX CONCURRENTLY "IX_People_Age";""");
+    }
+
+    [Fact]
     public virtual async Task Create_index_with_method()
     {
         await Test(

--- a/test/EFCore.PG.FunctionalTests/Migrations/NpgsqlMigrationsSqlGeneratorTest.cs
+++ b/test/EFCore.PG.FunctionalTests/Migrations/NpgsqlMigrationsSqlGeneratorTest.cs
@@ -619,6 +619,43 @@ INTERLEAVE IN PARENT my_schema.my_parent (col_a, col_b);
 
 #pragma warning restore 618
 
+    [Fact]
+    public virtual void DropIndexOperation_concurrently()
+    {
+        Generate(
+            new DropIndexOperation
+            {
+                Name = "IX_People_Name",
+                Table = "People",
+                Schema = "dbo",
+                [NpgsqlAnnotationNames.CreatedConcurrently] = true
+            });
+
+        AssertSql(
+            """
+DROP INDEX CONCURRENTLY dbo."IX_People_Name";
+
+""");
+    }
+
+    [Fact]
+    public virtual void DropIndexOperation_not_concurrently()
+    {
+        Generate(
+            new DropIndexOperation
+            {
+                Name = "IX_People_Name",
+                Table = "People",
+                Schema = "dbo"
+            });
+
+        AssertSql(
+            """
+DROP INDEX dbo."IX_People_Name";
+
+""");
+    }
+
     protected override string GetGeometryCollectionStoreType()
         => "GEOMETRY(GEOMETRYCOLLECTION)";
 }


### PR DESCRIPTION
Closes #3901

### What

`CREATE INDEX CONCURRENTLY` has been supported since #968, but the matching drop
was not - `Generate(DropIndexOperation, ...)` always emitted a plain `DROP INDEX`
inside the migration transaction. Removing an index created with
`IsCreatedConcurrently()` therefore takes an `ACCESS EXCLUSIVE` lock on the table.

Two things were missing, and both are needed for the feature to work end to end:

- `NpgsqlMigrationsAnnotationProvider` did not override `ForRemove(ITableIndex)`, so
  `Npgsql:CreatedConcurrently` never reached the `DropIndexOperation` produced by the
  differ - the operation had no annotations at all.
- `Generate(DropIndexOperation, ...)` did not look at the annotation.

This PR honours the annotation on both sides and suppresses the transaction for the
drop, mirroring `Generate(CreateIndexOperation, ...)`.

### Design note

I reused the existing `Npgsql:CreatedConcurrently` annotation instead of introducing
a new one, so `IsCreatedConcurrently()` now means "created *and* dropped
concurrently". No new public API, and I think it matches the intent - but it is a
behaviour change for existing users: dropping such an index now runs outside the
migration transaction. If you would rather have an explicit `IsDroppedConcurrently()`,
say the word and I will rework it; the generator half stays the same either way.

### Testing

- `DropIndexOperation_concurrently` / `DropIndexOperation_not_concurrently` in
  `NpgsqlMigrationsSqlGeneratorTest` cover the generated SQL.
- `Drop_index_concurrently` in `MigrationsNpgsqlTest` covers the full model-diff
  path, mirroring the existing `Create_index_concurrently`.

**What I could and could not run locally:** `main` targets `net11.0` and pins the
.NET 11 preview SDK in `global.json`, which I do not have installed, so I could not
build `main` or run its test suite. To verify the change I:

1. Applied the generator change to a `hotfix/10.0.4` worktree (identical code there,
   targets `net10.0`), added the two `NpgsqlMigrationsSqlGeneratorTest` tests and ran
   them - both pass.
2. Verified the `ForRemove(ITableIndex)` half separately against the shipped 10.0.0
   package by registering an `IMigrationsAnnotationProvider` with exactly this
   override and running the migrations differ: the `DropIndexOperation` goes from
   having no annotations to carrying `Npgsql:CreatedConcurrently = True`.

So both halves are verified, but not together on `main` - the new
`Drop_index_concurrently` functional test in particular has not been executed. Please
let CI confirm, and I am happy to fix anything it turns up.